### PR TITLE
test: add unit test suite and Vault API conformance tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "url-join": "^2.0.5"
       },
       "devDependencies": {
+        "c8": "^11.0.0",
         "chai": "^3.5.0",
         "co-mocha": "^1.2.2",
         "deep-freeze": "^0.0.1",
@@ -407,6 +408,54 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
@@ -529,6 +578,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -542,6 +598,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/asn1": {
@@ -646,6 +728,40 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "node_modules/c8": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
+      "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^8.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -663,6 +779,21 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/co": {
@@ -687,6 +818,26 @@
       "peerDependencies": {
         "mocha": ">=1.18 <6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -729,10 +880,32 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -807,6 +980,23 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -874,6 +1064,40 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -910,6 +1134,16 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/getpass": {
       "version": "0.1.7",
@@ -987,6 +1221,13 @@
         "he": "bin/he"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1028,6 +1269,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
@@ -1039,10 +1290,79 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
@@ -1095,6 +1415,22 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
@@ -1181,6 +1517,32 @@
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
       "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -1217,6 +1579,16 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.1",
@@ -1296,12 +1668,54 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-ms": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
       "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -1325,6 +1739,33 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1452,6 +1893,16 @@
         "request": "^2.34"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -1468,6 +1919,55 @@
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "deprecated": "This package has been deprecated in favour of @sinonjs/samsam",
       "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/sinon": {
       "version": "2.4.1",
@@ -1539,6 +2039,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
@@ -1560,6 +2088,78 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-encoding": {
@@ -1638,6 +2238,21 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -1649,6 +2264,40 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -1669,6 +2318,58 @@
       ],
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -1982,6 +2683,40 @@
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="
     },
+    "@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "@nodable/entities": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
@@ -2071,6 +2806,12 @@
         "tslib": "^2.6.2"
       }
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2080,6 +2821,21 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
       }
     },
     "asn1": {
@@ -2169,6 +2925,25 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "c8": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
+      "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^8.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      }
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -2183,6 +2958,17 @@
         "assertion-error": "^1.0.1",
         "deep-eql": "^0.1.3",
         "type-detect": "^1.0.0"
+      }
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "co": {
@@ -2200,6 +2986,21 @@
         "co": "^4.0.0",
         "is-generator": "^1.0.1"
       }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2233,10 +3034,27 @@
         "json5": "^2.2.3"
       }
     },
+    "convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -2298,6 +3116,18 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2344,6 +3174,26 @@
         "strnum": "^2.2.3"
       }
     },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2372,6 +3222,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "getpass": {
@@ -2434,6 +3290,12 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2468,6 +3330,12 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
     "is-generator": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
@@ -2479,10 +3347,60 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -2525,6 +3443,15 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -2611,6 +3538,21 @@
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
       "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
     },
+    "lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true
+    },
+    "make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.5.3"
+      }
+    },
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -2637,6 +3579,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true
     },
     "mkdirp": {
@@ -2699,10 +3647,34 @@
         "wrappy": "1"
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
     "parse-ms": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
       "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-expression-matcher": {
       "version": "1.5.0",
@@ -2714,6 +3686,22 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      }
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -2813,6 +3801,12 @@
         "lodash": "^4.17.11"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -2827,6 +3821,33 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true
     },
     "sinon": {
@@ -2881,6 +3902,26 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
     "strnum": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
@@ -2893,6 +3934,54 @@
       "dev": true,
       "requires": {
         "has-flag": "^1.0.0"
+      }
+    },
+    "test-exclude": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+          "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^4.0.2"
+          }
+        },
+        "glob": {
+          "version": "13.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+          "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+          "dev": true,
+          "requires": {
+            "minimatch": "^10.2.2",
+            "minipass": "^7.1.3",
+            "path-scurry": "^2.0.2"
+          }
+        },
+        "minimatch": {
+          "version": "10.2.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+          "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^5.0.5"
+          }
+        }
       }
     },
     "text-encoding": {
@@ -2959,6 +4048,17 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
+    "v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -2967,6 +4067,26 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "wrappy": {
@@ -2979,6 +4099,39 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,20 @@
     "src"
   ],
   "scripts": {
-    "test": "mocha test/**/*.test.js",
+    "test": "mocha \"test/**/*.test.js\"",
+    "test:unit": "mocha \"test/*.test.js\"",
+    "coverage": "c8 npm run test:unit",
     "version": "git add -A ."
+  },
+  "c8": {
+    "include": [
+      "src/**/*.js"
+    ],
+    "reporter": [
+      "text",
+      "html"
+    ],
+    "all": true
   },
   "author": "Namecheap <opensource@namecheap.com>",
   "license": "Apache-2.0",
