### PR TITLE
fix(security): stop logging secrets at debug level

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,9 @@
+# Socket.dev configuration — https://docs.socket.dev/docs/socket-yml
+version: 2
+
+issueRules:
+  # node-vault-client is an HTTP client for HashiCorp Vault; reaching the
+  # Vault server over the network (globalThis.fetch in src/VaultApiClient.js)
+  # is the core, intended function of the package, not a supply-chain risk.
+  # Acknowledged so the alert does not recur on every PR.
+  networkAccess: false

--- a/src/VaultApiClient.js
+++ b/src/VaultApiClient.js
@@ -80,10 +80,12 @@ class VaultApiClient {
                     throw error;
                 }
 
-                this._logger.debug('%s %s response body:\n%s',
+                // Do not log the response body: Vault responses carry secret
+                // material (auth tokens, secret reads). Log status only.
+                this._logger.debug('%s %s -> %d',
                     method,
                     uri,
-                    JSON.stringify(body, null, ' ')
+                    response.status
                 );
                 return body;
             });

--- a/src/auth/VaultKubernetesAuth.js
+++ b/src/auth/VaultKubernetesAuth.js
@@ -28,18 +28,15 @@ class VaultKubernetesAuth extends VaultBaseAuth {
 
         const k8sJwtToken = fs.readFileSync(this.__tokenPath).toString();
         this._log.debug(
-            'receive K8s token: %s',
-            k8sJwtToken
+            'read K8s service-account JWT from "%s" (%d bytes)',
+            this.__tokenPath, k8sJwtToken.length
         );
 
         return this.__apiClient.makeRequest('POST', `/auth/${this._mount}/login`, {
             role: this.__role,
             jwt: k8sJwtToken,
         }).then((res) => {
-            this._log.debug(
-                'receive token: %s',
-                res.auth.client_token
-            );
+            this._log.debug('received Vault client token from Kubernetes login');
 
             return this._getTokenEntity(res.auth.client_token);
         });

--- a/test/VaultApiClient.test.mjs
+++ b/test/VaultApiClient.test.mjs
@@ -88,12 +88,21 @@ describe('VaultApiClient', function () {
             });
         });
 
-        it('logs the request and the response body via the debug logger', function () {
+        it('logs the request and response status, never the response body', function () {
             const debug = sinon.spy();
+            responder = (req, res) => {
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'application/json');
+                res.end(JSON.stringify({ auth: { client_token: 'super-secret-token' } }));
+            };
             const api = new VaultApiClient({ url: baseUrl }, _.assign({}, logger, { debug }));
             return api.makeRequest('GET', '/secret/foo').then(() => {
                 expect(debug).to.have.been.calledWith('making request: %s %s', 'GET', `${baseUrl}/v1/secret/foo`);
-                expect(debug.callCount).to.be.at.least(2);
+                expect(debug).to.have.been.calledWith('%s %s -> %d', 'GET', `${baseUrl}/v1/secret/foo`, 200);
+                // Regression guard: secret-bearing response bodies must never reach the logger.
+                const leaked = debug.getCalls().some((call) =>
+                    call.args.some((arg) => typeof arg === 'string' && arg.includes('super-secret-token')));
+                expect(leaked, 'response body must not be logged').to.equal(false);
             });
         });
 

--- a/test/auth.kubernetes.test.mjs
+++ b/test/auth.kubernetes.test.mjs
@@ -52,4 +52,20 @@ describe('VaultKubernetesAuth', function () {
             expect(token).to.equal(entity);
         });
     });
+
+    it('never logs the JWT or the Vault client token', function () {
+        readFileSync = sinon.stub(fs, 'readFileSync').returns(Buffer.from('super-secret-jwt'));
+        const debug = sinon.spy();
+        const api = apiStub();
+        api.makeRequest.resolves({ auth: { client_token: 'super-secret-vault-token' } });
+        const auth = new VaultKubernetesAuth(api, _.assign({}, logger, { debug }), { role: 'r', tokenPath: '/tmp/tok' }, 'k8s');
+        sinon.stub(auth, '_getTokenEntity').resolves(new AuthToken('id', 'acc', 0, null, 0, 0, false));
+
+        return auth._authenticate().then(() => {
+            const leaked = debug.getCalls().some((call) =>
+                call.args.some((arg) => typeof arg === 'string'
+                    && (arg.includes('super-secret-jwt') || arg.includes('super-secret-vault-token'))));
+            expect(leaked, 'JWT and client token must not be logged').to.equal(false);
+        });
+    });
 });


### PR DESCRIPTION
Resolves the Socket.dev alerts.

## gptSecurity (medium) — plaintext secret logging
Two debug-level leaks where anyone with access to debug logs could recover live credentials:

**1. `src/auth/VaultKubernetesAuth.js`** (the flagged file)
- Logged the raw Kubernetes service-account **JWT** (`receive K8s token: <jwt>`)
- Logged the issued **Vault client token** (`receive token: <token>`)

**2. `src/VaultApiClient.js`** (same leak class, broader)
- `makeRequest` debug-logged the **entire response body** of every request. For Vault that includes `auth.client_token` on every login and the secret payload of every read — across *all* auth backends and secret reads, not just Kubernetes.

### Fix
Replaced the secret values with non-sensitive debug lines:
| Before | After |
|---|---|
| `receive K8s token: <jwt>` | `read K8s service-account JWT from "<path>" (<n> bytes)` |
| `receive token: <client_token>` | `received Vault client token from Kubernetes login` |
| `<METHOD> <uri> response body: <full JSON>` | `<METHOD> <uri> -> <status>` |

Paths, mounts, and the token *accessor* (a non-usable reference) are still logged — none are credentials.

### Regression tests
- `VaultKubernetesAuth` — *never logs the JWT or the Vault client token*
- `VaultApiClient` — *logs the request and response status, never the response body* (asserts a secret-bearing body never reaches the logger)

## networkAccess — `globalThis.fetch` in `src/VaultApiClient.js`
This is a **true-positive-but-expected** alert: a Vault client must reach the Vault server over the network — it's the package's core function, not a supply-chain risk, and there's no code change that removes it without breaking the library. Added `socket.yml` to acknowledge it so it doesn't recur on every PR:

```yaml
version: 2
issueRules:
  networkAccess: false
```

> Note: `issueRules` is supported but marked deprecated by Socket in favour of repository labels / dashboard acknowledgement. If you'd rather acknowledge it in the Socket dashboard (keeps networkAccess signal active for dependencies), say so and I'll drop `socket.yml`.

## Verification
- `npm run lint` passes
- `npm run test:unit` → **137 passing** (incl. the 2 new guards)