### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.0.1 Release notes (2026-06-16)
+
+- Security: stop logging secrets at debug level. The Kubernetes auth backend no longer logs the
+  service-account JWT or the issued Vault client token, and `VaultApiClient` no longer logs full
+  response bodies (which carry auth tokens and secret reads). Debug logs now record only
+  non-sensitive metadata — token paths, request method/URI, and HTTP status codes.
+- Dependencies: drop four runtime dependencies. `bluebird` and `assign-deep` are replaced with
+  native promises and `lodash`; `pretty-ms` and `url-join` are inlined as small helpers (their
+  latest majors are ESM-only and cannot be used from this CommonJS package). The `lodash` floor is
+  raised to `^4.17.21`. Runtime dependencies are now `@aws-sdk/credential-providers`, `aws4`,
+  `lodash`, and `long-timeout`.
+- Reject malformed substitution values whose path or key is empty (e.g. `#value` or `path#`) with
+  `InvalidArgumentsError`, instead of failing later with a less clear error.
+
 # 2.0.0 Release notes (2026-06-12)
 
 - Fix a process that never exits after reading with a renewable token. The background

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-vault-client",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.382.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"


### PR DESCRIPTION
Release prep for **2.0.1**. Bumps the version and adds the CHANGELOG entry covering everything merged since 2.0.0.

**Leave open for review — do not merge until approved.** After this merges, cutting the `v2.0.1` GitHub release triggers trusted publishing, and libraries.io will re-scan the new dependency set (which turns the dependencies badge green).

## Changes
- `package.json` + `package-lock.json`: `2.0.0` → `2.0.1`.
- `CHANGELOG.md`: new `2.0.1` section.

## What 2.0.1 contains (since 2.0.0)
- **Security** — stop logging secrets at debug level (K8s JWT, Vault client token, full response bodies). (#89)
- **Dependencies** — drop `bluebird`, `assign-deep`, `pretty-ms`, `url-join`; raise `lodash` floor to `^4.17.21`. Runtime deps are now `@aws-sdk/credential-providers`, `aws4`, `lodash`, `long-timeout`. (#90, #93)
- **Validation** — reject substitution values with an empty path or key (`#value`, `path#`). (#92)

(Internal-only changes — the CI test/e2e split and code-quality refactors — are intentionally omitted from the changelog.)

No code changes here, so this is a version + docs bump only.