### PR TITLE
Fix process hanging after read with a renewable token (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+- Fix a process that never exits after reading with a renewable token. The background
+  token-refresh timer (`long-timeout`) kept the Node.js event loop alive with no way to stop
+  it. Add `VaultClient#close()` (and `VaultBaseAuth#cancelTokenRefresh()`) to cancel the timer
+  so short-lived scripts can exit; `VaultClient.clear()` now also closes the instances it
+  removes. Default behavior is unchanged — long-running servers keep renewing as before. Closes #31.
 - Add `api.requestOptions`, shallow-merged into every underlying `fetch()` request. Enables
   routing traffic through a proxy/SOCKS agent and trusting a self-signed / internal-CA Vault by
   passing an undici `dispatcher`. Closes #37 and #29.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ vaultClient.read('secret/tst').then(v => {
         * [.read(path)](#VaultClient+read) ⇒ <code>Promise.&lt;Lease&gt;</code>
         * [.list(path)](#VaultClient+list) ⇒ <code>Promise.&lt;Lease&gt;</code>
         * [.write(path, data)](#VaultClient+write) ⇒ <code>Promise.&lt;(T\|never)&gt;</code>
+        * [.close()](#VaultClient+close)
     * _static_
         * [.boot(name, [options])](#VaultClient.boot) ⇒
         * [.get(name)](#VaultClient.get) ⇒
@@ -141,6 +142,27 @@ Writes data to Vault
 | --- | --- | --- |
 | path |  | path used to write data |
 | data | <code>object</code> | data to write |
+
+<a name="VaultClient+close"></a>
+
+#### vaultClient.close()
+Release resources held by this client.
+
+This client performs lease renewal for renewable auth tokens by arming a background timer.
+That timer keeps the Node.js event loop alive, so a short-lived script (e.g. a one-off
+`read`) never exits on its own. Call `close()` once you are done with the client to cancel
+the timer and let the process exit. It is null-safe and safe to call multiple times. The
+client may still be used afterwards — the next operation that fetches a renewable token
+will arm a new refresh timer.
+
+```javascript
+const vaultClient = VaultClient.boot('main', { /* ... */ });
+const secret = await vaultClient.read('secret/tst');
+console.log(secret);
+vaultClient.close(); // process can now exit
+```
+
+**Kind**: instance method of [<code>VaultClient</code>](#VaultClient)  
 
 <a name="VaultClient.boot"></a>
 

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -98,13 +98,35 @@ class VaultClient {
      */
     static clear(name) {
         if (typeof name === 'string') {
-            delete vaultInstances[name];
+            const instance = vaultInstances[name];
+            if (instance !== undefined) {
+                instance.close();
+                delete vaultInstances[name];
+            }
         } else {
             for (let k in vaultInstances) {
                 if (Object.hasOwn(vaultInstances, k)) {
+                    vaultInstances[k].close();
                     delete vaultInstances[k];
                 }
             }
+        }
+    }
+
+    /**
+     * Release resources held by this client.
+     *
+     * Cancels the background auth-token refresh timer that keeps the Node.js event loop
+     * alive for renewable tokens. Call this once you are done with the client so a
+     * short-lived script can exit on its own. Safe to call when no timer is armed and
+     * safe to call multiple times. After calling `close()` the client may still be used;
+     * the next operation that fetches a renewable token will arm a new refresh timer.
+     *
+     * @returns {void}
+     */
+    close() {
+        if (this.__auth && typeof this.__auth.cancelTokenRefresh === 'function') {
+            this.__auth.cancelTokenRefresh();
         }
     }
 

--- a/src/auth/VaultBaseAuth.js
+++ b/src/auth/VaultBaseAuth.js
@@ -69,6 +69,24 @@ class VaultBaseAuth {
     }
 
     /**
+     * Cancel any pending token-refresh timer.
+     *
+     * When a renewable token is fetched the client arms a `long-timeout` timer to renew it
+     * before it expires. That timer keeps the Node.js event loop alive, so a short-lived
+     * script never exits on its own. Call this (or {@link VaultClient#close}) once you are
+     * done with the client to release the event loop. Safe to call when no timer is armed
+     * and safe to call multiple times.
+     *
+     * @returns {void}
+     */
+    cancelTokenRefresh() {
+        if (this.__refreshTimeout !== null) {
+            lt.clearTimeout(this.__refreshTimeout);
+            this.__refreshTimeout = null;
+        }
+    }
+
+    /**
      * @protected
      * @returns {Promise<AuthToken>}
      */

--- a/test/VaultClient.test.js
+++ b/test/VaultClient.test.js
@@ -65,6 +65,43 @@ describe('VaultClient', function () {
         });
     });
 
+    describe('#close()', function () {
+        it('delegates to the auth provider\'s cancelTokenRefresh', function () {
+            const client = new VaultClient(bootOpts());
+            const cancel = sinon.stub();
+            client.__auth = { cancelTokenRefresh: cancel };
+            client.close();
+            expect(cancel).to.have.been.calledOnce;
+        });
+
+        it('is null-safe when the auth provider lacks cancelTokenRefresh', function () {
+            const client = new VaultClient(bootOpts());
+            client.__auth = {};
+            expect(() => client.close()).to.not.throw();
+            client.__auth = null;
+            expect(() => client.close()).to.not.throw();
+        });
+    });
+
+    describe('static clear() releases timers', function () {
+        it('calls close() on a single named instance before removing it', function () {
+            const i = VaultClient.boot('a', bootOpts());
+            const spy = sinon.spy(i, 'close');
+            VaultClient.clear('a');
+            expect(spy).to.have.been.calledOnce;
+        });
+
+        it('calls close() on every instance when clearing all', function () {
+            const a = VaultClient.boot('a', bootOpts());
+            const b = VaultClient.boot('b', bootOpts());
+            const sa = sinon.spy(a, 'close');
+            const sb = sinon.spy(b, 'close');
+            VaultClient.clear();
+            expect(sa).to.have.been.calledOnce;
+            expect(sb).to.have.been.calledOnce;
+        });
+    });
+
     describe('auth provider selection', function () {
         const cases = [
             ['token', { token: 'tok' }, VaultTokenAuth],

--- a/test/auth.base.test.js
+++ b/test/auth.base.test.js
@@ -189,6 +189,34 @@ describe('VaultBaseAuth', function () {
                 });
         });
 
+        it('cancelTokenRefresh() clears the armed timer so no further renewal fires', function () {
+            const renewable = new AuthToken('rid', 'racc', 0, 100, 0, 0, true);
+            const api = apiStub();
+            api.makeRequest.resolves({});
+            const auth = new TestAuth(api, 'mount', { authStub: sinon.stub().resolves(renewable) });
+            sinon.stub(auth, '_getTokenEntity').resolves(nonRenewableToken('rid2'));
+
+            return auth.getAuthToken()
+                .then(() => {
+                    expect(auth.__refreshTimeout).to.not.equal(null);
+                    auth.cancelTokenRefresh();
+                    expect(auth.__refreshTimeout).to.equal(null);
+                    // Advancing well past the original renewal point must not trigger a renewal.
+                    clock.tick(200000);
+                    return flush();
+                })
+                .then(() => {
+                    expect(api.makeRequest).to.not.have.been.called;
+                });
+        });
+
+        it('cancelTokenRefresh() is a no-op when no timer is armed and is safe to call twice', function () {
+            const auth = new TestAuth(apiStub(), 'mount');
+            expect(auth.__refreshTimeout).to.equal(null);
+            expect(() => { auth.cancelTokenRefresh(); auth.cancelTokenRefresh(); }).to.not.throw();
+            expect(auth.__refreshTimeout).to.equal(null);
+        });
+
         it('logs and reschedules when a renewal fails', function () {
             const renewable = new AuthToken('rid', 'racc', 0, 100, 0, 0, true);
             const api = apiStub();


### PR DESCRIPTION
## Problem

After a successful `read()` with a **renewable** token, a short Node.js script never exits on its own — the cursor blinks and the user must Ctrl-C (issue #31).

## Root cause

When the fetched auth token is renewable, `VaultBaseAuth#__setupTokenRefreshTimer()` arms a refresh timer via the `long-timeout` package:

```js
this.__refreshTimeout = lt.setTimeout(() => { /* renew */ }, timer);
```

This timer is never cleared and there is no public teardown method, so it keeps the event loop alive indefinitely. `long-timeout` timers do **not** honor Node's native `unref()`, so the correct fix is an explicit teardown (`clearTimeout`), not `unref`.

## Fix

- `VaultBaseAuth#cancelTokenRefresh()` — clears the pending refresh timer and nulls the handle. Null-safe and idempotent.
- `VaultClient#close()` — delegates to the auth provider's `cancelTokenRefresh()`, letting a finished script release the event loop and exit. Null-safe.
- `VaultClient.clear()` now calls `close()` on each instance it removes, so existing teardown paths also stop timers.

## Backward compatibility

Default behavior is unchanged. Long-running servers that rely on automatic token renewal keep working exactly as before; the timer is only cancelled when the new `close()` / `cancelTokenRefresh()` method is explicitly called. After `close()`, the client remains usable — the next fetch of a renewable token arms a fresh timer.

## Tests

Added unit tests (mocha + sinon + chai, `useFakeTimers`) covering:
- `cancelTokenRefresh()` clears the armed timer so no further renewal fires after advancing fake time.
- `cancelTokenRefresh()` is a no-op when no timer is armed and is safe to call twice.
- `VaultClient#close()` delegates to `cancelTokenRefresh()` and is null-safe.
- `VaultClient.clear()` (single and all) calls `close()` on removed instances.

Full unit suite: **129 passing** (was 123).

Manually verified end to end: without `close()` the process hangs; with `close()` it exits on its own.

## Docs

- Added a `close()` entry to the README API section.
- Added an Unreleased CHANGELOG entry.

Closes #31