### PR TITLE
feat(api): configurable requestOptions passthrough (proxy / custom TLS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- Add `api.requestOptions`, shallow-merged into every underlying `fetch()` request. Enables
+  routing traffic through a proxy/SOCKS agent and trusting a self-signed / internal-CA Vault by
+  passing an undici `dispatcher`. Closes #37 and #29.
+
 # 1.0.0. Release notes (2023-08-02)
 
 - `aws-sdk` is no longer a peer dependency

--- a/README.md
+++ b/README.md
@@ -65,10 +65,44 @@ Client constructor function.
 | options.api | <code>Object</code> |  |  |
 | options.api.url | <code>String</code> |  | the url of the vault server |
 | [options.api.apiVersion] | <code>String</code> | `v1` |  |
+| [options.api.requestOptions] | <code>Object</code> |  | extra options merged into every HTTP request (see [Custom transport](#custom-transport-proxy--self-signed-tls)) |
 | options.auth | <code>Object</code> |  |  |
 | options.auth.type | <code>String</code> |  |  |
 | options.auth.config | <code>Object</code> |  | auth configuration variables |
 | options.logger | <code>Object</code> | `false` |  | Logger that supports "error", "info", "warn", "trace", "debug" methods. Uses `console` by default. Pass `false` to disable logging. |
+
+##### Custom transport (proxy / self-signed TLS)
+
+`options.api.requestOptions` is shallow-merged into every underlying `fetch()` call, so you
+can route traffic through a proxy/SOCKS agent or trust a self-signed / internal-CA Vault.
+Pass an [undici](https://undici.nodejs.org/) `dispatcher` (request semantics like `method`
+and `body` always win; `headers` are merged with per-request headers taking precedence):
+
+```javascript
+const { Agent, ProxyAgent } = require('undici');
+
+// Trust an internal/self-signed CA (preferred over disabling verification)
+const vaultClient = VaultClient.boot('main', {
+    api: {
+        url: 'https://vault.internal:8200/',
+        requestOptions: {
+            dispatcher: new Agent({ connect: { ca: require('fs').readFileSync('/etc/ssl/internal-ca.pem') } }),
+        },
+    },
+    auth: { type: 'token', config: { token: '...' } },
+});
+
+// Route through an HTTP proxy / SOCKS agent
+const proxied = VaultClient.boot('proxied', {
+    api: { url: 'https://vault.example.com:8200/', requestOptions: { dispatcher: new ProxyAgent('http://proxy:8080') } },
+    auth: { type: 'token', config: { token: '...' } },
+});
+```
+
+For the self-signed-CA case you can also use the process-wide `NODE_EXTRA_CA_CERTS=/path/ca.pem`
+env var with no code change. Only disable verification
+(`new Agent({ connect: { rejectUnauthorized: false } })`) in throwaway/dev setups — it removes
+MITM protection.
 
 #### vaultClient.fillNodeConfig()
 Populates Vault's values to NPM "config" module

--- a/src/VaultApiClient.js
+++ b/src/VaultApiClient.js
@@ -9,12 +9,24 @@ class VaultApiClient {
      * @param {Object} config
      * @param {String} config.url - the url of the vault server
      * @param {String} [config.apiVersion='v1']
+     * @param {Object} [config.requestOptions] - extra options shallow-merged into every
+     *      `fetch()` call. Use it to inject an undici `dispatcher` for a proxy/SOCKS agent
+     *      or for custom TLS trust (self-signed / internal CA). Request-specific fields
+     *      (`method`, `body`) always take precedence; `headers` are merged with the
+     *      per-request headers winning. Stored by reference (not deep-cloned) so live
+     *      objects such as a Dispatcher keep their prototype and remain usable.
      * @param {Object} logger
      */
     constructor(config, logger) {
-        this.__config = _.defaultsDeep(_.cloneDeep(config), {
+        const requestOptions = config && config.requestOptions;
+
+        this.__config = _.defaultsDeep(_.cloneDeep(_.omit(config, ['requestOptions'])), {
             apiVersion: 'v1',
         });
+
+        if (requestOptions !== undefined) {
+            this.__config.requestOptions = requestOptions;
+        }
 
         this._logger = logger;
     }
@@ -25,11 +37,20 @@ class VaultApiClient {
 
         const uri = urljoin(this.__config.url, this.__config.apiVersion, path);
 
-        const options = {
-            method: method,
-            headers: Object.assign({ Accept: 'application/json' }, headers),
-            redirect: 'follow',
-        };
+        const requestOptions = this.__config.requestOptions || {};
+
+        const options = Object.assign(
+            { redirect: 'follow' },
+            requestOptions,
+            {
+                method: method,
+                headers: Object.assign(
+                    { Accept: 'application/json' },
+                    requestOptions.headers,
+                    headers
+                ),
+            }
+        );
         if (data !== null) {
             options.body = JSON.stringify(data);
             options.headers['Content-Type'] = 'application/json';

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -20,6 +20,9 @@ class VaultClient {
      * @param {Object} options.api
      * @param {String} options.api.url - the url of the vault server
      * @param {String} [options.api.apiVersion='v1']
+     * @param {Object} [options.api.requestOptions] - extra options merged into every HTTP
+     *      request (e.g. an undici `dispatcher` for a proxy/SOCKS agent or custom TLS/CA trust).
+     *      See {@link VaultApiClient#constructor}.
      * @param {Object} options.auth
      * @param {String} options.auth.type
      * @param {Object} options.auth.config - auth configuration variables

--- a/test/VaultApiClient.test.js
+++ b/test/VaultApiClient.test.js
@@ -119,5 +119,43 @@ describe('VaultApiClient', function () {
                 (err) => { expect(err.statusCode).to.equal(500); }
             );
         });
+
+        it('merges config.requestOptions.headers, with per-request headers taking precedence', function () {
+            const api = new VaultApiClient({
+                url: baseUrl,
+                requestOptions: { headers: { 'X-Custom': 'from-config', 'X-Vault-Token': 'config-tok' } },
+            }, logger);
+            return api.makeRequest('GET', '/secret/foo', null, { 'X-Vault-Token': 'call-tok' }).then(() => {
+                expect(lastRequest.headers['x-custom']).to.equal('from-config');
+                expect(lastRequest.headers['x-vault-token']).to.equal('call-tok');
+                expect(lastRequest.headers['accept']).to.equal('application/json');
+            });
+        });
+
+        it('forwards config.requestOptions (e.g. a custom dispatcher) into the fetch call', function () {
+            const dispatcher = { __sentinel: 'my-dispatcher' };
+            const fetchStub = sinon.stub(global, 'fetch').resolves(
+                new Response(JSON.stringify({ ok: true }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+            const api = new VaultApiClient({ url: baseUrl, requestOptions: { dispatcher } }, logger);
+            return api.makeRequest('GET', '/secret/foo').then((res) => {
+                expect(res).to.deep.equal({ ok: true });
+                expect(fetchStub).to.have.been.calledOnce;
+                const options = fetchStub.firstCall.args[1];
+                expect(options.dispatcher).to.equal(dispatcher);
+                // request semantics still win over requestOptions
+                expect(options.method).to.equal('GET');
+                expect(options.headers.Accept).to.equal('application/json');
+            }).finally(() => fetchStub.restore());
+        });
+
+        it('keeps a live requestOptions.dispatcher by reference (does not deep-clone it)', function () {
+            const dispatcher = { __sentinel: true };
+            const api = new VaultApiClient({ url: baseUrl, requestOptions: { dispatcher } }, logger);
+            expect(api.__config.requestOptions.dispatcher).to.equal(dispatcher);
+        });
     });
 });


### PR DESCRIPTION
## What

Adds `options.api.requestOptions` — a plain object shallow-merged into every underlying `fetch()` call in `VaultApiClient.makeRequest`. This gives consumers a supported hook to control the HTTP transport, which `fetch` does not otherwise expose per-client.

Closes #37 (configurable http agent) and #29 (self-signed / internal-CA Vault) — both converge on the same need: inject an undici `dispatcher`.

## Why

After the migration to native `fetch` (#59), there was no way to:

- route Vault traffic through a proxy / SOCKS agent (**#37**), or
- trust a self-signed / internal-CA certificate per-client (**#29**) — the only workaround was the process-wide `NODE_EXTRA_CA_CERTS` env var.

Native `fetch` ignores the old Node `agent` option; the supported mechanism is undici's `dispatcher`. A single `requestOptions` passthrough covers both cases (and any future fetch option) without adding a runtime dependency.

## How

- `requestOptions` is merged so that **request semantics win**: `method`/`body` always come from the request; `headers` merge with per-request headers taking precedence; `redirect` defaults to `follow` but is overridable.
- Stored **by reference**, not via the existing `_.cloneDeep`, because deep-cloning a live undici `Dispatcher`/`Agent` would strip its prototype and break it. (`requestOptions` is `_.omit`-ed before the clone, then reattached.)

## Usage

```js
const { Agent, ProxyAgent } = require('undici');

// Trust an internal/self-signed CA
VaultClient.boot('main', {
    api: {
        url: 'https://vault.internal:8200/',
        requestOptions: { dispatcher: new Agent({ connect: { ca: fs.readFileSync('/etc/ssl/internal-ca.pem') } }) },
    },
    auth: { type: 'token', config: { token: '...' } },
});

// Proxy / SOCKS
api: { url: '...', requestOptions: { dispatcher: new ProxyAgent('http://proxy:8080') } }
```

## Tests

`test/VaultApiClient.test.js` adds coverage for:
- header merge (config headers + per-request precedence + `Accept` preserved)
- `dispatcher` forwarded into the `fetch()` options while request semantics still win
- live `dispatcher` kept by reference (not deep-cloned)

Full unit suite: **123 passing**. Backward compatible — no behavior change when `requestOptions` is omitted.

## Docs

README gains a "Custom transport (proxy / self-signed TLS)" section + options-table row; CHANGELOG gets an Unreleased entry.