### PR TITLE
ci: cache npm, dedupe runs, cancel superseded runs

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -2,10 +2,17 @@ name: Node.js CI
 on:
   push:
     branches:
-      - '**'
+      - master
   pull_request:
     branches:
       - master
+
+# One in-flight run per branch/PR. New pushes (e.g. rebases) cancel the
+# superseded run, except on master where every commit is kept.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,6 +31,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci && npm install config


### PR DESCRIPTION
## Summary

Workflow-only optimizations to cut CI time and wasted runs. No job renames, so the `build (18/20/22/24)` required checks keep matching the master branch-protection rule.

## Changes

### 1. Cache npm dependencies
`actions/setup-node` now uses `cache: 'npm'` (keyed on `package-lock.json`). `npm ci` restores `~/.npm` from cache instead of re-downloading the whole dependency tree every run.

### 2. Stop running CI twice per PR
Triggers were `push: ['**']` **plus** `pull_request: [master]`, so every commit on a PR branch fired **two** runs (a push run *and* a pull_request run). Now:
```yaml
on:
  push:        { branches: [master] }   # post-merge runs on master
  pull_request:{ branches: [master] }   # one run per PR
```
PRs run once (via `pull_request`); `master` runs once after merge. This roughly **halves** total runs for PR work. (Branch protection is satisfied by the `pull_request` run's checks.)

### 3. Cancel superseded runs
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
```
A new push to the same branch/PR (e.g. a rebase force-push) cancels the in-flight run instead of letting both finish. `master` runs are never cancelled, so every merged commit is still fully tested.

## Expected impact
- Faster installs after the first cached run.
- ~50% fewer runs for PR iterations.
- No more piled-up runs during rebases.

## Possible follow-up (not in this PR)
Splitting into a fast `unit` matrix (no Docker, all Node versions) + a single `e2e` job (Docker Vault, one Node version) would cut more time, but it renames the status-check contexts and would require updating the branch-protection required checks in lockstep — better as its own change.