@@ -34,6 +46,7 @@
     "config": ">=1 <4"
   },
   "devDependencies": {
+    "c8": "^11.0.0",
     "chai": "^3.5.0",
     "co-mocha": "^1.2.2",
     "deep-freeze": "^0.0.1",

--- a/test/AuthToken.test.js
+++ b/test/AuthToken.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const AuthToken = require('../src/auth/AuthToken');
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+describe('AuthToken', function () {
+    describe('.fromResponse()', function () {
+        function build(dataOverrides) {
+            return AuthToken.fromResponse({
+                data: Object.assign({
+                    id: 'tok-id',
+                    accessor: 'tok-accessor',
+                    creation_time: 1000,
+                    ttl: 3600,
+                    explicit_max_ttl: 0,
+                    num_uses: 0,
+                    renewable: true,
+                }, dataOverrides),
+            });
+        }
+
+        it('maps id and accessor', function () {
+            const token = build();
+            expect(token.getId()).to.equal('tok-id');
+            expect(token.getAccessor()).to.equal('tok-accessor');
+        });
+
+        it('subtracts the 60s network latency for a ttl greater than the latency', function () {
+            // creation_time 1000 + (3600 - 60) = 4540
+            const token = build({ ttl: 3600 });
+            expect(token.getExpiresAt()).to.equal(4540);
+        });
+
+        it('keeps the ttl untouched when it is below the network latency', function () {
+            // creation_time 1000 + 30 = 1030
+            const token = build({ ttl: 30 });
+            expect(token.getExpiresAt()).to.equal(1030);
+        });
+
+        it('produces a null expiry for a ttl of 0', function () {
+            const token = build({ ttl: 0 });
+            expect(token.getExpiresAt()).to.equal(null);
+        });
+
+        it('prefers last_renewal_time over creation_time when present', function () {
+            // last_renewal_time 2000 + (3600 - 60) = 5540
+            const token = build({ last_renewal_time: 2000, ttl: 3600 });
+            expect(token.getExpiresAt()).to.equal(5540);
+        });
+
+        it('treats a missing renewable flag as not renewable', function () {
+            const token = build({ renewable: undefined, ttl: 3600 });
+            expect(token.isRenewable()).to.equal(false);
+        });
+    });
+
+    describe('#isExpired()', function () {
+        it('is never expired when there is no expiry', function () {
+            const token = new AuthToken('id', 'acc', 0, null, 0, 0, false);
+            expect(token.isExpired()).to.equal(false);
+        });
+
+        it('is expired when the expiry is in the past', function () {
+            const token = new AuthToken('id', 'acc', 0, nowSec() - 100, 0, 0, true);
+            expect(token.isExpired()).to.equal(true);
+        });
+
+        it('is not expired when the expiry is in the future', function () {
+            const token = new AuthToken('id', 'acc', 0, nowSec() + 1000, 0, 0, true);
+            expect(token.isExpired()).to.equal(false);
+        });
+    });
+
+    describe('#isRenewable()', function () {
+        it('is renewable when the flag is set and an expiry exists', function () {
+            const token = new AuthToken('id', 'acc', 0, nowSec() + 1000, 0, 0, true);
+            expect(token.isRenewable()).to.equal(true);
+        });
+
+        it('is not renewable without an expiry even when the flag is set', function () {
+            const token = new AuthToken('id', 'acc', 0, null, 0, 0, true);
+            expect(token.isRenewable()).to.equal(false);
+        });
+
+        it('is not renewable when the flag is unset', function () {
+            const token = new AuthToken('id', 'acc', 0, nowSec() + 1000, 0, 0, false);
+            expect(token.isRenewable()).to.equal(false);
+        });
+    });
+});

--- a/test/Lease.test.js
+++ b/test/Lease.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const Lease = require('../src/Lease');
+
+describe('Lease', function () {
+    const response = {
+        request_id: 'req-1',
+        lease_id: 'lease-1',
+        lease_duration: 3600,
+        renewable: true,
+        data: { foo: 'bar', num: 42 },
+    };
+
+    describe('constructor', function () {
+        it('stores provided data', function () {
+            const lease = new Lease('r', 'l', 10, false, { a: 1 });
+            expect(lease.getData()).to.deep.equal({ a: 1 });
+            expect(lease.isRenewable()).to.equal(false);
+        });
+
+        it('defaults data to an empty object when undefined', function () {
+            const lease = new Lease('r', 'l', 10, false, undefined);
+            expect(lease.getData()).to.deep.equal({});
+        });
+    });
+
+    describe('.fromResponse()', function () {
+        it('maps a Vault response onto a Lease', function () {
+            const lease = Lease.fromResponse(response);
+            expect(lease).to.be.instanceOf(Lease);
+            expect(lease.isRenewable()).to.equal(true);
+            expect(lease.getData()).to.deep.equal(response.data);
+        });
+    });
+
+    describe('#getValue()', function () {
+        it('returns the value for an existing key', function () {
+            const lease = Lease.fromResponse(response);
+            expect(lease.getValue('foo')).to.equal('bar');
+            expect(lease.getValue('num')).to.equal(42);
+        });
+
+        it('throws when the key does not exist', function () {
+            const lease = Lease.fromResponse(response);
+            expect(() => lease.getValue('missing')).to.throw('Requested key does not exist');
+        });
+    });
+
+    describe('#getData()', function () {
+        it('returns a deep clone (mutating the result keeps the lease intact)', function () {
+            const lease = Lease.fromResponse(response);
+            const data = lease.getData();
+            data.foo = 'mutated';
+            expect(lease.getValue('foo')).to.equal('bar');
+            expect(lease.getData()).to.deep.equal(response.data);
+        });
+    });
+
+    describe('#isRenewable()', function () {
+        it('reflects the renewable flag', function () {
+            expect(new Lease('r', 'l', 10, true, {}).isRenewable()).to.equal(true);
+            expect(new Lease('r', 'l', 10, false, {}).isRenewable()).to.equal(false);
+        });
+    });
+});

--- a/test/VaultApiClient.test.js
+++ b/test/VaultApiClient.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const http = require('http');
+const _ = require('lodash');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+const VaultApiClient = require('../src/VaultApiClient');
+
+const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (prop) => [prop, _.noop]));
+
+describe('VaultApiClient', function () {
+    let server;
+    let baseUrl;
+    let lastRequest;
+    let responder;
+
+    before(function (done) {
+        server = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', (chunk) => { body += chunk; });
+            req.on('end', () => {
+                lastRequest = {
+                    method: req.method,
+                    url: req.url,
+                    headers: req.headers,
+                    body: body,
+                };
+                responder(req, res);
+            });
+        });
+        server.listen(0, '127.0.0.1', () => {
+            baseUrl = `http://127.0.0.1:${server.address().port}`;
+            done();
+        });
+    });
+
+    after(function (done) {
+        server.close(done);
+    });
+
+    beforeEach(function () {
+        lastRequest = null;
+        responder = (req, res) => {
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ ok: true, echoMethod: req.method }));
+        };
+    });
+
+    describe('#makeRequest()', function () {
+        it('defaults the api version to v1 and joins the url segments', function () {
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('GET', '/secret/foo').then((res) => {
+                expect(res).to.deep.equal({ ok: true, echoMethod: 'GET' });
+                expect(lastRequest.url).to.equal('/v1/secret/foo');
+            });
+        });
+
+        it('honours a custom api version', function () {
+            const api = new VaultApiClient({ url: baseUrl, apiVersion: 'v2' }, logger);
+            return api.makeRequest('GET', 'secret/foo').then(() => {
+                expect(lastRequest.url).to.equal('/v2/secret/foo');
+            });
+        });
+
+        it('sends the payload as JSON on a POST', function () {
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('POST', '/secret/foo', { hello: 'world' }, { 'X-Vault-Token': 'tok' }).then(() => {
+                expect(lastRequest.method).to.equal('POST');
+                expect(JSON.parse(lastRequest.body)).to.deep.equal({ hello: 'world' });
+                expect(lastRequest.headers['x-vault-token']).to.equal('tok');
+            });
+        });
+
+        it('sends no body when data is undefined', function () {
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('GET', '/secret/foo').then(() => {
+                expect(lastRequest.body).to.equal('');
+            });
+        });
+
+        it('sends no body when data is null', function () {
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('POST', '/secret/foo', null).then(() => {
+                expect(lastRequest.body).to.equal('');
+            });
+        });
+
+        it('logs the request and the response body via the debug logger', function () {
+            const debug = sinon.spy();
+            const api = new VaultApiClient({ url: baseUrl }, _.assign({}, logger, { debug }));
+            return api.makeRequest('GET', '/secret/foo').then(() => {
+                expect(debug).to.have.been.calledWith('making request: %s %s', 'GET', `${baseUrl}/v1/secret/foo`);
+                // second debug call logs the response body
+                expect(debug.callCount).to.be.at.least(2);
+            });
+        });
+
+        it('does not mutate the config object passed in', function () {
+            const config = { url: baseUrl };
+            const api = new VaultApiClient(config, logger);
+            expect(config).to.not.have.property('apiVersion');
+            return api.makeRequest('GET', '/secret/foo');
+        });
+
+        it('rejects when the server responds with a non-2xx status', function () {
+            responder = (req, res) => {
+                res.statusCode = 500;
+                res.end('boom');
+            };
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('GET', '/secret/foo').then(
+                () => { throw new Error('expected rejection'); },
+                (err) => { expect(err.statusCode).to.equal(500); }
+            );
+        });
+    });
+});

