### PR TITLE
ci: split unit and Vault-backed e2e tests into separate jobs

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -77,7 +77,7 @@ jobs:
           name: coverage-report
           path: coverage/
 
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -86,9 +86,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - name: Build the Docker Compose stack
-        run: docker compose up -d
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -99,14 +96,32 @@ jobs:
       - name: Install dependencies
         run: npm ci && npm install config
 
-      - name: Run tests
-        run: |
-          npm test 2>&1 | tee test-output-node${{ matrix.node-version }}.txt
-          exit ${PIPESTATUS[0]}
+      - name: Run unit tests
+        run: npm run test:unit
 
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+  # Full integration suite — exercises the client against a real Vault
+  # instance started via docker-compose.
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20, 22, 24]
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Start Vault (docker compose)
+        run: docker compose up -d --wait
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          name: test-results-node${{ matrix.node-version }}
-          path: test-output-node${{ matrix.node-version }}.txt
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci && npm install config
+
+      - name: Run e2e tests
+        run: npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test": "mocha --exit \"test/**/*.test.mjs\"",
     "test:unit": "mocha \"test/*.test.mjs\"",
+    "test:e2e": "mocha --exit \"test/e2e/**/*.test.mjs\"",
     "coverage": "c8 npm run test:unit",
     "lint": "eslint src/",
     "version": "git add -A ."


### PR DESCRIPTION
Splits the single matrix `build` job (which ran the full suite) into two purpose-named jobs so unit failures are distinguishable from integration failures, and the Vault-backed suite gets an explicit startup gate.

### Changes
- **`package.json`** — new `test:e2e` script scoped to the integration tests:
  `"test:e2e": "mocha --exit 'test/e2e/**/*.test.mjs'"`
- **`pipeline.yaml`** — replace `build` with:
  - **`test`** — unit tests only (`npm run test:unit`), no Vault, Node 18/20/22/24.
  - **`e2e`** — `docker compose up -d --wait` to start Vault, then `npm run test:e2e`, Node 18/20/22/24.

### Why
- The old job was named `build` but built nothing — it ran tests. Confusing in the checks list.
- It did `docker compose up -d` and went straight into `npm ci`; the e2e tests only passed because install happened to outlast Vault's startup. `--wait` makes the dependency explicit.
- Test coverage is unchanged: unit + e2e still both run on all four Node versions, just in separate jobs.

### Note
Dropped the per-Node `test-output-*.txt` artifact upload — mocha output is already in the job logs, and it let me remove the `tee`/`PIPESTATUS` shell plumbing. Say the word if you want the artifacts back.

### Verification
- YAML parses; jobs are `audit, lint, coverage, test, e2e`.
- `npm run test:unit` → **136 passing** locally.
- The `e2e` job uses the same docker-compose Vault mechanism that already passed on all four Node versions in PR #86, so CI on this PR is the real check (Docker isn't available in my local env).