### PR TITLE
chore(deps): drop bluebird and assign-deep, bump lodash floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.382.0",
-        "assign-deep": "^1.0.1",
         "aws4": "^1.8.0",
-        "bluebird": "^3.7.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "long-timeout": "^0.1.1",
         "pretty-ms": "^2.1.0",
         "url-join": "^2.0.5"
@@ -984,25 +982,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/assign-deep": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-1.0.1.tgz",
-      "integrity": "sha512-CSXAX79mibneEYfqLT5FEmkqR5WXF+xDRjgQQuVf6wSCXCYU8/vHttPidNar7wJ5BFmKAo8Wei0rCtzb+M/yeA==",
-      "dependencies": {
-        "assign-symbols": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/assign-symbols": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.2.tgz",
-      "integrity": "sha512-9sBQUQZMKFKcO/C3Bo6Rx4CQany0R0UeVcefNGRRdW2vbmaMOhV1sbmlXcQLcD56juLXbSGTBm0GGuvmrAF8pA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
@@ -1014,11 +993,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-      "integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg=="
     },
     "node_modules/bowser": {
       "version": "2.14.1",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.382.0",
-    "assign-deep": "^1.0.1",
     "aws4": "^1.8.0",
-    "bluebird": "^3.7.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "long-timeout": "^0.1.1",
     "pretty-ms": "^2.1.0",
     "url-join": "^2.0.5"

--- a/src/VaultNodeConfig.js
+++ b/src/VaultNodeConfig.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const path = require('path');
-const Bluebird = require('bluebird');
 const _ = require('lodash');
-const assignDeep = require('assign-deep');
 
 const errors = require('./errors');
 
@@ -38,9 +36,10 @@ class VaultNodeConfig {
             requiredData[path] = null;
         });
 
-        let promises = _.mapValues(requiredData, (value, path) => this.__vault.read(path));
+        const paths = Object.keys(requiredData);
 
-        return Bluebird.props(promises).then(results => {
+        return Promise.all(paths.map((path) => this.__vault.read(path))).then((leases) => {
+            const results = _.zipObject(paths, leases);
             requiredData = _.mapValues(requiredData, (value, path) => results[path].getData());
 
             this.__traverse(substitutionMap, (key, val, obj) => {
@@ -54,7 +53,7 @@ class VaultNodeConfig {
                 obj[key] = requiredData[path][value];
             });
 
-            return assignDeep(this.__nodeConfig, substitutionMap);
+            return _.merge(this.__nodeConfig, substitutionMap);
         });
     }
 


### PR DESCRIPTION
Follow-up to #86, covering the **rest** of the runtime dependencies.

## TL;DR — most deps are already current
The caret ranges already resolve to the latest published versions, so there's little to "bump":

| Package | Range | Latest | Status |
|---|---|---|---|
| @aws-sdk/credential-providers | `^3.382.0` | 3.1069.0 | ✅ resolves to latest (v3 is current major) |
| aws4 | `^1.8.0` | 1.13.2 | ✅ resolves to latest |
| long-timeout | `^0.1.1` | 0.1.1 | ✅ already newest |
| lodash | `^4.17.15` | 4.18.x | ⬆️ floor raised (below) |
| bluebird | `^3.7.0` | 3.7.2 | ❌ **removed** (below) |
| assign-deep | `^1.0.1` | 1.0.1 | ❌ **removed** (below) |

## Changes
**1. Drop two legacy deps** — both used only in `VaultNodeConfig.js`:
- **bluebird** (unmaintained since ~2019) — `Bluebird.props(promises)` → native `Promise.all` + `_.zipObject`.
- **assign-deep** — the single deep-merge → `_.merge` (lodash is already a dependency).

**2. lodash floor** `^4.17.15` → `^4.17.21` — pulls the minimum past the prototype-pollution CVEs (CVE-2020-8203 etc.) so consumers who dedupe to the floor get a patched lodash. (Installed version was already 4.18.x.)

## Behavior
Unchanged. The `Bluebird.props` → `Promise.all` swap is semantically identical (object-of-promises → resolved-by-key). `_.merge` and `assign-deep` both deep-merge the source into the target in place; the substitution map holds object/string leaves, which both handle the same way.

## Verification
- `npm install` → **0 vulnerabilities**; `npm ls bluebird assign-deep` → gone from the tree.
- `npm run lint` passes.
- `npm run test:unit` → **136 passing**, incl. `VaultNodeConfig#populate` "resolves substitution values from Vault into the config object", which exercises both replaced call sites.
- Full integration suite runs in CI.

## Not done (separate decision)
- **`config` peer dep** is capped at `>=1 <4` while config **v4.4.1** exists. Widening to allow v4 needs `VaultNodeConfig` tested against config v4's API (it changed how some utils behave), so I left it out. Happy to do it as its own PR if you want v4 support.