### PR TITLE
chore(deps): update pretty-ms, url-join, globals, eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,16 +15,16 @@
         "bluebird": "^3.7.0",
         "lodash": "^4.17.15",
         "long-timeout": "^0.1.1",
-        "pretty-ms": "^2.1.0",
-        "url-join": "^2.0.5"
+        "pretty-ms": "^7.0.1",
+        "url-join": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "c8": "^11.0.0",
         "chai": "^6.0.0",
         "deep-freeze": "^0.0.1",
-        "eslint": "^9.0.0",
-        "globals": "^16.0.0",
+        "eslint": "^9.39.4",
+        "globals": "^17.6.0",
         "mocha": "^11.7.6",
         "sinon": "^22.0.0",
         "sinon-chai": "^4.0.0"
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1781,17 +1781,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2154,14 +2143,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2226,11 +2207,12 @@
       }
     },
     "node_modules/parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -2291,14 +2273,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/plur": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
-      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2310,16 +2284,18 @@
       }
     },
     "node_modules/pretty-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
-      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "license": "MIT",
       "dependencies": {
-        "is-finite": "^1.0.1",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
+        "parse-ms": "^2.1.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/punycode": {
@@ -2624,9 +2600,10 @@
       }
     },
     "node_modules/url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "bluebird": "^3.7.0",
     "lodash": "^4.17.15",
     "long-timeout": "^0.1.1",
-    "pretty-ms": "^2.1.0",
-    "url-join": "^2.0.5"
+    "pretty-ms": "^7.0.1",
+    "url-join": "^4.0.1"
   },
   "peerDependencies": {
     "config": ">=1 <4"
@@ -55,8 +55,8 @@
     "c8": "^11.0.0",
     "chai": "^6.0.0",
     "deep-freeze": "^0.0.1",
-    "eslint": "^9.0.0",
-    "globals": "^16.0.0",
+    "eslint": "^9.39.4",
+    "globals": "^17.6.0",
     "mocha": "^11.7.6",
     "sinon": "^22.0.0",
     "sinon-chai": "^4.0.0"


### PR DESCRIPTION
Updates the four requested dependencies to their newest **CommonJS-compatible** versions.

| Package | From | To | Notes |
|---|---|---|---|
| `pretty-ms` | `^2.1.0` | `^7.0.1` | last CJS release — v8+ is ESM-only |
| `url-join` | `^2.0.5` | `^4.0.1` | last CJS release — v5 is ESM-only |
| `globals` | `^16.0.0` | `^17.6.0` | dev-only (eslint config) |
| `eslint` | `^9.0.0` | `^9.39.4` | kept in v9 line — see below |

### Why not the latest majors?
- **pretty-ms / url-join** — the client is `require()`-based (CommonJS). `pretty-ms@9` and `url-join@5` are pure ESM (`"type": "module"`) and can't be `require()`d, so they're pinned to the last CJS major. Both are used in a single spot each (`VaultBaseAuth`, `VaultApiClient`) and the call signatures are unchanged.
- **eslint** — `eslint@10` is available but its engines require `Node >= 20.19`, which would drop this package's declared **Node 18** support (`engines.node: >=18`, and the CI matrix tests Node 18). Staying on the v9 line keeps dev tooling installable on Node 18. Happy to do the v10 bump separately (it'd also need `@eslint/js` → 10) if you'd rather drop Node 18.

### Verification (local)
- `npm install` clean, **0 vulnerabilities**
- `npm run lint` passes (eslint 9.39 + globals 17)
- `npm run test:unit` — **136 passing**
- `require()` smoke test: `prettyMs(1234)` → `1.2s`, `urljoin('https://v/','v1','secret/data')` → `https://v/v1/secret/data`

Full integration suite (needs the Vault docker-compose) runs in CI.