### PR TITLE
test: address AI findings in unit.test.mjs

### DIFF
--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -4,13 +4,15 @@ import VaultClient from '../src/VaultClient.js';
 
 describe('Unit tests', function () {
 
+    const TEST_TOKEN = 'test-not-a-real-token';
+
     const bootOpts = deepFreeze({
         api: { url: 'https://example.com/' },
         logger: false,
         auth: {
             type: 'token',
             config: {
-                token: 'XXXXXXXX-eb8e-5f25-fad2-79274fa13a64',
+                token: TEST_TOKEN,
             }
         },
     });
@@ -42,6 +44,7 @@ describe('Unit tests', function () {
     it('should clear a client and allow re-creation', () => {
         const client = VaultClient.boot('primaryClient', bootOpts);
         VaultClient.clear('primaryClient');
+        expect(() => VaultClient.get('primaryClient')).to.throw(Error, 'Invalid instance name');
 
         const recreatedClient = VaultClient.boot('primaryClient', bootOpts);
         expect(recreatedClient).to.be.instanceOf(VaultClient);


### PR DESCRIPTION
Fixes the 2 GitHub AI code-quality findings reported on `test/unit.test.mjs`.

## Findings addressed

1. **Hardcoded token in test configuration** — the `token` value used a
   real-looking UUID-style string (`XXXXXXXX-eb8e-5f25-fad2-...`) that
   could be mistaken for a live secret. Replaced it with a clearly fake
   `TEST_TOKEN = 'test-not-a-real-token'` constant referenced from
   `bootOpts`.

2. **Missing assertion after `clear()`** — the *"should clear a client and
   allow re-creation"* test re-booted the client without first verifying
   the cleared instance was actually removed. Added
   `expect(() => VaultClient.get('primaryClient')).to.throw(Error, 'Invalid instance name')`
   immediately after `clear()` to confirm the instance is gone before
   re-creation.

## Verification

`npx mocha "test/unit.test.mjs"` — all 6 tests pass.