### PR TITLE
test: split monolithic boot/get/clear test into focused cases

### DIFF
--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -15,27 +15,46 @@ describe('Unit tests', function () {
         },
     });
 
-    it('should correctly boot/get/clear VaultClient instance', () => {
+    afterEach(function () {
+        VaultClient.clear();
+    });
+
+    it('should boot a new VaultClient instance', () => {
         const client = VaultClient.boot('primaryClient', bootOpts);
-
         expect(client).to.be.instanceOf(VaultClient);
+    });
 
+    it('should return the same instance when booting with the same name', () => {
+        const client = VaultClient.boot('primaryClient', bootOpts);
+        const sameClient = VaultClient.boot('primaryClient', bootOpts);
+        expect(sameClient).to.equal(client);
+    });
+
+    it('should return the booted instance via get', () => {
+        const client = VaultClient.boot('primaryClient', bootOpts);
         expect(VaultClient.get('primaryClient')).to.equal(client);
+    });
 
-        expect(VaultClient.boot('primaryClient', bootOpts)).to.equal(client);
-
-
-        const secondClient = VaultClient.boot('secondaryClient', bootOpts);
+    it('should clear a client and allow re-creation', () => {
+        const client = VaultClient.boot('primaryClient', bootOpts);
         VaultClient.clear('primaryClient');
 
         const recreatedClient = VaultClient.boot('primaryClient', bootOpts);
         expect(recreatedClient).to.be.instanceOf(VaultClient);
         expect(recreatedClient).to.not.equal(client);
+    });
 
-        expect(VaultClient.get('secondaryClient')).to.equal(secondClient);
+    it('should not affect other named instances when clearing one client', () => {
+        const primaryClient = VaultClient.boot('primaryClient', bootOpts);
+        const secondaryClient = VaultClient.boot('secondaryClient', bootOpts);
+
+        VaultClient.clear('primaryClient');
+
+        expect(VaultClient.get('secondaryClient')).to.equal(secondaryClient);
+        expect(() => VaultClient.get('primaryClient')).to.throw('Invalid instance name');
 
         VaultClient.clear('secondaryClient');
-        expect(() => VaultClient.get('secondaryClient')).to.throw();
+        expect(() => VaultClient.get('secondaryClient')).to.throw('Invalid instance name');
     });
 
 });

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -45,7 +45,7 @@ describe('Unit tests', function () {
     });
 
     it('should not affect other named instances when clearing one client', () => {
-        const primaryClient = VaultClient.boot('primaryClient', bootOpts);
+        VaultClient.boot('primaryClient', bootOpts);
         const secondaryClient = VaultClient.boot('secondaryClient', bootOpts);
 
         VaultClient.clear('primaryClient');


### PR DESCRIPTION
## Summary

Addresses 2 remaining AI code quality findings on `test/unit.test.mjs`:

- **Split single test** — the original `it('should correctly boot/get/clear VaultClient instance')` covered 5 distinct behaviors in one block. Split into focused cases: boot, idempotent boot, get, clear+re-create, and clear isolation. Failure messages now pinpoint exactly which behavior broke.
- **Narrow `.to.throw()`** — replaced the broad `.to.throw()` with `.to.throw('Invalid instance name')` to assert the exact error message thrown by `VaultClient.get` when a name is not registered.
- **Add `afterEach` cleanup** — `VaultClient.clear()` after each test ensures full isolation; no test can leak registry state into the next.

## Test plan

- [x] `mocha test/unit.test.mjs` — 5 tests passing
- [x] `npm run lint` — clean
- [ ] AI findings page shows 0 open findings after merge