--- a/test/VaultClient.test.js
+++ b/test/VaultClient.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const _ = require('lodash');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+const VaultClient = require('../src/VaultClient');
+const VaultNodeConfig = require('../src/VaultNodeConfig');
+const Lease = require('../src/Lease');
+const VaultTokenAuth = require('../src/auth/VaultTokenAuth');
+const VaultAppRoleAuth = require('../src/auth/VaultAppRoleAuth');
+const VaultIAMAuth = require('../src/auth/VaultIAMAuth');
+const VaultKubernetesAuth = require('../src/auth/VaultKubernetesAuth');
+const errors = require('../src/errors');
+
+function bootOpts(overrides) {
+    return _.merge({
+        api: { url: 'https://example.com/' },
+        logger: false,
+        auth: {
+            type: 'token',
+            config: { token: 'tok-123' },
+        },
+    }, overrides);
+}
+
+describe('VaultClient', function () {
+    afterEach(function () {
+        VaultClient.clear();
+    });
+
+    describe('static boot/get/clear', function () {
+        it('throws when options are not provided to boot', function () {
+            expect(() => VaultClient.boot('x')).to.throw(errors.InvalidArgumentsError, 'Options should be provided');
+        });
+
+        it('creates, caches and returns the same instance', function () {
+            const i = VaultClient.boot('main', bootOpts());
+            expect(i).to.be.instanceOf(VaultClient);
+            expect(VaultClient.boot('main', bootOpts())).to.equal(i);
+            expect(VaultClient.get('main')).to.equal(i);
+        });
+
+        it('throws when getting an unknown instance', function () {
+            expect(() => VaultClient.get('does-not-exist')).to.throw(errors.InvalidArgumentsError, 'Invalid instance name');
+        });
+
+        it('clears a single named instance', function () {
+            const i = VaultClient.boot('a', bootOpts());
+            VaultClient.boot('b', bootOpts());
+            VaultClient.clear('a');
+            expect(() => VaultClient.get('a')).to.throw(errors.InvalidArgumentsError);
+            expect(VaultClient.get('b')).to.be.instanceOf(VaultClient);
+            expect(VaultClient.boot('a', bootOpts())).to.not.equal(i);
+        });
+
+        it('clears every instance when no name is given', function () {
+            VaultClient.boot('a', bootOpts());
+            VaultClient.boot('b', bootOpts());
+            VaultClient.clear();
+            expect(() => VaultClient.get('a')).to.throw();
+            expect(() => VaultClient.get('b')).to.throw();
+        });
+    });
+
+    describe('auth provider selection', function () {
+        const cases = [
+            ['token', { token: 'tok' }, VaultTokenAuth],
+            ['appRole', { role_id: 'rid' }, VaultAppRoleAuth],
+            ['iam', { role: 'r' }, VaultIAMAuth],
+            ['kubernetes', { role: 'r' }, VaultKubernetesAuth],
+        ];
+
+        cases.forEach(([type, config, Klass]) => {
+            it(`builds a ${Klass.name} for the "${type}" auth type`, function () {
+                const client = new VaultClient(bootOpts({ auth: { type, config } }));
+                expect(client.__auth).to.be.instanceOf(Klass);
+            });
+        });
+
+        it('throws for an unsupported auth type', function () {
+            expect(() => new VaultClient(bootOpts({ auth: { type: 'nope', config: {} } })))
+                .to.throw(errors.InvalidArgumentsError, 'Unsupported auth method');
+        });
+    });
+
+    describe('#getHeaders()', function () {
+        const token = { getId: () => 'tid' };
+
+        it('returns only the token header without a namespace', function () {
+            const client = new VaultClient(bootOpts());
+            expect(client.getHeaders(token)).to.deep.equal({ 'X-Vault-Token': 'tid' });
+        });
+
+        it('adds the namespace header when configured', function () {
+            const client = new VaultClient(bootOpts({ auth: { config: { namespace: 'ns1' } } }));
+            expect(client.getHeaders(token)).to.deep.equal({
+                'X-Vault-Token': 'tid',
+                'X-Vault-Namespace': 'ns1',
+            });
+        });
+    });
+
+    describe('secret operations', function () {
+        let client;
+        const token = { getId: () => 'tid' };
+
+        beforeEach(function () {
+            client = new VaultClient(bootOpts());
+            client.__auth = { getAuthToken: sinon.stub().resolves(token) };
+        });
+
+        it('read() issues a GET and wraps the response in a Lease', function () {
+            client.__api = { makeRequest: sinon.stub().resolves({ request_id: 'r', data: { k: 'v' } }) };
+            return client.read('secret/x').then((lease) => {
+                expect(lease).to.be.instanceOf(Lease);
+                expect(lease.getData()).to.deep.equal({ k: 'v' });
+                expect(client.__api.makeRequest).to.have.been.calledWith('GET', 'secret/x', null, { 'X-Vault-Token': 'tid' });
+            });
+        });
+
+        it('list() issues a LIST and wraps the response in a Lease', function () {
+            client.__api = { makeRequest: sinon.stub().resolves({ data: { keys: ['a'] } }) };
+            return client.list('secret').then((lease) => {
+                expect(lease).to.be.instanceOf(Lease);
+                expect(lease.getData()).to.deep.equal({ keys: ['a'] });
+                expect(client.__api.makeRequest).to.have.been.calledWith('LIST', 'secret', null, { 'X-Vault-Token': 'tid' });
+            });
+        });
+
+        it('write() issues a POST and returns the raw response', function () {
+            const response = { data: { ip: '127.0.0.1' } };
+            client.__api = { makeRequest: sinon.stub().resolves(response) };
+            return client.write('secret/x', { a: 1 }).then((res) => {
+                expect(res).to.equal(response);
+                expect(client.__api.makeRequest).to.have.been.calledWith('POST', 'secret/x', { a: 1 }, { 'X-Vault-Token': 'tid' });
+            });
+        });
+
+        ['read', 'list', 'write'].forEach((method) => {
+            it(`${method}() rejects with the underlying error`, function () {
+                const boom = new Error('boom');
+                client.__api = { makeRequest: sinon.stub().rejects(boom) };
+                return client[method]('secret/x', {}).then(
+                    () => { throw new Error('expected rejection'); },
+                    (err) => { expect(err).to.equal(boom); }
+                );
+            });
+        });
+    });
+
+    describe('#__setupLogger()', function () {
+        let client;
+        beforeEach(function () { client = new VaultClient(bootOpts()); });
+
+        it('returns an all-noop logger when given false', function () {
+            const log = client.__setupLogger(false);
+            expect(log.error).to.equal(_.noop);
+            expect(log.debug).to.equal(_.noop);
+        });
+
+        it('returns the supplied logger when it implements the full interface', function () {
+            const custom = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+            expect(client.__setupLogger(custom)).to.equal(custom);
+        });
+
+        it('falls back to console for an incomplete logger (with a silent debug)', function () {
+            const log = client.__setupLogger({});
+            expect(log.error).to.equal(console.error);
+            expect(log.warn).to.equal(console.warn);
+            expect(log.debug).to.equal(_.noop);
+        });
+    });
+
+    describe('#fillNodeConfig()', function () {
+        it('delegates to VaultNodeConfig#populate', function () {
+            const sentinel = Promise.resolve('populated');
+            const populate = sinon.stub(VaultNodeConfig.prototype, 'populate').returns(sentinel);
+            try {
+                const client = new VaultClient(bootOpts());
+                const result = client.fillNodeConfig();
+                expect(populate).to.have.been.calledOnce;
+                return result.then((value) => expect(value).to.equal('populated'));
+            } finally {
+                populate.restore();
+            }
+        });
+    });
+});

