### PR TITLE
Return Instance if instance already booted when calling vault.boot() function.

### DIFF
--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -63,11 +63,8 @@ class VaultClient {
         let instance = vaultInstances[name];
         if (instance === undefined) {
             vaultInstances[name] = instance = new VaultClient(options);
-
-            return instance;
         }
-
-        throw new errors.InvalidArgumentsError('Instance with such name already booted');
+        return instance;
     }
 
     /**

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -27,7 +27,7 @@ describe('Unit tests', function () {
 
         expect(VaultClient.get('tst')).to.equal(i);
 
-        expect(() => VaultClient.boot('tst', bootOpts)).to.throw(VaultErr.InvalidArgumentsError, 'Instance with such name already booted');
+        expect(VaultClient.boot('tst')).to.equal(i);
 
 
         const i2 = VaultClient.boot('tst2', bootOpts);


### PR DESCRIPTION
The description of the boot function says that "Calling Vault.boot multiple times with the same name will return the same instance." but in the code it is throwing error when the instance is already booted. Changed the code and its respective test to return the instance instead of throwing error.