### PR TITLE
fix: raise AuthTokenExpiredError for expired non-refreshable tokens (closes #50)

### DIFF
--- a/src/auth/VaultBaseAuth.js
+++ b/src/auth/VaultBaseAuth.js
@@ -32,11 +32,15 @@ class VaultBaseAuth {
     }
 
     getAuthToken() {
-        if (this.__authToken === null || (this.__authToken instanceof AuthToken && this.__authToken.isExpired() && this._reauthenticationAllowed())) {
-            if (this.__authToken !== null && this.__authToken.isExpired() && !this._reauthenticationAllowed()) {
-                throw new errors.AuthTokenExpiredError('Auth token has expired & cannot be refreshed since auth method doesn\'t support this.');
-            }
+        const tokenExpired = this.__authToken instanceof AuthToken && this.__authToken.isExpired();
 
+        if (tokenExpired && !this._reauthenticationAllowed()) {
+            return Promise.reject(new errors.AuthTokenExpiredError(
+                'Auth token has expired & cannot be refreshed since auth method doesn\'t support this.'
+            ));
+        }
+
+        if (this.__authToken === null || tokenExpired) {
             this._log.info('getting auth token (mount=%s)', this._mount);
 
             const tokenPromise = this._authenticate().then(authToken => {

--- a/test/auth.base.test.js
+++ b/test/auth.base.test.js
@@ -9,6 +9,7 @@ chai.use(require('sinon-chai'));
 const VaultApiClient = require('../src/VaultApiClient');
 const VaultBaseAuth = require('../src/auth/VaultBaseAuth');
 const AuthToken = require('../src/auth/AuthToken');
+const errors = require('../src/errors');
 
 const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
 
@@ -104,22 +105,24 @@ describe('VaultBaseAuth', function () {
                 });
         });
 
-        // Documents current behaviour: when reauth is disallowed (e.g. token auth) an
-        // expired token is returned as-is. The AuthTokenExpiredError branch in the
-        // source is in fact unreachable given a deterministic _reauthenticationAllowed().
-        it('returns the expired token without re-authenticating when reauth is disallowed', function () {
+        // When reauth is disallowed (e.g. token auth) and the cached token has expired,
+        // getAuthToken rejects with AuthTokenExpiredError instead of silently handing
+        // back the expired token.
+        it('rejects with AuthTokenExpiredError when the cached token expired and reauth is disallowed', function () {
             const expired = new AuthToken('old', 'acc', 0, nowSec() - 100, 0, 0, false);
             const authStub = sinon.stub().resolves(expired);
             const auth = new TestAuth(apiStub(), 'mount', { authStub, reauth: false });
 
             return auth.getAuthToken()
                 .then((t1) => {
-                    expect(t1).to.equal(expired);
-                    return auth.getAuthToken();
-                })
-                .then((t2) => {
-                    expect(t2).to.equal(expired);
-                    expect(authStub).to.have.been.calledOnce;
+                    expect(t1).to.equal(expired); // first call authenticates & caches
+                    return auth.getAuthToken().then(
+                        () => { throw new Error('expected rejection'); },
+                        (err) => {
+                            expect(err).to.be.instanceOf(errors.AuthTokenExpiredError);
+                            expect(authStub).to.have.been.calledOnce; // did NOT re-authenticate
+                        }
+                    );
                 });
         });
 


### PR DESCRIPTION
## Summary

Fixes #50.

`VaultBaseAuth.getAuthToken`'s `AuthTokenExpiredError` branch was unreachable. As a result, an expired token obtained from a non-refreshable auth method (e.g. `VaultTokenAuth`) was returned silently instead of surfacing an error.

## The bug

The outer guard only entered the expired-token path when re-authentication **was allowed**, but the `throw new AuthTokenExpiredError(...)` inside required re-authentication to be **disallowed** (`!_reauthenticationAllowed()`). Those two conditions are mutually contradictory, so the throw was dead code:

- If reauth is allowed -> the code re-authenticates instead of throwing.
- If reauth is disallowed -> the outer guard is never entered, so the throw is never reached.

The expired token therefore fell through and was returned to the caller as if it were valid.

## The fix

`getAuthToken` now **rejects with `AuthTokenExpiredError`** when the cached token is expired and `_reauthenticationAllowed()` is `false`. This makes the previously-unreachable error path reachable and correct.

The rejection is async-consistent with the rest of `getAuthToken` (it returns/throws within the promise chain rather than throwing synchronously), so callers handle it via normal promise rejection like every other outcome of this method.

## Scope

- All other `getAuthToken` paths are unchanged: a valid cached token is still returned as-is, and refreshable auth methods still re-authenticate as before.
- 111 unit tests pass.

Closes #50.