### PR TITLE
docs: sync documentation with current code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@
 - Add `api.requestOptions`, shallow-merged into every underlying `fetch()` request. Enables
   routing traffic through a proxy/SOCKS agent and trusting a self-signed / internal-CA Vault by
   passing an undici `dispatcher`. Closes #37 and #29.
+- Replace the deprecated `request`/`request-promise` HTTP libraries with Node's native `fetch`.
+  Removes the `request` runtime dependency and clears the associated Dependabot/deprecation
+  alerts; this is the foundation for the new `api.requestOptions` (undici dispatcher) support.
+  Closes #59.
+- [BREAKING] Minimum supported Node.js is now 18.0.0 (was 14.0.0); the client relies on native `fetch`.
+- Auth token: derive expiry from Vault's authoritative `expire_time` (RFC3339), falling back to
+  `ttl` only when absent. Closes #51.
+- Raise `AuthTokenExpiredError` for expired non-refreshable tokens instead of silently using a
+  stale token. Closes #50.
+- Replace deprecated `new Buffer()` with `Buffer.from()` in IAM auth STS body encoding. Closes #52.
 
 # 1.0.0. Release notes (2023-08-02)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ It supports variety of Auth Backends and performs lease renewal for issued auth 
 npm install --save node-vault-client
 ```
 
+### Requirements
+
+Node.js >= 18 — the client uses the native `fetch` API.
+
 ## Example
 
 ```javascript
@@ -19,21 +23,22 @@ const VaultClient = require('node-vault-client');
 const vaultClient = VaultClient.boot('main', {
     api: { url: 'https://vault.example.com:8200/' },
     auth: { 
-        type: 'appRole', // or 'token', 'iam'
+        type: 'appRole', // one of: 'appRole' | 'token' | 'iam' | 'kubernetes'
         config: { role_id: '637c065f-c644-5e12-d3d1-e9fa4363af61' } 
     },
 });
 
