### PR TITLE
docs: add open-source community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+**Node.js version**
+
+**node-vault-client version**
+
+**Vault server version**
+
+**Auth backend** (one of: `appRole` / `token` / `iam` / `kubernetes`)
+
+**What happened?**
+
+**What did you expect to happen?**
+
+**Minimal reproduction**
+
+```javascript
+// paste code here
+```
+
+**Additional context**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/namecheap/node-vault-client/security/advisories/new
+    about: Please report security vulnerabilities privately, not as public issues. See SECURITY.md.
+  - name: Questions and usage help
+    url: https://github.com/namecheap/node-vault-client/blob/master/SUPPORT.md
+    about: Where to get help with installation, configuration, and usage.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+**What problem does this solve?**
+
+**Proposed API / behavior (if applicable)**
+
+```javascript
+// example usage
+```
+
+**Alternatives considered**
+
+**Additional context**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do? Why? -->
+
+## Changes
+
+<!-- List the files changed and why -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `npm run lint && npm test` passes locally
+- [ ] User-facing changes recorded under `# Unreleased` in `CHANGELOG.md`
+- [ ] All commits have a `Signed-off-by:` trailer (`git commit -s`)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opensource@namecheap.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,74 @@
-## New version release
-To relese new version of package use the following steps:
+# Contributing to Node.js Vault Client
+
+You're welcome to start a discussion about a feature you'd like, file an issue, or submit a
+work-in-progress (WIP) pull request. Feel free to ask us for help — we'll do our best to guide
+you and help you get it merged.
+
+By participating in this project you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Prerequisites
+
+- Node.js >= 18 — the client uses the native `fetch` API. CI runs against 18, 20, 22 and 24
+  (`.nvmrc` pins 20 for local development).
+- npm (the repo ships a committed `package-lock.json`; use `npm ci`).
+- Docker — used to run a local dev Vault server for the integration and end-to-end tests
+  (see `docker-compose.yml`).
+
+## Development workflow
+
+```shell
+npm ci                 # install dependencies from the lockfile
+npm install config     # peer dependency used by the node-config integration and coverage
+docker compose up -d   # start a local dev Vault on 127.0.0.1:8200
+
+npm run lint           # ESLint (must be clean)
+npm run test:unit      # fast unit tests (no Vault required)
+npm test               # full suite, including integration/e2e (needs the Vault container)
+npm run coverage       # unit tests with c8 coverage report
 ```
