### PR TITLE
chore(deps): drop pretty-ms and url-join

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,7 @@
         "@aws-sdk/credential-providers": "^3.382.0",
         "aws4": "^1.8.0",
         "lodash": "^4.17.21",
-        "long-timeout": "^0.1.1",
-        "pretty-ms": "^7.0.1",
-        "url-join": "^4.0.1"
+        "long-timeout": "^0.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
@@ -2180,15 +2178,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2255,21 +2244,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pretty-ms": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/punycode": {
@@ -2572,12 +2546,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
     "@aws-sdk/credential-providers": "^3.382.0",
     "aws4": "^1.8.0",
     "lodash": "^4.17.21",
-    "long-timeout": "^0.1.1",
-    "pretty-ms": "^7.0.1",
-    "url-join": "^4.0.1"
+    "long-timeout": "^0.1.1"
   },
   "peerDependencies": {
     "config": ">=1 <4"

--- a/src/VaultApiClient.js
+++ b/src/VaultApiClient.js
@@ -1,7 +1,26 @@
 'use strict';
 
-const urljoin = require('url-join');
 const _ = require('lodash');
+
+/**
+ * Joins URL segments with single slashes while preserving the leading
+ * protocol (e.g. "https://"). Replaces the former `url-join` dependency.
+ */
+function joinUrl(...parts) {
+    return parts
+        .map((part, i) => {
+            let segment = String(part);
+            if (i > 0) {
+                segment = segment.replace(/^\/+/, '');
+            }
+            if (i < parts.length - 1) {
+                segment = segment.replace(/\/+$/, '');
+            }
+            return segment;
+        })
+        .filter((segment) => segment.length > 0)
+        .join('/');
+}
 
 class VaultApiClient {
 
@@ -35,7 +54,7 @@ class VaultApiClient {
         data = data === undefined ? null : data;
         headers = headers === undefined ? {} : headers;
 
-        const uri = urljoin(this.__config.url, this.__config.apiVersion, path);
+        const uri = joinUrl(this.__config.url, this.__config.apiVersion, path);
 
         const requestOptions = this.__config.requestOptions || {};
 

--- a/src/auth/VaultBaseAuth.js
+++ b/src/auth/VaultBaseAuth.js
@@ -1,9 +1,25 @@
 'use strict';
 
 const lt = require('long-timeout');
-const prettyMs = require('pretty-ms');
 const AuthToken = require('./AuthToken');
 const errors = require('../errors');
+
+/**
+ * Formats a millisecond duration as a short human-readable string
+ * (e.g. "1s", "2m 5s", "1h 3m"). Replaces the former `pretty-ms` dependency.
+ */
+function humanizeMs(ms) {
+    const totalSeconds = Math.round(ms / 1000);
+    if (totalSeconds < 60) {
+        return `${totalSeconds}s`;
+    }
+    const totalMinutes = Math.floor(totalSeconds / 60);
+    if (totalMinutes < 60) {
+        return `${totalMinutes}m ${totalSeconds % 60}s`;
+    }
+    const hours = Math.floor(totalMinutes / 60);
+    return `${hours}h ${totalMinutes % 60}m`;
+}
 
 class VaultBaseAuth {
 
@@ -135,7 +151,7 @@ class VaultBaseAuth {
 
         this._log.debug(
             'sleeping for %s',
-            prettyMs(timer)
+            humanizeMs(timer)
         );
     }
 


### PR DESCRIPTION
Removes the last two runtime deps that keep the dependency badge non-green.

## Why
`pretty-ms@9` and `url-join@5` (the latest majors) are **pure ESM**, so this CommonJS package can't upgrade to them. libraries.io therefore flags them as out-of-date on the published package, and the dependency badge can't go green while they're present. Both are used in exactly one spot, so they're inlined:

- **url-join** → a small `joinUrl()` helper in `VaultApiClient` (preserves the leading protocol, single-slash joins between segments).
- **pretty-ms** → a small `humanizeMs()` helper in `VaultBaseAuth` for the `'sleeping for …'` debug log.

## Result
Runtime dependencies are now just:
`@aws-sdk/credential-providers`, `aws4`, `lodash`, `long-timeout` — all within range of their latest releases. Once this is **published**, libraries.io reports 0 out-of-date and the badge turns green.

## Verification
- `npm install` → **0 vulnerabilities**; `npm ls pretty-ms url-join` → gone.
- `joinUrl` checked against a trailing-slash base and a no-leading-slash path: `https://vault.example.com:8200/v1/secret/foo`, `http://h:1/v1/secret/bar`.
- `npm run lint` passes; `npm run test:unit` → **137 passing** (URL joining covered by the `VaultApiClient` tests); full e2e suite runs in CI.

> Note: merging this doesn't flip the badge by itself — the badge tracks the **published npm package**, so a new release must be published afterward.