### PR TITLE
fix: replace deprecated new Buffer() with Buffer.from() (closes #52)

### DIFF
--- a/src/auth/VaultIAMAuth.js
+++ b/src/auth/VaultIAMAuth.js
@@ -157,7 +157,7 @@ class VaultIAMAuth extends VaultBaseAuth {
      * @private
      */
     __base64encode(string) {
-        return new Buffer(string).toString('base64')
+        return Buffer.from(string).toString('base64')
     }
 
     /**

--- a/test/auth.iam.test.js
+++ b/test/auth.iam.test.js
@@ -16,7 +16,7 @@ const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p
 describe('Unit AWS auth backend :: IAM', function () {
 
     function base64decode(str) {
-        return new Buffer(str, 'base64').toString();
+        return Buffer.from(str, 'base64').toString();
     }
 
     function getAuthorizationHeaderRegExp(awsAccessKey) {
@@ -184,5 +184,15 @@ describe('Unit AWS auth backend :: IAM', function () {
         it('Should throw InvalidAWSCredentialsError if credentials are an array', () => {
             expect(() => instantiate([])).to.throw(errors.InvalidAWSCredentialsError);
         })
+    });
+
+    describe('base64 encoding', function () {
+        it('encodes via Buffer.from (no deprecated new Buffer) and round-trips', function () {
+            const auth = new VaultIAMAuth(getApiStub(), logger, { role: 'MyRole' }, 'aws');
+            const input = 'Action=GetCallerIdentity&Version=2011-06-15';
+            const encoded = auth.__base64encode(input);
+            expect(encoded).to.equal(Buffer.from(input).toString('base64'));
+            expect(base64decode(encoded)).to.equal(input);
+        });
     });
 });


### PR DESCRIPTION
## Summary

Closes #52. Replaces the deprecated `new Buffer()` constructor (DEP0005) with `Buffer.from()`.

`new Buffer()` is deprecated "due to security and usability issues" and is slated for removal from Node.js; it prints a `DeprecationWarning [DEP0005]` on every IAM auth call. Both occurrences take a **string** (UTF-8) or a **base64 string**, for which `Buffer.from(...)` is a behaviour-identical drop-in (no `Buffer.alloc` needed — neither call allocates by size).

## Changes

- `src/auth/VaultIAMAuth.js` — `#__base64encode`: `new Buffer(string)` → `Buffer.from(string)`.
- `test/auth.iam.test.js` — `base64decode` helper: `new Buffer(str, 'base64')` → `Buffer.from(str, 'base64')` (this call was the other DEP0005 source during the IAM tests).
- Added a unit test pinning `__base64encode`: asserts it equals `Buffer.from(input).toString('base64')` and round-trips through `base64decode`.

## Verification

- `grep -rn "new Buffer(" src test` → **none remaining**.
- `npm run test:unit` → **112 passing** (was 111; +1 new test).
- **DEP0005 count in the test output: 0** (previously printed once per IAM run).

No behaviour change — the base64 output is byte-for-byte identical; this only removes the deprecated API.