--- a/test/VaultNodeConfig.test.js
+++ b/test/VaultNodeConfig.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+// Silence node-config's "no configuration directory" warning during the run.
+process.env.SUPPRESS_NO_CONFIG_WARNING = 'true';
+
+const path = require('path');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+
+const VaultNodeConfig = require('../src/VaultNodeConfig');
+const errors = require('../src/errors');
+
+const CONFIG_BASE = path.join(__dirname, 'data', 'config-base');
+const CONFIG_NOT_OBJECT = path.join(__dirname, 'data', 'config-not-object');
+
+function fakeVault(dataByPath) {
+    return {
+        read: (p) => Promise.resolve({ getData: () => dataByPath[p] }),
+    };
+}
+
+describe('VaultNodeConfig', function () {
+    let originalConfigDir;
+
+    before(function () {
+        originalConfigDir = process.env.NODE_CONFIG_DIR;
+    });
+
+    after(function () {
+        if (originalConfigDir === undefined) {
+            delete process.env.NODE_CONFIG_DIR;
+        } else {
+            process.env.NODE_CONFIG_DIR = originalConfigDir;
+        }
+    });
+
+    describe('constructor', function () {
+        it('constructs when the "config" package is installed', function () {
+            const vnc = new VaultNodeConfig({});
+            expect(vnc).to.be.instanceOf(VaultNodeConfig);
+        });
+    });
+
+    describe('#__getSubstitutionMap()', function () {
+        it('reads custom-vault-variables.js from an absolute NODE_CONFIG_DIR', function () {
+            process.env.NODE_CONFIG_DIR = CONFIG_BASE;
+            const vnc = new VaultNodeConfig({});
+            expect(vnc.__getSubstitutionMap()).to.deep.equal({
+                deep: { aStr: 'secret/a#tstStr', aInt: 'secret/a#tstInt' },
+                b: 'secret/b#tst',
+            });
+        });
+
+        it('resolves a relative NODE_CONFIG_DIR against the working directory', function () {
+            process.env.NODE_CONFIG_DIR = './test/data/config-base';
+            const vnc = new VaultNodeConfig({});
+            expect(vnc.__getSubstitutionMap()).to.have.property('b', 'secret/b#tst');
+        });
+
+        it('returns a fresh clone on each call', function () {
+            process.env.NODE_CONFIG_DIR = CONFIG_BASE;
+            const vnc = new VaultNodeConfig({});
+            const a = vnc.__getSubstitutionMap();
+            const b = vnc.__getSubstitutionMap();
+            expect(a).to.not.equal(b);
+            expect(a).to.deep.equal(b);
+        });
+
+        it('throws a VaultError when the config file cannot be read', function () {
+            process.env.NODE_CONFIG_DIR = path.join(__dirname, 'data', 'does-not-exist');
+            const vnc = new VaultNodeConfig({});
+            expect(() => vnc.__getSubstitutionMap()).to.throw(errors.VaultError, 'cannot be read');
+        });
+
+        it('throws a VaultError when the config file is not a plain object', function () {
+            process.env.NODE_CONFIG_DIR = CONFIG_NOT_OBJECT;
+            const vnc = new VaultNodeConfig({});
+            expect(() => vnc.__getSubstitutionMap()).to.throw(errors.VaultError, 'should return plain object');
+        });
+    });
+
+    describe('#__traverse()', function () {
+        let vnc;
+        beforeEach(function () {
+            process.env.NODE_CONFIG_DIR = CONFIG_BASE;
+            vnc = new VaultNodeConfig({});
+        });
+
+        it('invokes the callback for each string leaf, descending into nested objects', function () {
+            const calls = [];
+            vnc.__traverse({ a: 'x', nested: { b: 'y' } }, (key, val) => calls.push([key, val]));
+            expect(calls).to.deep.equal([['a', 'x'], ['b', 'y']]);
+        });
+
+        it('skips inherited (non-own) properties', function () {
+            const obj = Object.create({ inherited: 'nope' });
+            obj.own = 'yes';
+            const calls = [];
+            vnc.__traverse(obj, (key, val) => calls.push([key, val]));
+            expect(calls).to.deep.equal([['own', 'yes']]);
+        });
+
+        it('throws for an illegal (non-string, non-object) leaf type', function () {
+            expect(() => vnc.__traverse({ a: 123 }, () => {}))
+                .to.throw(errors.InvalidArgumentsError, 'Illegal key type');
+        });
+    });
+
+    describe('#populate()', function () {
+        function instance(substitutionMap, dataByPath) {
+            process.env.NODE_CONFIG_DIR = CONFIG_BASE;
+            const vnc = new VaultNodeConfig(fakeVault(dataByPath || {}));
+            sinon.stub(vnc, '__getSubstitutionMap').returns(substitutionMap);
+            return vnc;
+        }
+
+        it('throws (synchronously) on a substitution value without a "#"', function () {
+            const vnc = instance({ key: 'no-hash-here' });
+            expect(() => vnc.populate())
+                .to.throw(errors.InvalidArgumentsError, 'Invalid format of substitution value');
+        });
+
+        it('rejects when a substitution cannot be found in the secret data', function () {
+            const vnc = instance({ key: 'secret/a#missing' }, { 'secret/a': { present: 'v' } });
+            return vnc.populate().then(
+                () => { throw new Error('expected rejection'); },
+                (err) => {
+                    expect(err).to.be.instanceOf(errors.VaultError);
+                    expect(err.message).to.match(/Can't find substitution/);
+                }
+            );
+        });
+
+        it('resolves substitution values from Vault into the config object', function () {
+            const vnc = instance(
+                { b: 'secret/b#tst', deep: { aStr: 'secret/a#tstStr' } },
+                { 'secret/a': { tstStr: 'hello' }, 'secret/b': { tst: 'world' } }
+            );
+            return vnc.populate().then((config) => {
+                expect(config.b).to.equal('world');
+                expect(config.deep.aStr).to.equal('hello');
+            });
+        });
+    });
+});

--- a/test/auth.appRole.test.js
+++ b/test/auth.appRole.test.js
@@ -87,5 +87,30 @@ describe("AppRole auth backend", function () {
         ),
       ).to.be.true;
     });
+
+    it("defaults the mount to 'approle' when none is provided", async () => {
+      const api = getApiStub();
+
+      const auth = new VaultAppRoleAuth(api, logger, {
+        role_id: "role123",
+        secret_id: "secret456",
+      });
+
+      api.makeRequest
+        .withArgs("POST")
+        .resolves({ auth: { client_token: "fake_token" } });
+      sinon.stub(auth, "_getTokenEntity");
+
+      await auth._authenticate();
+
+      expect(
+        api.makeRequest.calledWith(
+          "POST",
+          "/auth/approle/login",
+          { role_id: "role123", secret_id: "secret456" },
+          {},
+        ),
+      ).to.be.true;
+    });
   });
 });

