### PR TITLE
chore: address second round of AI code-quality findings

### DIFF
--- a/src/VaultNodeConfig.js
+++ b/src/VaultNodeConfig.js
@@ -58,7 +58,7 @@ class VaultNodeConfig {
      */
     __parseSubstitutionValue(val) {
         const [vaultPath, value] = val.split('#');
-        if (vaultPath === undefined || value === undefined) {
+        if (!vaultPath || !value) {
             throw new errors.InvalidArgumentsError('Invalid format of substitution value');
         }
 
@@ -91,12 +91,8 @@ class VaultNodeConfig {
     }
 
     __traverse(o, func) {
-        for (let i in o) {
-            if (!Object.hasOwn(o, i)) {
-                continue;
-            }
-
-            if (o[i] !== null && typeof(o[i]) === "object") {
+        for (const i of Object.keys(o)) {
+            if (o[i] !== null && typeof o[i] === 'object') {
                 //going one step down in the object tree!!
                 this.__traverse(o[i], func);
             } else if (typeof o[i] === 'string') {

--- a/test/VaultNodeConfig.test.mjs
+++ b/test/VaultNodeConfig.test.mjs
@@ -120,6 +120,13 @@ describe('VaultNodeConfig', function () {
                 .to.throw(errors.InvalidArgumentsError, 'Invalid format of substitution value');
         });
 
+        it('throws when either side of the "#" is empty', function () {
+            for (const bad of ['#value', 'secret/a#', '#']) {
+                expect(() => instance({ key: bad }).populate(), bad)
+                    .to.throw(errors.InvalidArgumentsError, 'Invalid format of substitution value');
+            }
+        });
+
         it('rejects when a substitution cannot be found in the secret data', function () {
             const vnc = instance({ key: 'secret/a#missing' }, { 'secret/a': { present: 'v' } });
             return vnc.populate().then(

--- a/test/auth.kubernetes.test.mjs
+++ b/test/auth.kubernetes.test.mjs
@@ -9,7 +9,7 @@ import AuthToken from '../src/auth/AuthToken.js';
 
 use(sinonChai);
 
-const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (level) => [level, _.noop]));
 
 function apiStub() {
     return sinon.createStubInstance(VaultApiClient);
@@ -25,16 +25,30 @@ describe('VaultKubernetesAuth', function () {
         }
     });
 
-    it('defaults the mount and the kube token path', function () {
-        const auth = new VaultKubernetesAuth(apiStub(), logger, { role: 'r' });
+    it('defaults the mount and reads the kube token from the default path', function () {
+        readFileSync = sinon.stub(fs, 'readFileSync').returns(Buffer.from('jwt-token'));
+        const api = apiStub();
+        api.makeRequest.resolves({ auth: { client_token: 'vault-token' } });
+        const auth = new VaultKubernetesAuth(api, logger, { role: 'r' });
+        sinon.stub(auth, '_getTokenEntity').resolves(new AuthToken('id', 'acc', 0, null, 0, 0, false));
+
         expect(auth._mount).to.equal('kubernetes');
-        expect(auth.__tokenPath).to.equal('/var/run/secrets/kubernetes.io/serviceaccount/token');
+        return auth._authenticate().then(() => {
+            expect(readFileSync).to.have.been.calledWith('/var/run/secrets/kubernetes.io/serviceaccount/token');
+        });
     });
 
-    it('honours a custom mount and token path', function () {
-        const auth = new VaultKubernetesAuth(apiStub(), logger, { role: 'r', tokenPath: '/tmp/tok' }, 'k8s');
+    it('honours a custom mount and reads the kube token from a custom path', function () {
+        readFileSync = sinon.stub(fs, 'readFileSync').returns(Buffer.from('jwt-token'));
+        const api = apiStub();
+        api.makeRequest.resolves({ auth: { client_token: 'vault-token' } });
+        const auth = new VaultKubernetesAuth(api, logger, { role: 'r', tokenPath: '/tmp/tok' }, 'k8s');
+        sinon.stub(auth, '_getTokenEntity').resolves(new AuthToken('id', 'acc', 0, null, 0, 0, false));
+
         expect(auth._mount).to.equal('k8s');
-        expect(auth.__tokenPath).to.equal('/tmp/tok');
+        return auth._authenticate().then(() => {
+            expect(readFileSync).to.have.been.calledWith('/tmp/tok');
+        });
     });
 
     it('reads the JWT from disk and performs a login request', function () {


### PR DESCRIPTION
Follow-up to #91. Fixes the new AI findings on `src/VaultNodeConfig.js` plus the `test/auth.kubernetes.test.mjs` findings that were lost when #91 squash-merged before they landed.

## src/VaultNodeConfig.js (3 findings)
- **Empty-part validation** — `__parseSubstitutionValue` checked `=== undefined`, but `val.split('#')` always returns strings, so `'#value'` / `'path#'` slipped through. Now uses `if (!vaultPath || !value)`. Added a regression test for `'#value'`, `'secret/a#'`, `'#'`.
- **`for...in` → `for (const i of Object.keys(o))`** in `__traverse` — iterates own enumerable props only, so the `Object.hasOwn` guard is no longer needed.
- **Quote style** — `=== "object"` → `=== 'object'` to match the file.

## test/auth.kubernetes.test.mjs (3 findings)
- Rename the ambiguous `p` map arg to `level`.
- The two tests asserted the **private `__tokenPath`** field; rewritten to verify the behavior — which path `readFileSync` is called with — through the public `_authenticate()` flow.

## Verification
- `npm run lint` passes.
- `npm run test:unit` → **138 passing**, including "skips inherited (non-own) properties" (guards the `Object.keys` change) and the new "throws when either side of the '#' is empty".
- Full integration suite runs in CI.