### PR TITLE
fix: derive token expiry from Vault's expire_time (closes #51)

### DIFF
--- a/src/auth/AuthToken.js
+++ b/src/auth/AuthToken.js
@@ -35,23 +35,71 @@ class AuthToken {
     static fromResponse(response) {
         const data = response.data;
 
-        let expiresAt = null;
-        if (data.ttl !== 0) {
-            const creationTime = parseInt(data.last_renewal_time !== undefined ? data.last_renewal_time : data.creation_time, 10);
-            const networkLatency = 60;
-            const ttl = parseInt(data.ttl > networkLatency ? data.ttl - networkLatency : data.ttl);
-            expiresAt = creationTime + ttl;
-        }
-
         return new AuthToken(
             data.id,
             data.accessor,
             data.creation_time,
-            expiresAt,
+            AuthToken.__resolveExpiresAt(data),
             data.explicit_max_ttl,
             data.num_uses,
             data.renewable !== undefined ? data.renewable : false
         );
+    }
+
+    /**
+     * Resolve the UNIX timestamp (seconds) at which the client should treat the token
+     * as expired, shifted earlier by a network-latency safety margin so renewal happens
+     * before the real expiry.
+     *
+     * Prefers Vault's authoritative `expire_time` (RFC3339), which is the documented
+     * absolute expiry. Falls back to `(last_renewal_time || creation_time) + ttl` for
+     * responses that don't carry `expire_time` — note `ttl` is the *remaining* lifetime,
+     * so that sum is only accurate when the lookup happens right after issuance/renewal.
+     *
+     * @private
+     * @param {Object} data - the `data` object of a token lookup response
+     * @returns {int|null} null when the token never expires (ttl === 0)
+     */
+    static __resolveExpiresAt(data) {
+        if (data.ttl === 0) {
+            return null;
+        }
+
+        const networkLatency = 60;
+        const margin = data.ttl > networkLatency ? networkLatency : 0;
+
+        const expireTime = AuthToken.__parseRfc3339Seconds(data.expire_time);
+        if (expireTime !== null) {
+            return expireTime - margin;
+        }
+
+        // Fallback for responses without a usable `expire_time`.
+        const creationTime = parseInt(data.last_renewal_time !== undefined ? data.last_renewal_time : data.creation_time, 10);
+        const ttl = data.ttl > networkLatency ? data.ttl - networkLatency : data.ttl;
+        return creationTime + parseInt(ttl, 10);
+    }
+
+    /**
+     * Parse an RFC3339 timestamp (as returned by Vault, up to nanosecond precision with
+     * a timezone offset) into whole UNIX seconds. Returns null for missing, empty,
+     * unparseable, or non-positive (e.g. Vault's "0001-01-01T00:00:00Z" zero value) input.
+     *
+     * @private
+     * @param {String} value
+     * @returns {int|null}
+     */
+    static __parseRfc3339Seconds(value) {
+        if (typeof value !== 'string' || value === '') {
+            return null;
+        }
+
+        const ms = Date.parse(value);
+        if (isNaN(ms)) {
+            return null;
+        }
+
+        const seconds = Math.floor(ms / 1000);
+        return seconds > 0 ? seconds : null;
     }
 
     /**

--- a/test/AuthToken.test.js
+++ b/test/AuthToken.test.js
@@ -58,6 +58,66 @@ describe('AuthToken', function () {
         });
     });
 
+    describe('.fromResponse() expire_time handling', function () {
+        const epoch = (s) => Math.floor(Date.parse(s) / 1000);
+        function build(dataOverrides) {
+            return AuthToken.fromResponse({
+                data: Object.assign({
+                    id: 'tok-id',
+                    accessor: 'tok-accessor',
+                    creation_time: 1000,
+                    ttl: 3600,
+                    explicit_max_ttl: 0,
+                    num_uses: 0,
+                    renewable: true,
+                }, dataOverrides),
+            });
+        }
+
+        it('prefers the authoritative expire_time over creation_time + ttl', function () {
+            const token = build({ creation_time: 1000, ttl: 3600, expire_time: '2030-01-01T00:00:00Z' });
+            expect(token.getExpiresAt()).to.equal(epoch('2030-01-01T00:00:00Z') - 60);
+        });
+
+        it('does not subtract the margin when the remaining ttl is below the latency', function () {
+            const token = build({ ttl: 30, expire_time: '2030-01-01T00:00:00Z' });
+            expect(token.getExpiresAt()).to.equal(epoch('2030-01-01T00:00:00Z'));
+        });
+
+        it('uses expire_time for a token looked up long after issuance (the fix)', function () {
+            // Aged token: created long ago, only 100s of ttl remaining. The old code
+            // returned creation_time + remaining_ttl (wrong); the fix uses expire_time.
+            const token = build({ creation_time: 1000, ttl: 100, expire_time: '2031-06-01T12:00:00Z' });
+            expect(token.getExpiresAt()).to.equal(epoch('2031-06-01T12:00:00Z') - 60);
+            expect(token.getExpiresAt()).to.not.equal(1000 + 100);
+        });
+
+        it('parses Vault RFC3339 with nanoseconds and a timezone offset', function () {
+            const token = build({ ttl: 3600, expire_time: '2030-05-19T11:35:54.466476215-04:00' });
+            expect(token.getExpiresAt()).to.equal(epoch('2030-05-19T11:35:54.466476215-04:00') - 60);
+        });
+
+        it('falls back to creation_time + ttl when expire_time is absent', function () {
+            const token = build({ creation_time: 1000, ttl: 3600 });
+            expect(token.getExpiresAt()).to.equal(1000 + (3600 - 60));
+        });
+
+        it('falls back when expire_time is an empty string', function () {
+            const token = build({ creation_time: 1000, ttl: 3600, expire_time: '' });
+            expect(token.getExpiresAt()).to.equal(1000 + (3600 - 60));
+        });
+
+        it('falls back when expire_time is the Vault zero value', function () {
+            const token = build({ creation_time: 1000, ttl: 3600, expire_time: '0001-01-01T00:00:00Z' });
+            expect(token.getExpiresAt()).to.equal(1000 + (3600 - 60));
+        });
+
+        it('never expires when ttl is 0, even if expire_time is present', function () {
+            const token = build({ ttl: 0, expire_time: '2030-01-01T00:00:00Z' });
+            expect(token.getExpiresAt()).to.equal(null);
+        });
+    });
+
     describe('#isExpired()', function () {
         it('is never expired when there is no expiry', function () {
             const token = new AuthToken('id', 'acc', 0, null, 0, 0, false);

--- a/test/conformance.vault-api.test.js
+++ b/test/conformance.vault-api.test.js
@@ -275,22 +275,20 @@ describe('Vault API conformance', function () {
     });
 
     // -----------------------------------------------------------------------
-    // DEVIATION (documented here, not fixed): token expiry reconstruction.
+    // Token expiry.
     //
     // Vault's lookup-self response documents `expire_time` (RFC3339) as the
     // authoritative absolute expiry, alongside `creation_time` (unix seconds, when
     // the token was CREATED) and `ttl` (REMAINING seconds, counting down at lookup).
     //
-    // AuthToken.fromResponse ignores `expire_time` and reconstructs:
-    //     expiresAt = (last_renewal_time || creation_time) + (ttl - 60s margin)
-    //
-    // This is only accurate when lookup-self runs right after issuance/renewal
-    // (which is exactly this client's flow: login -> lookup-self, renew -> lookup-self).
-    // For a token looked up long after issuance it would be wrong, because it adds the
-    // *remaining* ttl to the *creation* time instead of using `expire_time`.
+    // AuthToken.fromResponse derives the expiry from `expire_time` (minus a 60s
+    // network-latency safety margin), falling back to
+    // `(last_renewal_time || creation_time) + ttl` only for responses that don't
+    // carry `expire_time`. Using `expire_time` is correct regardless of how long
+    // after issuance the lookup happens.
     // -----------------------------------------------------------------------
-    describe('token expiry reconstruction (current behaviour)', function () {
-        it('derives expiry from creation_time + ttl - 60s and ignores expire_time', function () {
+    describe('token expiry', function () {
+        it('derives expiry from the documented expire_time (minus the safety margin)', function () {
             const token = AuthToken.fromResponse({
                 data: {
                     id: 's.token',
@@ -298,14 +296,14 @@ describe('Vault API conformance', function () {
                     creation_time: 1600000000,
                     creation_ttl: 2764800,
                     ttl: 2764790,                       // remaining at lookup
-                    expire_time: '2020-10-16T00:00:00Z', // authoritative per docs — NOT used by the client
+                    expire_time: '2020-10-16T00:00:00Z', // authoritative per docs
                     explicit_max_ttl: 0,
                     num_uses: 0,
                     renewable: true,
                 },
             });
-            // 1600000000 + (2764790 - 60)
-            expect(token.getExpiresAt()).to.equal(1600000000 + (2764790 - 60));
+            // expire_time epoch (1602806400) minus the 60s margin, NOT creation_time + ttl
+            expect(token.getExpiresAt()).to.equal(Math.floor(Date.parse('2020-10-16T00:00:00Z') / 1000) - 60);
             expect(token.isRenewable()).to.equal(true);
         });
 


### PR DESCRIPTION
## Summary

Closes #51. Derives the token's expiry from Vault's authoritative `expire_time` instead of reconstructing it from `creation_time + ttl`.

## The bug

`AuthToken.fromResponse` computed:

```js
expiresAt = (last_renewal_time || creation_time) + (ttl - 60s margin)
```

But Vault's `ttl` is the **remaining** lifetime — it counts down on every lookup — while `creation_time` is the absolute moment the token was *created*. So `creation_time + ttl` only equals the real expiry at the instant of issuance. For a token looked up later it **under-estimates** the expiry (by roughly the elapsed time), which makes the client consider the token expired earlier than it really is.

Vault's lookup-self response documents [`expire_time`](https://developer.hashicorp.com/vault/api-docs/auth/token) (RFC3339) as the authoritative absolute expiry.

## The fix

- **`src/auth/AuthToken.js`** — new `__resolveExpiresAt(data)`:
  - `ttl === 0` → `null` (never expires), as before.
  - Otherwise prefer `expire_time`, parsed to whole UNIX seconds via `__parseRfc3339Seconds` (handles nanosecond precision + timezone offset, e.g. `2018-05-19T11:35:54.466476215-04:00`), keeping the **same 60s network-latency margin** (subtracted only when remaining `ttl > 60`, matching the prior guard).
  - **Fall back** to the previous `creation_time/last_renewal_time + ttl` computation when `expire_time` is absent, empty, the Vault zero value (`0001-01-01T00:00:00Z`), or unparseable — so older Vault responses behave exactly as before.

No public API change; `getExpiresAt()` / `isExpired()` / `isRenewable()` are unchanged. In this client's normal flow (lookup right after login/renew) the value is essentially the same as before; the fix matters for any lookup of an already-aged token.

## Tests

- **`test/AuthToken.test.js`** — added an `expire_time handling` block: prefer-`expire_time`, margin vs. sub-latency ttl, **aged-token correctness** (the actual fix), RFC3339 nanosecond+offset parsing, and every fallback case (absent / empty / zero-value); plus `ttl===0` still wins.
- **`test/conformance.vault-api.test.js`** — updated the test that previously pinned the *deviating* behaviour to assert the documented `expire_time` is now used.
- `npm run test:unit` → **119 passing**.