--- a/test/auth.base.test.js
+++ b/test/auth.base.test.js
@@ -1,0 +1,208 @@
+'use strict';
+
+const _ = require('lodash');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+const VaultApiClient = require('../src/VaultApiClient');
+const VaultBaseAuth = require('../src/auth/VaultBaseAuth');
+const AuthToken = require('../src/auth/AuthToken');
+
+const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+
+function apiStub() {
+    return sinon.createStubInstance(VaultApiClient);
+}
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+// Minimal concrete subclass so we can drive the abstract base class behaviour.
+class TestAuth extends VaultBaseAuth {
+    constructor(api, mount, opts) {
+        super(api, logger, mount);
+        opts = opts || {};
+        this.__authStub = opts.authStub || sinon.stub();
+        this.__reauth = opts.reauth !== undefined ? opts.reauth : true;
+    }
+
+    _authenticate() {
+        return this.__authStub();
+    }
+
+    _reauthenticationAllowed() {
+        return this.__reauth;
+    }
+}
+
+function nonRenewableToken(id) {
+    return new AuthToken(id || 'id', 'acc', 0, null, 0, 0, false);
+}
+
+describe('VaultBaseAuth', function () {
+    describe('abstract members', function () {
+        it('_authenticate must be overridden', function () {
+            const auth = new VaultBaseAuth(apiStub(), logger, 'mount');
+            expect(() => auth._authenticate()).to.throw('Method should be overridden');
+        });
+
+        it('allows reauthentication by default', function () {
+            const auth = new VaultBaseAuth(apiStub(), logger, 'mount');
+            expect(auth._reauthenticationAllowed()).to.equal(true);
+        });
+    });
+
+    describe('#_getTokenEntity()', function () {
+        it('looks the token up via /auth/token/lookup-self', function () {
+            const api = apiStub();
+            api.makeRequest.resolves({
+                data: { id: 't', accessor: 'a', creation_time: 1000, ttl: 0, renewable: false },
+            });
+            const auth = new VaultBaseAuth(api, logger, 'mount');
+            return auth._getTokenEntity('my-token').then((token) => {
+                expect(api.makeRequest).to.have.been.calledWith('GET', '/auth/token/lookup-self', null, { 'X-Vault-Token': 'my-token' });
+                expect(token).to.be.instanceOf(AuthToken);
+                expect(token.getId()).to.equal('t');
+            });
+        });
+    });
+
+    describe('#getAuthToken()', function () {
+        it('authenticates once and caches the token for subsequent calls', function () {
+            const token = nonRenewableToken();
+            const authStub = sinon.stub().resolves(token);
+            const auth = new TestAuth(apiStub(), 'mount', { authStub });
+
+            return auth.getAuthToken()
+                .then((first) => {
+                    expect(first).to.equal(token);
+                    return auth.getAuthToken();
+                })
+                .then((second) => {
+                    expect(second).to.equal(token);
+                    expect(authStub).to.have.been.calledOnce;
+                });
+        });
+
+        it('re-authenticates when the cached token expired and reauth is allowed', function () {
+            const expired = new AuthToken('old', 'acc', 0, nowSec() - 100, 0, 0, false);
+            const fresh = nonRenewableToken('new');
+            const authStub = sinon.stub();
+            authStub.onCall(0).resolves(expired);
+            authStub.onCall(1).resolves(fresh);
+            const auth = new TestAuth(apiStub(), 'mount', { authStub, reauth: true });
+
+            return auth.getAuthToken()
+                .then((t1) => {
+                    expect(t1).to.equal(expired);
+                    return auth.getAuthToken();
+                })
+                .then((t2) => {
+                    expect(t2).to.equal(fresh);
+                    expect(authStub).to.have.been.calledTwice;
+                });
+        });
+
+        // Documents current behaviour: when reauth is disallowed (e.g. token auth) an
+        // expired token is returned as-is. The AuthTokenExpiredError branch in the
+        // source is in fact unreachable given a deterministic _reauthenticationAllowed().
+        it('returns the expired token without re-authenticating when reauth is disallowed', function () {
+            const expired = new AuthToken('old', 'acc', 0, nowSec() - 100, 0, 0, false);
+            const authStub = sinon.stub().resolves(expired);
+            const auth = new TestAuth(apiStub(), 'mount', { authStub, reauth: false });
+
+            return auth.getAuthToken()
+                .then((t1) => {
+                    expect(t1).to.equal(expired);
+                    return auth.getAuthToken();
+                })
+                .then((t2) => {
+                    expect(t2).to.equal(expired);
+                    expect(authStub).to.have.been.calledOnce;
+                });
+        });
+
+        it('resets state and propagates the error when authentication fails, allowing a retry', function () {
+            const boom = new Error('auth failed');
+            const token = nonRenewableToken();
+            const authStub = sinon.stub();
+            authStub.onCall(0).rejects(boom);
+            authStub.onCall(1).resolves(token);
+            const auth = new TestAuth(apiStub(), 'mount', { authStub });
+
+            return auth.getAuthToken()
+                .then(
+                    () => { throw new Error('expected rejection'); },
+                    (err) => {
+                        expect(err).to.equal(boom);
+                        return auth.getAuthToken();
+                    }
+                )
+                .then((t) => {
+                    expect(t).to.equal(token);
+                    expect(authStub).to.have.been.calledTwice;
+                });
+        });
+    });
+
+    describe('token refresh timer', function () {
+        let clock;
+
+        function flush(times) {
+            let p = Promise.resolve();
+            for (let i = 0; i < (times || 8); i++) {
+                p = p.then(() => undefined);
+            }
+            return p;
+        }
+
+        beforeEach(function () {
+            clock = sinon.useFakeTimers();
+        });
+
+        afterEach(function () {
+            clock.restore();
+        });
+
+        it('schedules and performs a renewal for a renewable token', function () {
+            // fake "now" == 0; expiresAt == 100s => timer == ((100-0)/2)*1000 == 50000ms
+            const renewable = new AuthToken('rid', 'racc', 0, 100, 0, 0, true);
+            const renewed = nonRenewableToken('rid2'); // non-renewable so the loop stops
+            const api = apiStub();
+            api.makeRequest.resolves({});
+            const auth = new TestAuth(api, 'mount', { authStub: sinon.stub().resolves(renewable) });
+            sinon.stub(auth, '_getTokenEntity').resolves(renewed);
+
+            return auth.getAuthToken()
+                .then(() => {
+                    expect(api.makeRequest).to.not.have.been.called;
+                    clock.tick(50000);
+                    return flush();
+                })
+                .then(() => {
+                    expect(api.makeRequest).to.have.been.calledWith('POST', '/auth/token/renew-self', null, { 'X-Vault-Token': 'rid' });
+                    expect(auth._getTokenEntity).to.have.been.calledWith('rid');
+                });
+        });
+
+        it('logs and reschedules when a renewal fails', function () {
+            const renewable = new AuthToken('rid', 'racc', 0, 100, 0, 0, true);
+            const api = apiStub();
+            api.makeRequest.rejects(new Error('renew failed'));
+            const errorSpy = sinon.spy();
+            const auth = new TestAuth(api, 'mount', { authStub: sinon.stub().resolves(renewable) });
+            auth._log = _.assign({}, logger, { error: errorSpy });
+
+            return auth.getAuthToken()
+                .then(() => {
+                    clock.tick(50000);
+                    return flush();
+                })
+                .then(() => {
+                    expect(api.makeRequest).to.have.been.calledWith('POST', '/auth/token/renew-self');
+                    expect(errorSpy).to.have.been.called;
+                });
+        });
+    });
+});

--- a/test/auth.iam.test.js
+++ b/test/auth.iam.test.js
@@ -108,6 +108,32 @@ describe('Unit AWS auth backend :: IAM', function () {
                 expect(headers['Authorization'][0]).to.match(getAuthorizationHeaderRegExp('FAKE_AWS_ACCESS_KEY'));
             });
         })
