### PR TITLE
ci: test on current Node LTS (18/20/22/24)

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -10,17 +10,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [18, 20, 22, 24]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build the Docker Compose stack
         run: docker compose up -d
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Summary

Modernizes the GitHub Actions test matrix to run on the current Node.js LTS releases and removes a job that can no longer pass.

## Changes

- **Add the current LTS lines:** Node **22** and **24** (24 is the latest LTS).
- **Drop Node 14 and 16:**
  - Node **14** can no longer pass — a (transitive) dependency now requires the `node:util/types` builtin, which Node 14 does not provide (`ERR_UNKNOWN_BUILTIN_MODULE`). This was the sole reason the previous matrix went red; with `fail-fast` it cancelled the otherwise-passing 16/18/20 jobs.
  - Node **16** is end-of-life (Sep 2023).
- **`fail-fast: false`** so each Node version is reported independently instead of one failing leg cancelling the rest.
- **Bump action runtimes:** `actions/checkout@v2 → v4`, `actions/setup-node@v3 → v4`. GitHub is removing the Node 20 action runtime used by v2/v3 from hosted runners (forced to Node 24 on 2026-06-16), so the old majors would soon stop working.

Resulting matrix: `[18, 20, 22, 24]`.

## Notes

- `package.json` still declares `engines.node >= 14`. That field is left untouched here (support-policy change is out of scope for a CI tweak), but it is now inconsistent with what CI exercises — worth a follow-up decision to bump it to `>= 18`.
- The Vault-dependent e2e suite continues to run against the `docker-compose.yml` Vault, unchanged.
