### PR TITLE
ci: bump checkout/setup-node to v6 (node24 runtime)

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -22,13 +22,13 @@ jobs:
         node-version: [18, 20, 22, 24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build the Docker Compose stack
         run: docker compose up -d
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
## Summary

Clears the annotated CI warning from [this run](https://github.com/namecheap/node-vault-client/actions/runs/27010627721):

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20:
actions/checkout@v4, actions/setup-node@v4. ... removed from the runner on September 16th, 2026.
```

Even at `@v4`, both actions run on the **node20** action runtime, which GitHub force-migrates on 2026-06-16. `actions/checkout@v6` and `actions/setup-node@v6` run on **node24** (`runs.using: node24`), so this clears the warning permanently rather than via the transitional `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env flag.

Inputs are unchanged (`cache: 'npm'`, `node-version` still supported), so behaviour is identical.

## Not addressed here (log-level deprecations, separate concerns)
- `npm warn deprecated request@…/request-promise@…` (+ har-validator/uuid/mkdirp/text-encoding/json3) — all from the `request` chain; resolved by replacing `request` (#15).
- `npm warn deprecated formatio/samsam` — from `sinon@2.4.1`; resolved by bumping sinon.
- `[DEP0005] Buffer()` — from `src/auth/VaultIAMAuth.js` (#52) and an IAM test; one-line `Buffer.from` fixes.