### PR TITLE
allow passing in extra request options

### DIFF
--- a/src/VaultApiClient.js
+++ b/src/VaultApiClient.js
@@ -12,12 +12,14 @@ class VaultApiClient {
      * @param {String} [config.apiVersion='v1']
      * @param {Object} logger
      */
-    constructor(config, logger) {
+    constructor(config, logger, requestOptions) {
         this.__config = _.defaultsDeep(_.cloneDeep(config), {
             apiVersion: 'v1',
         });
 
         this._logger = logger;
+
+        this.__requestOptions = requestOptions;
     }
 
     makeRequest(method, path, data, headers) {
@@ -32,6 +34,7 @@ class VaultApiClient {
             followAllRedirects: true,
             headers,
             json: true,
+            ...this.__requestOptions
         };
 
         this._logger.debug(

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -30,7 +30,8 @@ class VaultClient {
 
         this.__api = new VaultApiClient(
             options.api,
-            this.__log
+            this.__log,
+            options.request
         );
 
         /**


### PR DESCRIPTION
This allows specifying "request: { ... } " to the VaultClient options.

This was necessary to allow VaultClient hit a vault instance with a private certificate.
