### PR TITLE
test: pin Error type in throw assertions

### DIFF
--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -51,10 +51,10 @@ describe('Unit tests', function () {
         VaultClient.clear('primaryClient');
 
         expect(VaultClient.get('secondaryClient')).to.equal(secondaryClient);
-        expect(() => VaultClient.get('primaryClient')).to.throw('Invalid instance name');
+        expect(() => VaultClient.get('primaryClient')).to.throw(Error, 'Invalid instance name');
 
         VaultClient.clear('secondaryClient');
-        expect(() => VaultClient.get('secondaryClient')).to.throw('Invalid instance name');
+        expect(() => VaultClient.get('secondaryClient')).to.throw(Error, 'Invalid instance name');
     });
 
 });


### PR DESCRIPTION
## Summary

Both `.to.throw('Invalid instance name')` assertions in the last test case now specify the error type:

```js
.to.throw(Error, 'Invalid instance name')
```

This validates both that the thrown value is an `Error` instance and that the message matches exactly, as flagged by the AI code quality findings.

## Test plan

- [x] `mocha test/unit.test.mjs` — 5 tests passing
- [x] `npm run lint` — clean