### PR TITLE
chore(deps): drop lodash runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.382.0",
         "aws4": "^1.8.0",
-        "lodash": "^4.17.21",
         "long-timeout": "^0.1.1"
       },
       "devDependencies": {
@@ -21,6 +20,7 @@
         "deep-freeze": "^0.0.1",
         "eslint": "^9.39.4",
         "globals": "^17.6.0",
+        "lodash": "^4.17.21",
         "mocha": "^11.7.6",
         "sinon": "^22.0.0",
         "sinon-chai": "^4.0.0"
@@ -1971,7 +1971,8 @@
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.382.0",
     "aws4": "^1.8.0",
-    "lodash": "^4.17.21",
     "long-timeout": "^0.1.1"
   },
   "peerDependencies": {
@@ -54,6 +53,7 @@
     "deep-freeze": "^0.0.1",
     "eslint": "^9.39.4",
     "globals": "^17.6.0",
+    "lodash": "^4.17.21",
     "mocha": "^11.7.6",
     "sinon": "^22.0.0",
     "sinon-chai": "^4.0.0"

--- a/src/Lease.js
+++ b/src/Lease.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 class Lease {
     constructor(
         requestId,
@@ -43,7 +41,7 @@ class Lease {
      * @returns {Object}
      */
     getData() {
-        return _.cloneDeep(this.__data);
+        return structuredClone(this.__data);
     }
 
     /**

--- a/src/VaultApiClient.js
+++ b/src/VaultApiClient.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  * Joins URL segments with single slashes while preserving the leading
  * protocol (e.g. "https://"). Replaces the former `url-join` dependency.
@@ -39,9 +37,12 @@ class VaultApiClient {
     constructor(config, logger) {
         const requestOptions = config && config.requestOptions;
 
-        this.__config = _.defaultsDeep(_.cloneDeep(_.omit(config, ['requestOptions'])), {
-            apiVersion: 'v1',
-        });
+        const baseConfig = { ...(config || {}) };
+        delete baseConfig.requestOptions;
+        this.__config = structuredClone(baseConfig);
+        if (this.__config.apiVersion === undefined) {
+            this.__config.apiVersion = 'v1';
+        }
 
         if (requestOptions !== undefined) {
             this.__config.requestOptions = requestOptions;

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const Lease = require('./Lease');
 const errors = require('./errors');
 const VaultApiClient = require('./VaultApiClient');
@@ -9,6 +8,8 @@ const VaultTokenAuth = require('./auth/VaultTokenAuth');
 const VaultIAMAuth = require('./auth/VaultIAMAuth');
 const VaultNodeConfig = require('./VaultNodeConfig');
 const VaultKubernetesAuth = require('./auth/VaultKubernetesAuth');
+
+const noop = () => {};
 const vaultInstances = {};
 
 class VaultClient {
@@ -264,13 +265,13 @@ class VaultClient {
     __setupLogger(logger) {
         if (logger === false) {
             return {
-                error: _.noop,
-                warn: _.noop,
-                info: _.noop,
-                debug: _.noop,
-                trace: _.noop,
+                error: noop,
+                warn: noop,
+                info: noop,
+                debug: noop,
+                trace: noop,
             }
-        } else if (_.intersection(_.functionsIn(logger), ['error', 'warn', 'info', 'debug', 'trace']).length >= 5) {
+        } else if (['error', 'warn', 'info', 'debug', 'trace'].every((method) => typeof logger?.[method] === 'function')) {
             return logger
         } else {
             return {
@@ -279,7 +280,7 @@ class VaultClient {
                 info: console.info,
                 trace: console.trace,
                 // avoid output sensitive information
-                debug: _.noop
+                debug: noop
             };
         }
     }

--- a/src/VaultNodeConfig.js
+++ b/src/VaultNodeConfig.js
@@ -16,9 +16,6 @@ function isPlainObject(value) {
     return proto === null || proto === Object.prototype;
 }
 
-// Keys that must never be merged, to avoid prototype pollution.
-const FORBIDDEN_MERGE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
 /**
  * Recursively merges own enumerable properties of `source` into `target`,
  * mutating and returning `target`. Nested objects and arrays are merged in
@@ -28,7 +25,7 @@ const FORBIDDEN_MERGE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
  */
 function deepMerge(target, source) {
     for (const key of Object.keys(source)) {
-        if (FORBIDDEN_MERGE_KEYS.has(key)) {
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
             continue;
         }
 

--- a/src/VaultNodeConfig.js
+++ b/src/VaultNodeConfig.js
@@ -1,9 +1,46 @@
 'use strict';
 
 const path = require('path');
-const _ = require('lodash');
 
 const errors = require('./errors');
+
+function isObject(value) {
+    return value !== null && typeof value === 'object';
+}
+
+function isPlainObject(value) {
+    if (!isObject(value)) {
+        return false;
+    }
+    const proto = Object.getPrototypeOf(value);
+    return proto === null || proto === Object.prototype;
+}
+
+/**
+ * Recursively merges own enumerable properties of `source` into `target`,
+ * mutating and returning `target`. Nested objects and arrays are merged in
+ * place, other values overwrite, and `undefined` source values are skipped.
+ * Covers the subset of `lodash.merge` behavior this client relies on.
+ */
+function deepMerge(target, source) {
+    for (const key of Object.keys(source)) {
+        const sourceValue = source[key];
+        if (sourceValue === undefined) {
+            continue;
+        }
+
+        const targetValue = target[key];
+        if (isObject(sourceValue) && isObject(targetValue)) {
+            deepMerge(targetValue, sourceValue);
+        } else if (isObject(sourceValue)) {
+            target[key] = structuredClone(sourceValue);
+        } else {
+            target[key] = sourceValue;
+        }
+    }
+
+    return target;
+}
 
 class VaultNodeConfig {
 
@@ -34,8 +71,9 @@ class VaultNodeConfig {
         const vaultPaths = Object.keys(requiredData);
 
         return Promise.all(vaultPaths.map((vaultPath) => this.__vault.read(vaultPath))).then((leases) => {
-            const results = _.zipObject(vaultPaths, leases);
-            requiredData = _.mapValues(requiredData, (value, vaultPath) => results[vaultPath].getData());
+            requiredData = Object.fromEntries(
+                vaultPaths.map((vaultPath, index) => [vaultPath, leases[index].getData()])
+            );
 
             this.__traverse(substitutionMap, (key, val, obj) => {
                 const { vaultPath, value } = this.__parseSubstitutionValue(val);
@@ -47,7 +85,7 @@ class VaultNodeConfig {
                 obj[key] = requiredData[vaultPath][value];
             });
 
-            return _.merge(this.__nodeConfig, substitutionMap);
+            return deepMerge(this.__nodeConfig, substitutionMap);
         });
     }
 
@@ -83,11 +121,11 @@ class VaultNodeConfig {
             throw new errors.VaultError('Config file ' + fullFilename + ' cannot be read');
         }
 
-        if (!_.isPlainObject(fileContent)) {
+        if (!isPlainObject(fileContent)) {
             throw new errors.VaultError('Config file ' + fullFilename + ' should return plain object');
         }
 
-        return _.cloneDeep(fileContent);
+        return structuredClone(fileContent);
     }
 
     __traverse(o, func) {

--- a/src/VaultNodeConfig.js
+++ b/src/VaultNodeConfig.js
@@ -16,14 +16,22 @@ function isPlainObject(value) {
     return proto === null || proto === Object.prototype;
 }
 
+// Keys that must never be merged, to avoid prototype pollution.
+const FORBIDDEN_MERGE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * Recursively merges own enumerable properties of `source` into `target`,
  * mutating and returning `target`. Nested objects and arrays are merged in
  * place, other values overwrite, and `undefined` source values are skipped.
- * Covers the subset of `lodash.merge` behavior this client relies on.
+ * Prototype-polluting keys (`__proto__`, `constructor`, `prototype`) are
+ * skipped. Covers the subset of `lodash.merge` behavior this client relies on.
  */
 function deepMerge(target, source) {
     for (const key of Object.keys(source)) {
+        if (FORBIDDEN_MERGE_KEYS.has(key)) {
+            continue;
+        }
+
         const sourceValue = source[key];
         if (sourceValue === undefined) {
             continue;

--- a/src/auth/VaultIAMAuth.js
+++ b/src/auth/VaultIAMAuth.js
@@ -3,7 +3,6 @@
 const VaultBaseAuth = require('./VaultBaseAuth');
 const aws4 = require('aws4');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
-const _ = require('lodash');
 const errors = require('../errors');
 
 /**
@@ -194,7 +193,9 @@ class VaultIAMAuth extends VaultBaseAuth {
      * @private
      */
     __headersLikeGolangStyle(headers) {
-        return _.mapValues(headers, (value) => [`${value}`]);
+        return Object.fromEntries(
+            Object.entries(headers).map(([key, value]) => [key, [`${value}`]])
+        );
     }
 
     _validateCredentialsConfig(credentials) {

--- a/test/VaultClient.test.mjs
+++ b/test/VaultClient.test.mjs
@@ -192,8 +192,10 @@ describe('VaultClient', function () {
 
         it('returns an all-noop logger when given false', function () {
             const log = client.__setupLogger(false);
-            expect(log.error).to.equal(_.noop);
-            expect(log.debug).to.equal(_.noop);
+            for (const method of ['error', 'warn', 'info', 'debug', 'trace']) {
+                expect(log[method]).to.be.a('function');
+                expect(log[method]()).to.be.undefined;
+            }
         });
 
         it('returns the supplied logger when it implements the full interface', function () {
@@ -205,7 +207,9 @@ describe('VaultClient', function () {
             const log = client.__setupLogger({});
             expect(log.error).to.equal(console.error);
             expect(log.warn).to.equal(console.warn);
-            expect(log.debug).to.equal(_.noop);
+            expect(log.debug).to.be.a('function');
+            expect(log.debug).to.not.equal(console.debug);
+            expect(log.debug()).to.be.undefined;
         });
     });
 


### PR DESCRIPTION
## What

Removes `lodash` from the runtime dependency tree, replacing every `src/` call site with native JavaScript. `lodash` moves to `devDependencies` (the test suite still uses it). Runtime dependencies are now `@aws-sdk/credential-providers`, `aws4`, and `long-timeout`.

This addresses the npm/Socket "module-replacements" advisory flagging `lodash` as replaceable with native APIs, and continues the dependency-reduction direction of v2.0.1.

## Replacements

| Was | Now |
| --- | --- |
| `_.cloneDeep` (×3) | `structuredClone` (global, Node ≥ 18) |
| `_.noop` (×6) | a single module-level `const noop = () => {}` |
| `_.intersection(_.functionsIn(logger), [...]).length >= 5` | `[...].every(m => typeof logger?.[m] === 'function')` |
| `_.omit` + `_.cloneDeep` + `_.defaultsDeep` (VaultApiClient ctor) | shallow copy + `delete requestOptions` + `structuredClone` + explicit `apiVersion` default |
| `_.mapValues` (×2) | `Object.fromEntries(Object.entries(...).map(...))` |
| `_.zipObject` + `_.mapValues` (VaultNodeConfig) | one `Object.fromEntries(vaultPaths.map(...))` |
| `_.isPlainObject` | 5-line prototype check |
| `_.merge` | small recursive `deepMerge` helper |

## Compatibility

Public interfaces and runtime behavior are unchanged. The only internal nuance: a disabled logger (`logger: false`) now returns the client's own `noop` instead of `lodash`'s `_.noop`; the no-op contract is identical. One unit test that asserted identity against `_.noop` was updated to assert the behavioral contract.

`structuredClone` is safe at every clone site: the `requestOptions` object (which may hold a live undici dispatcher) is excluded *before* the clone and re-attached by reference, exactly as before; all other cloned data is plain config / secret JSON.

## Tests

- `eslint src/` — clean
- `npm run test:unit` — 138 passing, including the nested `deepMerge` path and the updated `__setupLogger` tests

Version/CHANGELOG intentionally untouched — to be handled in the release PR.
