### PR TITLE
test: improve boot/get/clear test coverage and naming

### DIFF
--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -16,23 +16,26 @@ describe('Unit tests', function () {
     });
 
     it('should correctly boot/get/clear VaultClient instance', () => {
-        const client = VaultClient.boot('tst', bootOpts);
+        const client = VaultClient.boot('primaryClient', bootOpts);
 
         expect(client).to.be.instanceOf(VaultClient);
 
-        expect(VaultClient.get('tst')).to.equal(client);
+        expect(VaultClient.get('primaryClient')).to.equal(client);
 
-        expect(VaultClient.boot('tst', bootOpts)).to.equal(client);
+        expect(VaultClient.boot('primaryClient', bootOpts)).to.equal(client);
 
 
-        const secondClient = VaultClient.boot('tst2', bootOpts);
-        VaultClient.clear('tst');
+        const secondClient = VaultClient.boot('secondaryClient', bootOpts);
+        VaultClient.clear('primaryClient');
 
-        const recreatedClient = VaultClient.boot('tst', bootOpts);
+        const recreatedClient = VaultClient.boot('primaryClient', bootOpts);
         expect(recreatedClient).to.be.instanceOf(VaultClient);
         expect(recreatedClient).to.not.equal(client);
 
-        expect(VaultClient.get('tst2')).to.equal(secondClient);
+        expect(VaultClient.get('secondaryClient')).to.equal(secondClient);
+
+        VaultClient.clear('secondaryClient');
+        expect(() => VaultClient.get('secondaryClient')).to.throw();
     });
 
 });


### PR DESCRIPTION
## Summary

Addresses 3 remaining AI code quality findings on `test/unit.test.mjs`:

- Rename registry keys `'tst'` / `'tst2'` → `'primaryClient'` / `'secondaryClient'` throughout the test (ambiguous string identifiers).
- Add `VaultClient.clear('secondaryClient')` followed by `expect(() => VaultClient.get('secondaryClient')).to.throw()` to verify that `clear()` actually removes the named instance (previously the `clear` path for this instance was exercised but not asserted). Uses `.to.throw()` rather than `.to.be.undefined` because `VaultClient.get` throws `InvalidArgumentsError` on a missing name.

## Test plan

- [x] `mocha test/unit.test.mjs` — 1 test passing
- [x] `npm run lint` — clean
- [x] AI findings page shows 0 open findings after merge