### PR TITLE
chore: address AI code-quality findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.0.0. Release notes (2026-06-12)
+# 2.0.0 Release notes (2026-06-12)
 
 - Fix a process that never exits after reading with a renewable token. The background
   token-refresh timer (`long-timeout`) kept the Node.js event loop alive with no way to stop
@@ -26,7 +26,7 @@
   stale token. Closes #50.
 - Replace deprecated `new Buffer()` with `Buffer.from()` in IAM auth STS body encoding. Closes #52.
 
-# 1.0.0. Release notes (2023-08-02)
+# 1.0.0 Release notes (2023-08-02)
 
 - `aws-sdk` is no longer a peer dependency
 - [BREAKING] From now on the minimum supported version of Node.js is 14.0.0.

--- a/src/VaultNodeConfig.js
+++ b/src/VaultNodeConfig.js
@@ -27,30 +27,24 @@ class VaultNodeConfig {
         let requiredData = {};
 
         this.__traverse(substitutionMap, (key, val) => {
-            const splitRes = val.split('#');
-            const path = splitRes[0], value = splitRes[1];
-            if (path === undefined || value === undefined) {
-                throw new errors.InvalidArgumentsError('Invalid format of substitution value');
-            }
-
-            requiredData[path] = null;
+            const { vaultPath } = this.__parseSubstitutionValue(val);
+            requiredData[vaultPath] = null;
         });
 
-        const paths = Object.keys(requiredData);
+        const vaultPaths = Object.keys(requiredData);
 
-        return Promise.all(paths.map((path) => this.__vault.read(path))).then((leases) => {
-            const results = _.zipObject(paths, leases);
-            requiredData = _.mapValues(requiredData, (value, path) => results[path].getData());
+        return Promise.all(vaultPaths.map((vaultPath) => this.__vault.read(vaultPath))).then((leases) => {
+            const results = _.zipObject(vaultPaths, leases);
+            requiredData = _.mapValues(requiredData, (value, vaultPath) => results[vaultPath].getData());
 
             this.__traverse(substitutionMap, (key, val, obj) => {
-                const splitRes = val.split('#');
-                const path = splitRes[0], value = splitRes[1];
-                const res = requiredData[path][value];
+                const { vaultPath, value } = this.__parseSubstitutionValue(val);
+                const res = requiredData[vaultPath][value];
                 if (res === undefined) {
                     throw new errors.VaultError(`Can't find substitution for "${val}"`);
                 }
 
-                obj[key] = requiredData[path][value];
+                obj[key] = requiredData[vaultPath][value];
             });
 
             return _.merge(this.__nodeConfig, substitutionMap);
@@ -58,15 +52,29 @@ class VaultNodeConfig {
     }
 
     /**
+     * Splits a substitution value of the form "<vaultPath>#<value>".
+     *
+     * @private
+     */
+    __parseSubstitutionValue(val) {
+        const [vaultPath, value] = val.split('#');
+        if (vaultPath === undefined || value === undefined) {
+            throw new errors.InvalidArgumentsError('Invalid format of substitution value');
+        }
+
+        return { vaultPath, value };
+    }
+
+    /**
      * @private
      */
     __getSubstitutionMap() {
-        let config_dir = this.__nodeConfig.util.initParam('NODE_CONFIG_DIR', path.join( process.cwd(), 'config') );
-        if (config_dir.indexOf('.') === 0) {
-            config_dir = path.join(process.cwd() , config_dir);
+        let configDir = this.__nodeConfig.util.initParam('NODE_CONFIG_DIR', path.join(process.cwd(), 'config'));
+        if (configDir.indexOf('.') === 0) {
+            configDir = path.join(process.cwd(), configDir);
         }
 
-        const fullFilename = path.join(config_dir, 'custom-vault-variables.js');
+        const fullFilename = path.join(configDir, 'custom-vault-variables.js');
 
         let fileContent;
         try {


### PR DESCRIPTION
Addresses the GitHub AI code-quality findings on master.

## CHANGELOG.md (2 findings)
Version numbers shouldn't end with a period in headings:
- `# 2.0.0. Release notes` → `# 2.0.0 Release notes`
- `# 1.0.0. Release notes` → `# 1.0.0 Release notes`

## src/VaultNodeConfig.js (4 findings)
- **Duplicated logic** — the `val.split('#')` + validation block (used in both `__traverse` callbacks) is extracted into a private `__parseSubstitutionValue(val)` helper returning `{ vaultPath, value }`.
- **Variable shadowing** — the local `path`/`paths` bindings shadowed the imported `path` module; renamed to `vaultPath`/`vaultPaths`. The `path` module is now referenced only where intended (`__getSubstitutionMap`).
- **snake_case** — `config_dir` → `configDir` for camelCase consistency.

No behavior change.

## Verification
- `npm run lint` passes.
- `npm run test:unit` → **137 passing**, incl. `VaultNodeConfig#__getSubstitutionMap()` and `#populate()` (the "throws synchronously on a value without '#'" test confirms the extracted helper keeps the synchronous validation).

## Not included yet
The **3 findings on `test/auth.kubernetes.test.mjs`** weren't in the shared screenshots and aren't exposed via the code-scanning API, so they're not addressed here. I'll add them to this PR once their text is available.