### PR TITLE
test: add coverage for VaultClient.get() with never-booted name

### DIFF
--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -35,6 +35,10 @@ describe('Unit tests', function () {
         expect(VaultClient.get('primaryClient')).to.equal(client);
     });
 
+    it('should throw when getting a client that was never booted', () => {
+        expect(() => VaultClient.get('neverBootedClient')).to.throw(Error, 'Invalid instance name');
+    });
+
     it('should clear a client and allow re-creation', () => {
         const client = VaultClient.boot('primaryClient', bootOpts);
         VaultClient.clear('primaryClient');


### PR DESCRIPTION
## Summary

Adds a dedicated test case for calling `VaultClient.get()` with a name that was never registered via `boot()`:

```js
it('should throw when getting a client that was never booted', () => {
    expect(() => VaultClient.get('neverBootedClient')).to.throw(Error, 'Invalid instance name');
});
```

Addresses the AI finding: the existing throw assertions only covered the post-`clear()` case; this closes the gap for the never-registered case.

## Test plan

- [x] `mocha test/unit.test.mjs` — 6 tests passing
- [x] `npm run lint` — clean