### PR TITLE
chore: add CODEOWNERS (default reviewer @wRLSS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for node-vault-client.
+#
+# GitHub automatically requests a review from the owners listed here when a
+# pull request changes matching files. With "Require review from Code Owners"
+# enabled in branch protection, their approval becomes mandatory before merge.
+#
+# The catch-all pattern below makes @wRLSS the default reviewer for every PR.
+
+* @wRLSS


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with a catch-all `* @wRLSS` so **@wRLSS** is automatically requested as reviewer on every pull request.

Pairs with the master branch-protection rule ("Require review from Code Owners"), which turns this into a required approval before merge.

@wRLSS is a repo admin, so they are eligible to be a code owner.