### PR TITLE
ci: switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
+      # Trusted publishing (OIDC) requires npm CLI >= 11.5.1
+      - name: Ensure recent npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
       - name: Publish
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Problem

The `Publish to npm` workflow fails with `ENEEDAUTH` — `secrets.NPM_TOKEN` is empty, so `NODE_AUTH_TOKEN` is blank and `npm publish` has no credentials. The tarball builds and packs fine; it's purely an auth failure ([failed run](https://github.com/namecheap/node-vault-client/actions/runs/27609135287)).

## Change

Switch to npm **trusted publishing** (OIDC) so no long-lived token is needed:

- **Drop** the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env — auth now comes from the GitHub OIDC token (`id-token: write`, already present).
- **Drop** `--provenance` — provenance is generated automatically under trusted publishing.
- **Add** `npm install -g npm@latest` — trusted publishing requires npm CLI >= 11.5.1.

## Prerequisite (done)

The GitHub Actions trusted publisher is configured for `node-vault-client` on npmjs.com:
- Org/user: `namecheap`, Repo: `node-vault-client`, Workflow: `publish.yml`, Environment: (none)

## Testing

Merge, then either re-run the failed `v2.0.0` release or cut a new release tag to exercise the publish job.