### PR TITLE
chore: add @m2broth as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 # pull request changes matching files. With "Require review from Code Owners"
 # enabled in branch protection, their approval becomes mandatory before merge.
 #
-# The catch-all pattern below makes @wRLSS the default reviewer for every PR.
+# The catch-all pattern below makes @wRLSS and @m2broth the default
+# reviewers for every PR.
 
-* @wRLSS
+* @wRLSS @m2broth


### PR DESCRIPTION
Adds **@m2broth** to the catch-all CODEOWNERS pattern alongside @wRLSS.

```
* @wRLSS @m2broth
```

With multiple owners on the pattern, a review from **either** @wRLSS or @m2broth satisfies the required code-owner review.

Verified @m2broth (id 986159) has write access to the repo, so the entry is valid (GitHub ignores CODEOWNERS entries for users without write access).