+
+        it('Should set the namespace header when configured', function* () {
+            const api = getApiStub();
+
+            const auth = new VaultIAMAuth(
+                api,
+                logger,
+                {
+                    role: 'MyRole',
+                    namespace: 'ns1',
+                    credentials: {
+                        accessKeyId: 'FAKE_AWS_ACCESS_KEY',
+                        secretAccessKey: 'FAKE_AWS_SECRET_KEY',
+                    },
+                },
+                'fake_aws'
+            );
+
+            api.makeRequest.withArgs('POST').resolves({auth: {client_token: 'fake_token'}});
+            sinon.stub(auth, '_getTokenEntity');
+
+            yield auth._authenticate();
+
+            const args = api.makeRequest.getCall(0).args;
+            expect(args[3]).to.deep.equal({'X-Vault-Namespace': 'ns1'});
+        });
     });
 
     describe('Credentials', function () {

--- a/test/auth.kubernetes.test.js
+++ b/test/auth.kubernetes.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const fs = require('fs');
+const _ = require('lodash');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+const VaultApiClient = require('../src/VaultApiClient');
+const VaultKubernetesAuth = require('../src/auth/VaultKubernetesAuth');
+const AuthToken = require('../src/auth/AuthToken');
+
+const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+
+function apiStub() {
+    return sinon.createStubInstance(VaultApiClient);
+}
+
+describe('VaultKubernetesAuth', function () {
+    let readFileSync;
+
+    afterEach(function () {
+        if (readFileSync) {
+            readFileSync.restore();
+            readFileSync = null;
+        }
+    });
+
+    it('defaults the mount and the kube token path', function () {
+        const auth = new VaultKubernetesAuth(apiStub(), logger, { role: 'r' });
+        expect(auth._mount).to.equal('kubernetes');
+        expect(auth.__tokenPath).to.equal('/var/run/secrets/kubernetes.io/serviceaccount/token');
+    });
+
+    it('honours a custom mount and token path', function () {
+        const auth = new VaultKubernetesAuth(apiStub(), logger, { role: 'r', tokenPath: '/tmp/tok' }, 'k8s');
+        expect(auth._mount).to.equal('k8s');
+        expect(auth.__tokenPath).to.equal('/tmp/tok');
+    });
+
+    it('reads the JWT from disk and performs a login request', function () {
+        readFileSync = sinon.stub(fs, 'readFileSync').returns(Buffer.from('jwt-token'));
+        const api = apiStub();
+        api.makeRequest.resolves({ auth: { client_token: 'vault-token' } });
+        const auth = new VaultKubernetesAuth(api, logger, { role: 'my-role', tokenPath: '/tmp/tok' }, 'k8s');
+        const entity = new AuthToken('id', 'acc', 0, null, 0, 0, false);
+        sinon.stub(auth, '_getTokenEntity').resolves(entity);
+
+        return auth._authenticate().then((token) => {
+            expect(readFileSync).to.have.been.calledWith('/tmp/tok');
+            expect(api.makeRequest).to.have.been.calledWith('POST', '/auth/k8s/login', { role: 'my-role', jwt: 'jwt-token' });
+            expect(auth._getTokenEntity).to.have.been.calledWith('vault-token');
+            expect(token).to.equal(entity);
+        });
+    });
+});

--- a/test/auth.token.test.js
+++ b/test/auth.token.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const _ = require('lodash');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+const VaultApiClient = require('../src/VaultApiClient');
+const VaultTokenAuth = require('../src/auth/VaultTokenAuth');
+const AuthToken = require('../src/auth/AuthToken');
+const errors = require('../src/errors');
+
+const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+
+function apiStub() {
+    return sinon.createStubInstance(VaultApiClient);
+}
+
+describe('VaultTokenAuth', function () {
+    it('throws when no token is provided', function () {
+        expect(() => new VaultTokenAuth(apiStub(), logger, {}))
+            .to.throw(errors.InvalidArgumentsError, 'Auth token should be provided');
+    });
+
+    it('defaults the mount to "token"', function () {
+        const auth = new VaultTokenAuth(apiStub(), logger, { token: 't' });
+        expect(auth._mount).to.equal('token');
+    });
+
+    it('honours a custom mount', function () {
+        const auth = new VaultTokenAuth(apiStub(), logger, { token: 't' }, 'custom');
+        expect(auth._mount).to.equal('custom');
+    });
+
+    it('does not allow reauthentication', function () {
+        const auth = new VaultTokenAuth(apiStub(), logger, { token: 't' });
+        expect(auth._reauthenticationAllowed()).to.equal(false);
+    });
+
+    it('authenticates by looking up the configured token', function () {
+        const api = apiStub();
+        api.makeRequest.resolves({
+            data: { id: 't', accessor: 'a', creation_time: 1000, ttl: 0, renewable: false },
+        });
+        const auth = new VaultTokenAuth(api, logger, { token: 'my-token' });
+
+        return auth._authenticate().then((token) => {
+            expect(api.makeRequest).to.have.been.calledWith('GET', '/auth/token/lookup-self', null, { 'X-Vault-Token': 'my-token' });
+            expect(token).to.be.instanceOf(AuthToken);
+            expect(token.getId()).to.equal('t');
+        });
+    });
+});

--- a/test/conformance.vault-api.test.js
+++ b/test/conformance.vault-api.test.js
@@ -1,0 +1,316 @@
+'use strict';
+
+/**
+ * Conformance tests: validate the client against the documented HashiCorp Vault HTTP API.
+ *
+ * Each assertion is cross-referenced with the official Vault API documentation
+ * (developer.hashicorp.com/vault/api-docs). These tests pin the on-the-wire contract
+ * the client produces (HTTP verb, path, request body keys, headers) and the response
+ * fields it consumes, so a regression against the documented Vault API fails loudly.
+ *
+ * NOTE: these are intentionally test-only. They document current behaviour (including the
+ * token-expiry deviation called out at the bottom); they do not change src/.
+ */
+
+const http = require('http');
+const _ = require('lodash');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+const VaultClient = require('../src/VaultClient');
+const VaultApiClient = require('../src/VaultApiClient');
+const VaultBaseAuth = require('../src/auth/VaultBaseAuth');
+const VaultAppRoleAuth = require('../src/auth/VaultAppRoleAuth');
+const VaultIAMAuth = require('../src/auth/VaultIAMAuth');
+const VaultKubernetesAuth = require('../src/auth/VaultKubernetesAuth');
+const VaultTokenAuth = require('../src/auth/VaultTokenAuth');
+const AuthToken = require('../src/auth/AuthToken');
+const Lease = require('../src/Lease');
+
+const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+const apiStub = () => sinon.createStubInstance(VaultApiClient);
+const b64decode = (s) => Buffer.from(s, 'base64').toString();
+
+describe('Vault API conformance', function () {
+    // -----------------------------------------------------------------------
+    // Transport — every request is rooted at /{apiVersion}/... (default "v1").
+    // Ref: api-docs examples all use http://127.0.0.1:8200/v1/...
+    // -----------------------------------------------------------------------
+    describe('transport (VaultApiClient)', function () {
+        let server;
+        let baseUrl;
+        let seen;
+
+        before(function (done) {
+            server = http.createServer((req, res) => {
+                seen = { method: req.method, url: req.url };
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'application/json');
+                res.end(JSON.stringify({ ok: true }));
+            });
+            server.listen(0, '127.0.0.1', () => {
+                baseUrl = `http://127.0.0.1:${server.address().port}`;
+                done();
+            });
+        });
+
+        after(function (done) { server.close(done); });
+
+        it('prefixes the documented /v1 API version on the wire', function () {
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('GET', '/secret/foo').then(() => {
+                expect(seen.url).to.equal('/v1/secret/foo');
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // KV v1 verbs — read=GET, write=POST, list=LIST (the LIST HTTP verb).
+    // Ref: api-docs/secret/kv/kv-v1 — "List secrets: LIST /secret/:path
+    // (using the LIST HTTP verb, not GET)".
+    // -----------------------------------------------------------------------
+    describe('KV v1 verbs (VaultClient)', function () {
+        let client;
+        const token = { getId: () => 'tid' };
+
+        beforeEach(function () {
+            client = new VaultClient({
+                api: { url: 'https://vault.example/' },
+                logger: false,
+                auth: { type: 'token', config: { token: 't' } },
+            });
+            client.__auth = { getAuthToken: sinon.stub().resolves(token) };
+            client.__api = { makeRequest: sinon.stub().resolves({ data: {} }) };
+        });
+
+        it('reads with GET and the X-Vault-Token header', function () {
+            return client.read('secret/foo').then(() => {
+                expect(client.__api.makeRequest).to.have.been.calledWith('GET', 'secret/foo', null, { 'X-Vault-Token': 'tid' });
+            });
+        });
+
+        it('writes with POST and the X-Vault-Token header', function () {
+            return client.write('secret/foo', { a: 1 }).then(() => {
+                expect(client.__api.makeRequest).to.have.been.calledWith('POST', 'secret/foo', { a: 1 }, { 'X-Vault-Token': 'tid' });
+            });
+        });
+
+        it('lists with the LIST verb (not GET)', function () {
+            return client.list('secret').then(() => {
+                expect(client.__api.makeRequest).to.have.been.calledWith('LIST', 'secret', null, { 'X-Vault-Token': 'tid' });
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Standard secret response envelope.
+    // Ref: api-docs/secret/kv/kv-v1 read example: top-level lease_id,
+    // lease_duration, renewable, data; list returns data.keys (folders suffixed "/").
+    // -----------------------------------------------------------------------
+    describe('secret response envelope (Lease)', function () {
+        it('reads the documented read envelope fields', function () {
+            const lease = Lease.fromResponse({
+                request_id: 'req',
+                lease_id: '',
+                lease_duration: 3600,
+                renewable: false,
+                data: { foo: 'bar', ttl: '1h' },
+            });
+            expect(lease.isRenewable()).to.equal(false);
+            expect(lease.getValue('foo')).to.equal('bar');
+        });
+
+        it('exposes data.keys from a LIST response', function () {
+            const lease = Lease.fromResponse({ data: { keys: ['foo', 'foo/'] } });
+            expect(lease.getValue('keys')).to.deep.equal(['foo', 'foo/']);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Token auth method.
+    // Ref: api-docs/auth/token
+    //   lookup-self: GET  /auth/token/lookup-self  (X-Vault-Token header)
+    //   renew-self : POST /auth/token/renew-self   (X-Vault-Token header)
+    // -----------------------------------------------------------------------
+    describe('token auth', function () {
+        it('looks a token up via GET /auth/token/lookup-self', function () {
+            const api = apiStub();
+            api.makeRequest.resolves({ data: { id: 't', accessor: 'a', creation_time: 1, ttl: 0, renewable: false } });
+            const auth = new VaultBaseAuth(api, logger, 'token');
+            return auth._getTokenEntity('the-token').then(() => {
+                expect(api.makeRequest).to.have.been.calledWith('GET', '/auth/token/lookup-self', null, { 'X-Vault-Token': 'the-token' });
+            });
+        });
+
+        it('renews a token via POST /auth/token/renew-self', function () {
+            const api = apiStub();
+            api.makeRequest.resolves({});
+            const auth = new VaultBaseAuth(api, logger, 'token');
+            sinon.stub(auth, '_getTokenEntity').resolves(new AuthToken('t', 'a', 0, null, 0, 0, false));
+            const token = new AuthToken('the-token', 'a', 0, null, 0, 0, true);
+            return auth.__renewToken(token).then(() => {
+                expect(api.makeRequest).to.have.been.calledWith('POST', '/auth/token/renew-self', null, { 'X-Vault-Token': 'the-token' });
+            });
+        });
+
+        it('VaultTokenAuth authenticates against lookup-self with the configured token', function () {
+            const api = apiStub();
+            api.makeRequest.resolves({ data: { id: 'cfg', accessor: 'a', creation_time: 1, ttl: 0, renewable: false } });
+            const auth = new VaultTokenAuth(api, logger, { token: 'cfg' });
+            return auth._authenticate().then(() => {
+                expect(api.makeRequest).to.have.been.calledWith('GET', '/auth/token/lookup-self', null, { 'X-Vault-Token': 'cfg' });
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // AppRole auth method.
+    // Ref: api-docs/auth/approle — POST /auth/:mount/login with {role_id, secret_id};
+    // response auth.client_token.
+    // -----------------------------------------------------------------------
+    describe('AppRole auth', function () {
+        it('logs in with POST /auth/:mount/login and {role_id, secret_id}', function () {
+            const api = apiStub();
+            api.makeRequest.resolves({ auth: { client_token: 'ct' } });
+            const auth = new VaultAppRoleAuth(api, logger, { role_id: 'r', secret_id: 's' }, 'approle');
+            const getEntity = sinon.stub(auth, '_getTokenEntity').resolves();
+            return auth._authenticate().then(() => {
+                expect(api.makeRequest).to.have.been.calledWith('POST', '/auth/approle/login', { role_id: 'r', secret_id: 's' });
+                // consumes auth.client_token from the response
+                expect(getEntity).to.have.been.calledWith('ct');
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // AWS IAM auth method.
+    // Ref: api-docs/auth/aws — POST /auth/:mount/login with role,
+    // iam_http_request_method, iam_request_url (b64 of https://sts.amazonaws.com/),
+    // iam_request_body (b64 of Action=GetCallerIdentity&Version=2011-06-15),
+    // iam_request_headers (b64 JSON). X-Vault-AWS-IAM-Server-ID must be a signed header.
+    // -----------------------------------------------------------------------
+    describe('AWS IAM auth', function () {
+        it('builds the documented sts:GetCallerIdentity login body', function () {
+            const api = apiStub();
+            api.makeRequest.resolves({ auth: { client_token: 'ct' } });
+            const auth = new VaultIAMAuth(api, logger, {
+                role: 'MyRole',
+                iam_server_id_header_value: 'https://vault.example',
+                credentials: { accessKeyId: 'AK', secretAccessKey: 'SK' },
+            }, 'aws');
+            const getEntity = sinon.stub(auth, '_getTokenEntity').resolves();
+
+            return auth._authenticate().then(() => {
+                const [method, path, body] = api.makeRequest.getCall(0).args;
+                expect(method).to.equal('POST');
+                expect(path).to.equal('/auth/aws/login');
+                expect(body.role).to.equal('MyRole');
+                expect(body.iam_http_request_method).to.equal('POST');
+                expect(b64decode(body.iam_request_url)).to.equal('https://sts.amazonaws.com/');
+                expect(b64decode(body.iam_request_body)).to.equal('Action=GetCallerIdentity&Version=2011-06-15');
+                const headers = JSON.parse(b64decode(body.iam_request_headers));
+                // X-Vault-AWS-IAM-Server-ID present and signed (golang-style array value)
+                expect(headers['X-Vault-AWS-IAM-Server-ID']).to.deep.equal(['https://vault.example']);
+                expect(headers['Authorization'][0]).to.match(/^AWS4-HMAC-SHA256 /);
+                expect(getEntity).to.have.been.calledWith('ct');
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Kubernetes auth method.
+    // Ref: api-docs/auth/kubernetes — POST /auth/:mount/login with {role, jwt}.
+    // -----------------------------------------------------------------------
+    describe('Kubernetes auth', function () {
+        let readFileSync;
+        afterEach(function () { if (readFileSync) { readFileSync.restore(); readFileSync = null; } });
+
+        it('logs in with POST /auth/:mount/login and {role, jwt}', function () {
+            const fs = require('fs');
+            readFileSync = sinon.stub(fs, 'readFileSync').returns(Buffer.from('signed-jwt'));
+            const api = apiStub();
+            api.makeRequest.resolves({ auth: { client_token: 'ct' } });
+            const auth = new VaultKubernetesAuth(api, logger, { role: 'r', tokenPath: '/tok' }, 'kubernetes');
+            const getEntity = sinon.stub(auth, '_getTokenEntity').resolves();
+            return auth._authenticate().then(() => {
+                expect(api.makeRequest).to.have.been.calledWith('POST', '/auth/kubernetes/login', { role: 'r', jwt: 'signed-jwt' });
+                expect(getEntity).to.have.been.calledWith('ct');
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Vault Enterprise namespaces.
+    // Ref: api-docs — namespace selection via the X-Vault-Namespace header.
+    // -----------------------------------------------------------------------
+    describe('namespaces', function () {
+        it('selects a namespace with the X-Vault-Namespace header on KV requests', function () {
+            const client = new VaultClient({
+                api: { url: 'https://vault.example/' },
+                logger: false,
+                auth: { type: 'token', config: { token: 't', namespace: 'team-a' } },
+            });
+            expect(client.getHeaders({ getId: () => 'tid' })).to.deep.equal({
+                'X-Vault-Token': 'tid',
+                'X-Vault-Namespace': 'team-a',
+            });
+        });
+
+        it('sends X-Vault-Namespace on the AppRole login request', function () {
+            const api = apiStub();
+            api.makeRequest.resolves({ auth: { client_token: 'ct' } });
+            const auth = new VaultAppRoleAuth(api, logger, { role_id: 'r', secret_id: 's', namespace: 'team-a' }, 'approle');
+            sinon.stub(auth, '_getTokenEntity').resolves();
+            return auth._authenticate().then(() => {
+                const headers = api.makeRequest.getCall(0).args[3];
+                expect(headers).to.deep.equal({ 'X-Vault-Namespace': 'team-a' });
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // DEVIATION (documented here, not fixed): token expiry reconstruction.
+    //
+    // Vault's lookup-self response documents `expire_time` (RFC3339) as the
+    // authoritative absolute expiry, alongside `creation_time` (unix seconds, when
+    // the token was CREATED) and `ttl` (REMAINING seconds, counting down at lookup).
+    //
+    // AuthToken.fromResponse ignores `expire_time` and reconstructs:
+    //     expiresAt = (last_renewal_time || creation_time) + (ttl - 60s margin)
+    //
+    // This is only accurate when lookup-self runs right after issuance/renewal
+    // (which is exactly this client's flow: login -> lookup-self, renew -> lookup-self).
+    // For a token looked up long after issuance it would be wrong, because it adds the
+    // *remaining* ttl to the *creation* time instead of using `expire_time`.
+    // -----------------------------------------------------------------------
+    describe('token expiry reconstruction (current behaviour)', function () {
+        it('derives expiry from creation_time + ttl - 60s and ignores expire_time', function () {
+            const token = AuthToken.fromResponse({
+                data: {
+                    id: 's.token',
+                    accessor: 'acc',
+                    creation_time: 1600000000,
+                    creation_ttl: 2764800,
+                    ttl: 2764790,                       // remaining at lookup
+                    expire_time: '2020-10-16T00:00:00Z', // authoritative per docs — NOT used by the client
+                    explicit_max_ttl: 0,
+                    num_uses: 0,
+                    renewable: true,
+                },
+            });
+            // 1600000000 + (2764790 - 60)
+            expect(token.getExpiresAt()).to.equal(1600000000 + (2764790 - 60));
+            expect(token.isRenewable()).to.equal(true);
+        });
+
+        it('treats ttl === 0 (root / non-expiring token) as never expiring', function () {
+            const token = AuthToken.fromResponse({
+                data: { id: 'root', accessor: 'a', creation_time: 1600000000, ttl: 0, renewable: false },
+            });
+            expect(token.getExpiresAt()).to.equal(null);
+            expect(token.isExpired()).to.equal(false);
+        });
+    });
+});

--- a/test/data/config-not-object/custom-vault-variables.js
+++ b/test/data/config-not-object/custom-vault-variables.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// Intentionally NOT a plain object, to exercise VaultNodeConfig validation.
+module.exports = 'this is not a plain object';

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -7,7 +7,7 @@ const rp = require('request-promise');
 const _ = require('lodash');
 const chai = require('chai');
 const expect = chai.expect;
-const VaultClient = require('../src/VaultClient');
+const VaultClient = require('../../src/VaultClient');
 
 describe('E2E', function () {
 
@@ -61,7 +61,7 @@ describe('E2E', function () {
         yield vaultClient.write('/secret/a', testData);
         yield vaultClient.write('/secret/b', {tst: 'ZZZ'});
 
-        process.env.NODE_CONFIG_DIR = `${__dirname}/data/config-base`;
+        process.env.NODE_CONFIG_DIR = `${__dirname}/../data/config-base`;
         const config = require('config');
 
         expect(JSON.parse(JSON.stringify(config))).to.deep.equal({deep: {aStr: '', aInt: 0}, b: 'NOT WORKING'});
@@ -76,7 +76,7 @@ describe('E2E', function () {
 
         const vaultClient = new VaultClient(this.bootOpts);
 
-        process.env.NODE_CONFIG_DIR = `${__dirname}/data/config-empty`;
+        process.env.NODE_CONFIG_DIR = `${__dirname}/../data/config-empty`;
         const config = require('config');
 
         expect(JSON.parse(JSON.stringify(config))).to.deep.equal({deep: {aStr: '', aInt: 0}, b: 'NOT WORKING'});

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const errors = require('../src/errors');
+
+describe('errors', function () {
+    it('exposes the expected error classes', function () {
+        expect(errors).to.have.all.keys([
+            'VaultError',
+            'InvalidArgumentsError',
+            'InvalidAWSCredentialsError',
+            'AuthTokenExpiredError',
+        ]);
+    });
+
+    describe('VaultError', function () {
+        it('is an Error carrying the message, name and a stack trace', function () {
+            const err = new errors.VaultError('boom');
+            expect(err).to.be.instanceOf(Error);
+            expect(err.name).to.equal('VaultError');
+            expect(err.message).to.equal('boom');
+            expect(err.stack).to.be.a('string');
+        });
+
+        it('accepts an optional wrapped error argument', function () {
+            const cause = new Error('cause');
+            const err = new errors.VaultError('boom', cause);
+            expect(err.message).to.equal('boom');
+        });
+    });
+
+    describe('error hierarchy', function () {
+        it('InvalidArgumentsError extends VaultError', function () {
+            const err = new errors.InvalidArgumentsError('bad arg');
+            expect(err).to.be.instanceOf(errors.VaultError);
+            expect(err).to.be.instanceOf(Error);
+            expect(err.name).to.equal('InvalidArgumentsError');
+        });
+
+        it('InvalidAWSCredentialsError extends InvalidArgumentsError', function () {
+            const err = new errors.InvalidAWSCredentialsError('bad creds');
+            expect(err).to.be.instanceOf(errors.InvalidArgumentsError);
+            expect(err).to.be.instanceOf(errors.VaultError);
+            expect(err.name).to.equal('InvalidAWSCredentialsError');
+        });
+
+        it('AuthTokenExpiredError extends VaultError', function () {
+            const err = new errors.AuthTokenExpiredError('expired');
+            expect(err).to.be.instanceOf(errors.VaultError);
+            expect(err).to.not.be.instanceOf(errors.InvalidArgumentsError);
+            expect(err.name).to.equal('AuthTokenExpiredError');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds a unit test suite and a Vault-API conformance suite for `src/`. **No production code is modified** — this PR is test-only.

Statement coverage of `src/` goes from **~62% to ~99.6%** (100% of functions), measured without a live Vault:

| | Before | After |
|---|---|---|
| Statements | 62.2% | 99.6% |
| Branches | 78.3% | 98.9% |
| Functions | 38.5% | 100% |

## What's included

- **Unit tests** for `Lease`, `AuthToken`, `errors`, `VaultApiClient`, `VaultClient`, `VaultBaseAuth`, `VaultTokenAuth`, `VaultKubernetesAuth` and `VaultNodeConfig`. Covers token caching/expiry/re-auth, the renewal refresh timer (sinon fake timers), logger setup, and node-config substitution + error paths. External boundaries are exercised honestly: `VaultApiClient` runs against a throwaway local HTTP server, `fs`/AWS creds are stubbed.
- **Branch top-ups** to the existing AppRole / AWS IAM tests (default mount, `X-Vault-Namespace` header).
- **Conformance tests** (`test/conformance.vault-api.test.js`) cross-referenced with the HashiCorp Vault HTTP API docs — token `lookup-self`/`renew-self`, AppRole/AWS IAM/Kubernetes login bodies, KV v1 verbs (read=`GET`, write=`POST`, list=`LIST`), the `/v1` prefix and the `X-Vault-Namespace` header.

## Test layout / tooling

- Vault-dependent e2e moved to `test/e2e/` so the unit suite runs without Docker. `npm test` still runs **everything** (unchanged for CI); `npm run test:unit` runs unit-only; `npm run coverage` runs unit-only under `c8`.
- Added `c8` as a dev dependency. `config` remains a peer dependency installed separately in CI (`npm ci && npm install config`).

## Findings surfaced by the tests (not fixed here — see linked issues)

The two uncovered lines that remain map to real findings, documented in tests rather than changed:

1. **Unreachable `AuthTokenExpiredError`** in `VaultBaseAuth.getAuthToken` (`src/auth/VaultBaseAuth.js:37-38`).
2. **Token expiry reconstructed from `creation_time + ttl`** instead of the documented authoritative `expire_time` (`src/auth/AuthToken.js`).
3. Deprecated `new Buffer()` in `src/auth/VaultIAMAuth.js:160`.

## Verification

`npm run test:unit` → **111 passing**. (e2e remains Vault-dependent and runs in CI via the existing `docker-compose.yml`.)