-vaultClient.read('secret/tst').then(v => {
-    console.log(v);
+vaultClient.read('secret/tst').then(lease => {
+    console.log(lease.getData()); // read() resolves to a Lease; use getData()/getValue(key)
 }).catch(e => console.error(e));
 ```
 
 ## Supported Auth Backends
 
-* [AWS IAM](https://www.vaultproject.io/docs/auth/aws.html#iam-auth-method)
-* [AppRole](https://www.vaultproject.io/docs/auth/approle.html)
-* [Token](https://www.vaultproject.io/docs/auth/token.html)
+* [AWS IAM](https://developer.hashicorp.com/vault/docs/auth/aws)
+* [AppRole](https://developer.hashicorp.com/vault/docs/auth/approle)
+* [Token](https://developer.hashicorp.com/vault/docs/auth/token)
+* [Kubernetes](https://developer.hashicorp.com/vault/docs/auth/kubernetes)
 
 ### AWS IAM auth
 
@@ -68,6 +73,53 @@ when Vault's `sts_region` / `sts_endpoint` is configured for a non-`us-east-1` r
 `SignatureDoesNotMatch — Credential should be scoped to a valid region`. Omitting `region`
 preserves the previous (global-endpoint) behavior.
 
+### AppRole auth
+
+```javascript
+const vaultClient = VaultClient.boot('main', {
+    api: { url: 'https://vault.example.com:8200/' },
+    auth: {
+        type: 'appRole',
+        mount: 'approle',                              // Optional. Vault AppRole auth mount point ("approle" by default)
+        config: {
+            role_id: '637c065f-c644-5e12-d3d1-e9fa4363af61', // Required. RoleID of the AppRole
+            secret_id: '...',                          // Optional. Required when bind_secret_id is enabled
+        },
+    },
+});
+```
+
+### Token auth
+
+```javascript
+const vaultClient = VaultClient.boot('main', {
+    api: { url: 'https://vault.example.com:8200/' },
+    auth: {
+        type: 'token',
+        mount: 'token',                                // Optional. Vault token auth mount point ("token" by default)
+        config: {
+            token: 's.xxxxxxxxxxxxxxxxxxxxxxxx',       // Required. Vault token
+        },
+    },
+});
+```
+
+### Kubernetes auth
+
+```javascript
+const vaultClient = VaultClient.boot('main', {
+    api: { url: 'https://vault.example.com:8200/' },
+    auth: {
+        type: 'kubernetes',
+        mount: 'kubernetes',                           // Optional. Vault Kubernetes auth mount point ("kubernetes" by default)
+        config: {
+            role: 'my_k8s_role',                       // Required. Role configured in the Vault Kubernetes auth backend
+            tokenPath: '/var/run/secrets/kubernetes.io/serviceaccount/token', // Optional. Defaults to the in-pod service-account token path
+        },
+    },
+});
+```
+
 ## API
 
 <a name="VaultClient"></a>
@@ -80,12 +132,13 @@ preserves the previous (global-endpoint) behavior.
         * [.fillNodeConfig()](#VaultClient+fillNodeConfig)
         * [.read(path)](#VaultClient+read) ⇒ <code>Promise.&lt;Lease&gt;</code>
         * [.list(path)](#VaultClient+list) ⇒ <code>Promise.&lt;Lease&gt;</code>
-        * [.write(path, data)](#VaultClient+write) ⇒ <code>Promise.&lt;(T\|never)&gt;</code>
+        * [.write(path, data)](#VaultClient+write) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.close()](#VaultClient+close)
     * _static_
-        * [.boot(name, [options])](#VaultClient.boot) ⇒
-        * [.get(name)](#VaultClient.get) ⇒
+        * [.boot(name, [options])](#VaultClient.boot) ⇒ <code>VaultClient</code>
+        * [.get(name)](#VaultClient.get) ⇒ <code>VaultClient</code>
         * [.clear([name])](#VaultClient.clear)
+* [Lease](#Lease)
 
 <a name="new_VaultClient_new"></a>
 
@@ -102,7 +155,9 @@ Client constructor function.
 | [options.api.requestOptions] | <code>Object</code> |  | extra options merged into every HTTP request (see [Custom transport](#custom-transport-proxy--self-signed-tls)) |
 | options.auth | <code>Object</code> |  |  |
 | options.auth.type | <code>String</code> |  |  |
+| [options.auth.mount] | <code>String</code> |  | Vault auth backend mount point; default varies per method (e.g. "aws" for iam, "approle", "token", "kubernetes") |
 | options.auth.config | <code>Object</code> |  | auth configuration variables |
+| [options.auth.config.namespace] | <code>String</code> |  | Optional. Vault namespace, sent as the `X-Vault-Namespace` header on all secret read/list/write requests. Applies to every auth type, not just IAM. |
 | options.logger | <code>Object</code> | `false` |  | Logger that supports "error", "info", "warn", "trace", "debug" methods. Uses `console` by default. Pass `false` to disable logging. |
 
 ##### Custom transport (proxy / self-signed TLS)
@@ -138,8 +193,10 @@ env var with no code change. Only disable verification
 (`new Agent({ connect: { rejectUnauthorized: false } })`) in throwaway/dev setups — it removes
 MITM protection.
 
-#### vaultClient.fillNodeConfig()
+#### vaultClient.fillNodeConfig() ⇒ <code>Promise</code>
 Populates Vault's values to NPM "config" module
+
+Resolves once the npm `config` module has been populated from Vault.
 
 **Kind**: instance method of [<code>VaultClient</code>](#VaultClient)  
 <a name="VaultClient+read"></a>
@@ -166,8 +223,11 @@ Retrieves secrets list
 
 <a name="VaultClient+write"></a>
 
-#### vaultClient.write(path, data) ⇒ <code>Promise.&lt;(T\|never)&gt;</code>
+#### vaultClient.write(path, data) ⇒ <code>Promise.&lt;Object&gt;</code>
 Writes data to Vault
+
+Resolves to the raw parsed Vault response body, which may be empty/undefined for
+`204 No Content` responses.
 
 **Kind**: instance method of [<code>VaultClient</code>](#VaultClient)  
 
@@ -197,16 +257,27 @@ vaultClient.close(); // process can now exit
 
 **Kind**: instance method of [<code>VaultClient</code>](#VaultClient)  
 
+<a name="Lease"></a>
+
+### Lease
+
+The object returned by `read()` and `list()` (they resolve to `Promise<Lease>`). Use its
+accessors to extract the secret data:
+
+* `getValue(key)` ⇒ <code>String</code> — value for a single key. Throws `Requested key does not exist` when the key is absent.
+* `getData()` ⇒ <code>Object</code> — a deep-cloned copy of the whole secret data object.
+* `isRenewable()` ⇒ <code>boolean</code> — whether the underlying lease is renewable.
+
 <a name="VaultClient.boot"></a>
 
-#### VaultClient.boot(name, [options]) ⇒
+#### VaultClient.boot(name, [options]) ⇒ <code>VaultClient</code>
 Boot an instance of Vault
 
 The instance will be stored in a local hash. Calling Vault.boot multiple
 times with the same name will return the same instance.
 
 **Kind**: static method of [<code>VaultClient</code>](#VaultClient)  
-**Returns**: Vault  
+**Returns**: <code>VaultClient</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -215,14 +286,14 @@ times with the same name will return the same instance.
 
 <a name="VaultClient.get"></a>
 
-#### VaultClient.get(name) ⇒
+#### VaultClient.get(name) ⇒ <code>VaultClient</code>
 Get an instance of Vault
 
 The instance will be stored in a local hash. Calling Vault.pop multiple
 times with the same name will return the same instance.
 
 **Kind**: static method of [<code>VaultClient</code>](#VaultClient)  
-**Returns**: Vault  
+**Returns**: <code>VaultClient</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -55,8 +55,8 @@ class VaultClient {
      * times with the same name will return the same instance.
      *
      * @param {String} name - Vault instance name
-     * @param {Object} [options] - options for {@link Vault#constructor}.
-     * @return Vault
+     * @param {Object} [options] - options for {@link VaultClient#constructor}.
+     * @return {VaultClient}
      */
     static boot(name, options) {
         if (options === undefined) {
@@ -77,7 +77,7 @@ class VaultClient {
      * times with the same name will return the same instance.
      *
      * @param {String} name - Vault instance name
-     * @return Vault
+     * @return {VaultClient}
      */
     static get(name) {
         let instance = vaultInstances[name];
@@ -240,9 +240,9 @@ class VaultClient {
     /**
      * Writes data to Vault
      *
-     * @param path - path used to write data
+     * @param {string} path - path used to write data
      * @param {object} data - data to write
-     * @returns {Promise<T | never>}
+     * @returns {Promise<Object>} the parsed Vault response body
      */
     write(path, data) {
         this.__log.debug('write secret %s', path);

--- a/src/auth/VaultAppRoleAuth.js
+++ b/src/auth/VaultAppRoleAuth.js
@@ -6,9 +6,11 @@ class VaultAppRoleAuth extends VaultBaseAuth {
 
     /**
      * @param {VaultApiClient} apiClient - see {@link VaultBaseAuth#constructor}
+     * @param {Object} logger
      * @param {Object} config
      * @param {String} config.role_id - RoleID of the AppRole.
      * @param {String} [config.secret_id] - required when bind_secret_id is enabled SecretID belonging to AppRole.
+     * @param {String} [config.namespace] - Optional. Vault namespace, sent as the X-Vault-Namespace header.
      * @param {String} mount - Vault's  mount point ("approle" by default)
      */
     constructor(apiClient, logger, config, mount) {

--- a/src/auth/VaultIAMAuth.js
+++ b/src/auth/VaultIAMAuth.js
@@ -48,7 +48,8 @@ class VaultIAMAuth extends VaultBaseAuth {
      *
      * @typedef {Object} VaultIAMAuthConfig
      * @property {String} role - Role name of the auth/{mount}/role/{name} backend.
-     * @property [AWSCredentials] [credentials] - Optional. AWS Credentials
+     * @property {AWSCredentials} [credentials] - Optional. AWS Credentials
+     * @property {String} [namespace] - Optional. Vault namespace, sent as the X-Vault-Namespace header.
      * @property {String} [iam_server_id_header_value] - Optional. Header's value X-Vault-AWS-IAM-Server-ID.
      * @property {String} [region] - Optional. AWS region used to sign the STS GetCallerIdentity
      *   request. When set, the request is signed against the regional STS endpoint

--- a/src/auth/VaultKubernetesAuth.js
+++ b/src/auth/VaultKubernetesAuth.js
@@ -4,6 +4,7 @@ const VaultBaseAuth = require('./VaultBaseAuth');
 class VaultKubernetesAuth extends VaultBaseAuth {
     /**
      * @param {VaultApiClient} apiClient - see {@link VaultBaseAuth#constructor}
+     * @param {Object} logger
      * @param {Object} config
      * @param {String} config.role - Role configured in Vault Kubernetes Auth backend under which we want to issue Vault token.
      * @param {String} [config.tokenPath] - Path to the Kube JWT token. If omitted - default will be used.

--- a/src/auth/VaultTokenAuth.js
+++ b/src/auth/VaultTokenAuth.js
@@ -6,7 +6,8 @@ const errors = require('../errors');
 class VaultTokenAuth extends VaultBaseAuth {
 
     /**
-     * @param {Object} connConfig - see {@link VaultBaseAuth#constructor}
+     * @param {VaultApiClient} apiClient - see {@link VaultBaseAuth#constructor}
+     * @param {Object} logger
      * @param {Object} config
      * @param {String} config.token
      * @param {String} mount - Vault's  mount point ("token" by default)


### PR DESCRIPTION
Documentation-only sync. No code logic changed — only README.md, CHANGELOG.md, and JSDoc comments in src/. All 131 unit tests pass and `npm run lint` is clean.

## README
- Add **Kubernetes** to the Supported Auth Backends list (it is implemented and registered in `VaultClient.__getAuthProvider`) and refresh the AWS IAM / AppRole / Token links to their canonical `developer.hashicorp.com` URLs.
- Correct the auth `type` comment in the top example to list all four values: `appRole | token | iam | kubernetes`.
- Show `read()` resolving to a `Lease` and using `getData()` (previously it logged the raw wrapper).
- Document the **Lease** object (`getValue(key)`, `getData()`, `isRenewable()`) that `read()`/`list()` resolve to.
- Add `options.auth.mount` and `options.auth.config.namespace` rows to the constructor options table, and clarify that `namespace` (`X-Vault-Namespace`) applies to every auth type, not just IAM.
- Fix `write()` return type from `Promise<(T|never)>` to `Promise<Object>` and note the `204 No Content` empty-body case; add a return annotation to `fillNodeConfig()`.
- Add AppRole / Token / Kubernetes auth config examples alongside the existing IAM one.
- Add a Requirements note: Node.js >= 18 (native `fetch`).
- Correct `boot()`/`get()` return type from `Vault` to `VaultClient`.

## CHANGELOG
Record post-1.0.0 changes under **Unreleased**:
- `request`/`request-promise` replaced with native `fetch` (removes the `request` runtime dep).
- [BREAKING] Minimum Node.js bumped 14 -> 18.
- Token expiry derived from Vault's `expire_time` (RFC3339), with `ttl` fallback.
- `AuthTokenExpiredError` raised for expired non-refreshable tokens.
- Deprecated `new Buffer()` replaced with `Buffer.from()` in IAM STS encoding.

## src JSDoc
- Document the undocumented `logger` constructor param in the AppRole, Token, and Kubernetes auth providers (the `@param` lists were off-by-one).
- Fix `VaultTokenAuth`'s first param (`connConfig` -> `apiClient: VaultApiClient`).
- Fix the invalid `[AWSCredentials]` type and add the missing `namespace` property in the IAM config typedef.
- Give `write()` a typed `path` and a real return type (was `Promise<T | never>`).
- Correct the non-existent `Vault` symbol references in `VaultClient.boot()`/`get()` JSDoc to `VaultClient`.