-$ npm version [major | minor | patch]
-# Review last commit
-$ git push && git push --tags
-$ npm publish
+
+Run `npm run lint` and the tests before pushing — the same checks run in CI
+(`.github/workflows/pipeline.yaml`: audit, lint, coverage, and a test matrix on Node 18/20/22/24).
+
+## Tests
+
+Tests live in `test/**/*.test.mjs` and use [mocha](https://mochajs.org/),
+[chai](https://www.chaijs.com/) and [sinon](https://sinonjs.org/). Add or update tests for any
+code you change. Mock HTTP interactions with sinon — **never** use real Vault servers or
+credentials in unit tests. The integration and `test/e2e` suites talk to the dev Vault started by
+`docker compose up -d`.
+
+## DCO sign-off
+
+This project requires a [Developer Certificate of Origin](https://developercertificate.org/)
+sign-off on every commit. Add the following trailer to each commit message (use `git commit -s`
+or add it manually):
+
 ```
+Signed-off-by: Your Name <your-email@example.com>
+```
+
+Pull requests with commits missing the sign-off will fail the DCO check in CI.
+
+## Pull requests
+
+1. Fork the repo and create a topic branch off `master`.
+2. Make your change with tests, and keep `npm run lint` and the test suite green.
+3. Record user-facing changes under the `# Unreleased` heading in [`CHANGELOG.md`](CHANGELOG.md).
+4. Sign off your commits (see above) and open the PR against `master`.
+5. A code owner (see [`.github/CODEOWNERS`](.github/CODEOWNERS)) will review your PR before merge.
+
+## Release (maintainers)
+
+Publishing is automated by `.github/workflows/publish.yml`, which runs
+`npm publish --provenance --access public` whenever a GitHub Release is published:
+
+```shell
+npm version [major | minor | patch]   # bumps package.json and tags the commit
+# review the version-bump commit, then:
+git push && git push --tags
+```
+
+Then create a [GitHub Release](https://github.com/namecheap/node-vault-client/releases/new) for
+the new tag (move the `# Unreleased` notes from `CHANGELOG.md` into a dated section). Publishing
+the release triggers the workflow that pushes the package to npm.

--- a/README.md
+++ b/README.md
@@ -314,3 +314,24 @@ If no name passed all named instances will be cleared.
 | Param | Type | Description |
 | --- | --- | --- |
 | [name] | <code>String</code> | Vault instance name, all instances will be cleared if no name were passed |
+
+## Contributing
+
+Contributions are welcome! Please read the [contributing guide](CONTRIBUTING.md) to get started,
+and note that this project requires a [DCO sign-off](CONTRIBUTING.md#dco-sign-off) on every commit.
+
+## Getting help
+
+Not sure where to start? See [SUPPORT.md](SUPPORT.md).
+
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+To report a security vulnerability, please follow our [Security Policy](SECURITY.md).
+
+## License
+
+Licensed under the [Apache License 2.0](LICENSE.txt).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest published release of [`node-vault-client`](https://www.npmjs.com/package/node-vault-client)
+receives security fixes.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Use GitHub's [private vulnerability reporting](https://github.com/namecheap/node-vault-client/security/advisories/new)
+to report a vulnerability confidentially. We will acknowledge receipt within 5 business days and
+aim to release a fix within 30 days for confirmed issues.
+
+Alternatively, email `opensource@namecheap.com` with the subject line `[SECURITY] node-vault-client`.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,14 @@
+# Getting help
+
+Thanks for using `node-vault-client`! Here's where to go depending on what you need:
+
+- **Usage questions and configuration help** — start with the [README](README.md), which covers
+  installation, every supported auth backend, and the full client API.
+- **Bugs and unexpected behavior** — open a [bug report](https://github.com/namecheap/node-vault-client/issues/new?template=bug_report.md).
+- **Feature ideas** — open a [feature request](https://github.com/namecheap/node-vault-client/issues/new?template=feature_request.md).
+- **Security vulnerabilities** — please do **not** open a public issue; follow our
+  [Security Policy](SECURITY.md) instead.
+- **Contributing a change** — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Before opening an issue, please search the [existing issues](https://github.com/namecheap/node-vault-client/issues)
+to see if your question has already been answered.


### PR DESCRIPTION
## Summary

Brings the repo up to GitHub's **community-standards** checklist and the recommendations on [opensource.guide](https://opensource.guide/). The community profile was at **50%** — missing a code of conduct, issue templates, and a pull request template — and `CONTRIBUTING.md` only contained maintainer release notes.

The added files mirror the house style already used in [`namecheap/go-namecheap-sdk`](https://github.com/namecheap/go-namecheap-sdk) (Contributor Covenant 2.1, DCO sign-off, private vulnerability reporting, `opensource@namecheap.com` contact), adapted to this project's Node.js / npm / mocha tooling.

## Changes

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1 (was missing).
- **`SECURITY.md`** — supported versions + private vulnerability reporting policy.
- **`SUPPORT.md`** — where to get help.
- **`.github/ISSUE_TEMPLATE/`** — `bug_report.md`, `feature_request.md`, `config.yml` (was missing).
- **`.github/pull_request_template.md`** — PR checklist incl. lint/test, CHANGELOG, DCO (was missing).
- **`CONTRIBUTING.md`** — rewritten: prerequisites, dev workflow, DCO sign-off, testing guidance, and a release section corrected to match the GitHub-Release-driven `publish.yml`.
- **`README.md`** — footer linking Contributing / Support / Code of Conduct / Security / License.

No source code changes. `npm run lint` and `npm run test:unit` (131 passing) verified locally.

## Type of change

- [x] Documentation

## Checklist

- [x] `npm run lint && npm run test:unit` passes locally
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)