### PR TITLE
ci: use Node.js 24 for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 


### PR DESCRIPTION
## Summary

- Switch the publish job from Node.js 20 to Node.js 24

Node 20 action runners are deprecated and will be forced to Node 24 on June 16, 2026; this aligns the publish job with that deadline and with the build matrix which already tests on Node 24.