### PR TITLE
test: assert boot initialization and clear cleanup in unit.test.mjs

### DIFF
--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -1,6 +1,11 @@
 import deepFreeze from 'deep-freeze';
-import { expect } from 'chai';
+import sinon from 'sinon';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
 import VaultClient from '../src/VaultClient.js';
+import VaultTokenAuth from '../src/auth/VaultTokenAuth.js';
+
+use(sinonChai);
 
 describe('Unit tests', function () {
 
@@ -19,11 +24,17 @@ describe('Unit tests', function () {
 
     afterEach(function () {
         VaultClient.clear();
+        sinon.restore();
     });
 
-    it('should boot a new VaultClient instance', () => {
+    it('should boot a new VaultClient instance initialized from the given options', () => {
         const client = VaultClient.boot('primaryClient', bootOpts);
         expect(client).to.be.instanceOf(VaultClient);
+
+        // The configuration is wired into the API client and the auth provider.
+        expect(client.__api.__config.url).to.equal(bootOpts.api.url);
+        expect(client.__auth).to.be.instanceOf(VaultTokenAuth);
+        expect(client.__auth.__token).to.equal(bootOpts.auth.config.token);
     });
 
     it('should return the same instance when booting with the same name', () => {
@@ -41,9 +52,14 @@ describe('Unit tests', function () {
         expect(() => VaultClient.get('neverBootedClient')).to.throw(Error, 'Invalid instance name');
     });
 
-    it('should clear a client and allow re-creation', () => {
+    it('should release the instance resources and allow re-creation when cleared', () => {
         const client = VaultClient.boot('primaryClient', bootOpts);
+        const closeSpy = sinon.spy(client, 'close');
+
         VaultClient.clear('primaryClient');
+
+        // clear() disposes the instance (close() cancels the auth-refresh timer) before removing it.
+        expect(closeSpy).to.have.been.calledOnce;
         expect(() => VaultClient.get('primaryClient')).to.throw(Error, 'Invalid instance name');
 
         const recreatedClient = VaultClient.boot('primaryClient', bootOpts);


### PR DESCRIPTION
Addresses the 2 GitHub AI code-quality findings on `test/unit.test.mjs`.

## Findings addressed

1. **Boot test didn't verify initialization from config.** The
   *"should boot a new VaultClient instance"* test only checked
   `instanceOf`. It now asserts the options are actually wired into the
   instance:
   - `client.__api.__config.url` equals `bootOpts.api.url`
   - `client.__auth` is a `VaultTokenAuth` (honors `auth.type`)
   - `client.__auth.__token` equals `bootOpts.auth.config.token`

2. **Clear test didn't verify resource cleanup.** `VaultClient.clear()`
   calls `instance.close()`, which cancels the auth token-refresh timer
   (the resource that otherwise keeps the event loop alive). The test now
   spies on the instance's `close()` and asserts it is invoked exactly
   once when `clear()` is called, before the instance is removed.

## Notes

Rather than the suggested speculative property-name fallback chains
(`client?.api?.url ?? client?.config?.api?.url ?? …`) and a
`dispose`/`close`/`destroy` heuristic, these assertions target the
client's real internals — matching the existing conventions already used
in `test/VaultClient.test.mjs` (private-field access, `sinon.spy(i, 'close')`).

## Verification

`npm run test:unit` — 136 passing. (`npm test` also runs `test/e2e/*`,
which require a live Vault at `127.0.0.1:8200` and are unrelated to this change.)