### PR TITLE
Add region support to IAM authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
   it. Add `VaultClient#close()` (and `VaultBaseAuth#cancelTokenRefresh()`) to cancel the timer
   so short-lived scripts can exit; `VaultClient.clear()` now also closes the instances it
   removes. Default behavior is unchanged — long-running servers keep renewing as before. Closes #31.
+- IAM auth: add an optional `region` config option. When set, the STS
+  `GetCallerIdentity` request is signed against the regional endpoint
+  (`sts.<region>.amazonaws.com`) and the SigV4 credential scope is bound to that
+  region, with the signed Host header and `iam_request_url` kept consistent.
+  Fixes `SignatureDoesNotMatch — Credential should be scoped to a valid region`
+  on non-`us-east-1` STS endpoints. Omitting `region` preserves the previous
+  global-endpoint behavior. Closes #25.
 - Add `api.requestOptions`, shallow-merged into every underlying `fetch()` request. Enables
   routing traffic through a proxy/SOCKS agent and trusting a self-signed / internal-CA Vault by
   passing an undici `dispatcher`. Closes #37 and #29.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,39 @@ vaultClient.read('secret/tst').then(v => {
 * [AppRole](https://www.vaultproject.io/docs/auth/approle.html)
 * [Token](https://www.vaultproject.io/docs/auth/token.html)
 
+### AWS IAM auth
+
+```javascript
+const vaultClient = VaultClient.boot('main', {
+    api: { url: 'https://vault.example.com:8200/' },
+    auth: {
+        type: 'iam',
+        mount: 'aws',                                  // Optional. Vault AWS auth mount point ("aws" by default)
+        config: {
+            role: 'my_iam_role',
+            iam_server_id_header_value: 'https://vault.example.com:8200/', // Optional. X-Vault-AWS-IAM-Server-ID header
+            namespace: 'some_namespace',               // Optional. X-Vault-Namespace header
+            region: 'eu-central-1',                     // Optional. AWS STS region (see below)
+            credentials: {                             // Optional. Resolved from the AWS provider chain when omitted
+                accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+                secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+            },
+        },
+    },
+});
+```
+
+#### `region`
+
+By default the signed `GetCallerIdentity` request targets the global STS endpoint
+`sts.amazonaws.com` and the SigV4 credential scope is bound to `us-east-1`. Set
+`config.region` to sign against a regional STS endpoint instead — the request is then sent to
+`sts.<region>.amazonaws.com` and the signature scope is bound to that region. This is required
+when Vault's `sts_region` / `sts_endpoint` is configured for a non-`us-east-1` region (e.g.
+`eu-central-1`); otherwise STS rejects the replayed request with
+`SignatureDoesNotMatch — Credential should be scoped to a valid region`. Omitting `region`
+preserves the previous (global-endpoint) behavior.
+
 ## API
 
 <a name="VaultClient"></a>

--- a/src/auth/VaultIAMAuth.js
+++ b/src/auth/VaultIAMAuth.js
@@ -29,6 +29,7 @@ const errors = require('../errors');
  *               role: 'my_iam_role',
  *               iam_server_id_header_value: VAULT_ADDR,   // Optional
  *               namespace: 'some_namespace',              // Optional
+ *               region: 'eu-central-1',                   // Optional. AWS STS region.
  *               credentials: {                            // Optional
  *                 accessKeyId: AWS_ACCESS_KEY,
  *                 secretAccessKey: AWS_SECRET_KEY,
@@ -49,6 +50,11 @@ class VaultIAMAuth extends VaultBaseAuth {
      * @property {String} role - Role name of the auth/{mount}/role/{name} backend.
      * @property [AWSCredentials] [credentials] - Optional. AWS Credentials
      * @property {String} [iam_server_id_header_value] - Optional. Header's value X-Vault-AWS-IAM-Server-ID.
+     * @property {String} [region] - Optional. AWS region used to sign the STS GetCallerIdentity
+     *   request. When set, the request is signed against the regional STS endpoint
+     *   (`sts.<region>.amazonaws.com`) and the SigV4 credential scope is bound to that region.
+     *   When omitted, the global endpoint (`sts.amazonaws.com`, scope `us-east-1`) is used,
+     *   preserving the previous default behavior.
      *
      * @param {VaultApiClient} api - see {@link VaultBaseAuth#constructor}
      * @param {Object} logger
@@ -61,6 +67,7 @@ class VaultIAMAuth extends VaultBaseAuth {
         this.__role = config.role;
         this.__iam_server_id_header_value = config.iam_server_id_header_value;
         this.__namespace = config.namespace;
+        this.__region = config.region;
 
 
         const { credentials } = config;
@@ -130,7 +137,11 @@ class VaultIAMAuth extends VaultBaseAuth {
                 JSON.stringify(this.__headersLikeGolangStyle(stsRequest.headers))
             ),
             iam_request_body: this.__base64encode(stsRequest.body),
-            iam_request_url: this.__base64encode(`https://${stsRequest.hostname}${stsRequest.path}`),
+            // `aws4` populates `hostname` for the default (global) endpoint, but
+            // `host` when an explicit host is supplied (regional endpoint). Use
+            // whichever is present so the URL sent to Vault matches the signed
+            // Host header.
+            iam_request_url: this.__base64encode(`https://${stsRequest.host || stsRequest.hostname}${stsRequest.path}`),
             role: this.__role
         }
     }
@@ -142,14 +153,27 @@ class VaultIAMAuth extends VaultBaseAuth {
      * @private
      */
     __getStsRequest(credentials) {
-        return aws4.sign({
+        const request = {
             service: 'sts',
             method: 'POST',
             body: 'Action=GetCallerIdentity&Version=2011-06-15',
             headers: this.__iam_server_id_header_value ? {
                 'X-Vault-AWS-IAM-Server-ID': this.__iam_server_id_header_value,
             } : {}
-        }, credentials);
+        };
+
+        // When a region is configured, sign the request against the regional STS
+        // endpoint. Both the SigV4 credential scope (via `region`) and the signed
+        // Host header / request URL (via `host`) must reference the same region,
+        // otherwise Vault's STS replay fails with `SignatureDoesNotMatch`.
+        // When omitted, `aws4` defaults to the global endpoint (`sts.amazonaws.com`,
+        // scope `us-east-1`), preserving the previous behavior.
+        if (this.__region) {
+            request.region = this.__region;
+            request.host = `sts.${this.__region}.amazonaws.com`;
+        }
+
+        return aws4.sign(request, credentials);
     }
 
     /**

--- a/test/auth.iam.test.js
+++ b/test/auth.iam.test.js
@@ -108,6 +108,75 @@ describe('Unit AWS auth backend :: IAM', function () {
             });
         })
 
+        it('Should target the regional STS endpoint and scope the signature to the region when `region` is set', async function () {
+            const api = getApiStub();
+
+            const auth = new VaultIAMAuth(
+                api,
+                logger,
+                {
+                    role: 'MyRole',
+                    iam_server_id_header_value: 'https://vault.fake.com',
+                    region: 'eu-central-1',
+                    credentials: {
+                        accessKeyId: 'FAKE_AWS_ACCESS_KEY',
+                        secretAccessKey: 'FAKE_AWS_SECRET_KEY',
+                    },
+                },
+                'fake_aws'
+            );
+
+            api.makeRequest.withArgs('POST').resolves({auth: {client_token: 'fake_token'}});
+            sinon.stub(auth, '_getTokenEntity');
+
+            await auth._authenticate();
+
+            const args = api.makeRequest.getCall(0).args;
+
+            // URL sent to Vault must point at the regional endpoint.
+            expect(base64decode(args[2].iam_request_url)).to.equal('https://sts.eu-central-1.amazonaws.com/');
+
+            const headers = JSON.parse(base64decode(args[2].iam_request_headers));
+
+            // Signed Host header must match the URL (otherwise Vault's STS replay fails).
+            expect(headers['Host']).to.deep.equal(['sts.eu-central-1.amazonaws.com']);
+
+            // SigV4 credential scope must be bound to the configured region.
+            expect(headers['Authorization'][0]).to.match(getAuthorizationHeaderRegExp('FAKE_AWS_ACCESS_KEY'));
+            expect(headers['Authorization'][0]).to.contain('/eu-central-1/sts/aws4_request');
+        });
+
+        it('Should preserve the global STS endpoint and us-east-1 scope when `region` is omitted', async function () {
+            const api = getApiStub();
+
+            const auth = new VaultIAMAuth(
+                api,
+                logger,
+                {
+                    role: 'MyRole',
+                    iam_server_id_header_value: 'https://vault.fake.com',
+                    credentials: {
+                        accessKeyId: 'FAKE_AWS_ACCESS_KEY',
+                        secretAccessKey: 'FAKE_AWS_SECRET_KEY',
+                    },
+                },
+                'fake_aws'
+            );
+
+            api.makeRequest.withArgs('POST').resolves({auth: {client_token: 'fake_token'}});
+            sinon.stub(auth, '_getTokenEntity');
+
+            await auth._authenticate();
+
+            const args = api.makeRequest.getCall(0).args;
+
+            expect(base64decode(args[2].iam_request_url)).to.equal('https://sts.amazonaws.com/');
+
+            const headers = JSON.parse(base64decode(args[2].iam_request_headers));
+            expect(headers['Authorization'][0]).to.match(getAuthorizationHeaderRegExp('FAKE_AWS_ACCESS_KEY'));
+            expect(headers['Authorization'][0]).to.contain('/us-east-1/sts/aws4_request');
+        });
+
         it('Should set the namespace header when configured', async function () {
             const api = getApiStub();
 


### PR DESCRIPTION
## Problem

AWS IAM auth cannot specify a region. `src/auth/VaultIAMAuth.js` signs the STS `GetCallerIdentity` request via `aws4.sign({ service: 'sts', ... })` with no `region`/`host`, so `aws4` defaults to the global endpoint `sts.amazonaws.com` and signs the SigV4 credential scope as `us-east-1`. There is no config path to override it.

On a Vault/AWS setup whose STS is configured for a non-default region (e.g. `eu-central-1`), the request is rejected:

```
400 ... 403 from STS: SignatureDoesNotMatch
Credential should be scoped to a valid region
```

Closes #25.

## Fix

- Read a new optional `config.region` in the constructor (`this.__region`).
- In `__getStsRequest()`, when a region is set, pass **both** `region` and the regional `host` (`sts.<region>.amazonaws.com`) to `aws4.sign`. This is required because in the bundled `aws4` version, `region` alone binds the credential scope to the region but leaves the Host header at `sts.amazonaws.com` — a mismatch that would still fail Vault's STS replay. Setting `host` keeps the signed Host header and credential scope consistent.
- In `__getVaultAuthRequestBody()`, build `iam_request_url` from `stsRequest.host || stsRequest.hostname`. `aws4` populates `hostname` for the default endpoint but `host` when an explicit host is supplied, so this keeps the URL sent to Vault matching the signed Host header in both cases.

## Backward compatibility

Omitting `region` is unchanged: `aws4` still defaults to the global endpoint (`sts.amazonaws.com`, scope `us-east-1`). No new dependencies (`aws4` was already used). No changes needed in `VaultClient.js` — it passes the full `authConfig.config` straight to the constructor.

## Tests

Extended `test/auth.iam.test.js`:
- With `region` set: asserts `iam_request_url` targets the regional host, the signed Host header matches, and the credential scope contains the region.
- With `region` omitted: asserts the global endpoint and `us-east-1` scope are preserved.

Full unit suite passes: **125 passing**.

## Follow-up (not in this PR)

A custom `sts_endpoint`/`host` option (STS VPC endpoints, GovCloud, China partitions) could be added later; this PR keeps the change minimal and focused on `region`.