### PR TITLE
feat: backport KV v2 support to legacy 1.0.x (Node 16 compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,114 @@ vaultClient.read('secret/tst').then(v => {
 }).catch(e => console.error(e));
 ```
 
+## KV v2 support
+
+This release adds transparent support for the [KV v2 secrets engine](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2)
+on top of the existing KV v1 / raw passthrough behaviour.
+
+**It is fully opt-in and non-breaking.** With no extra configuration the client behaves exactly as
+before: every path is treated as KV v1 / raw passthrough and no extra request is made. KV v2 is
+activated per mount by setting `api.kv.autoDetect: true` **or** by supplying a static `api.engines`
+map. Once enabled, the client rewrites paths (`secret/foo` → `secret/data/foo`) and unwraps the
+nested KV v2 response automatically — callers never deal with the `data/` / `metadata/` segments
+themselves.
+
+### Configuration options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `api.kv.autoDetect` | `boolean` | `false` | Auto-detect the KV version of each mount on first use via `GET sys/internal/ui/mounts/<path>`. The result is cached per mount for the lifetime of the client. |
+| `api.engines` | `Object` | `{}` | Static mount-to-version map, e.g. `{ secret: 2, legacy: 1 }`. Listed mounts resolve with no detection round-trip; use this when the token lacks permission on `sys/internal/ui/mounts`. |
+
+`engines` always takes precedence over detection, so the two can be combined: matching mounts use
+the map while unmatched mounts are auto-detected (when `autoDetect: true`) or treated as v1.
+
+### KV v1 (default — nothing to configure)
+
+```javascript
+const client = VaultClient.boot('main', {
+    api: { url: 'https://vault.example.com:8200/' },
+    auth: { type: 'token', config: { token: '...' } },
+});
+
+const lease = await client.read('secret/my-app/config'); // GET secret/my-app/config
+console.log(lease.getData());      // the secret object
+console.log(lease.getMetadata());  // undefined on KV v1
+```
+
+### KV v2
+
+Pass **logical** paths only — the client inserts the `data/` (and `metadata/` for `list`) segment
+for you.
+
+```javascript
+const client = VaultClient.boot('main', {
+    api: {
+        url: 'https://vault.example.com:8200/',
+        engines: { secret: 2 },          // or: kv: { autoDetect: true }
+    },
+    auth: { type: 'token', config: { token: '...' } },
+});
+
+// read  → GET    secret/data/my-app/config, response.data.data is unwrapped automatically
+const lease = await client.read('secret/my-app/config');
+console.log(lease.getData());      // the secret values
+console.log(lease.getMetadata());  // { version, created_time, ... } on KV v2
+
+// write → POST   secret/data/my-app/config with { data: { ... } } wrapping done for you
+await client.write('secret/my-app/config', { password: 's3cr3t' });
+
+// list  → LIST   secret/metadata/my-app
+await client.list('secret/my-app');
+```
+
+### Mixed v1 + v2 mounts on one client
+
+Version resolution is **per mount**, so a single client can talk to v1 and v2 mounts at the same
+time. List each mount's version in `api.engines`:
+
+```javascript
+const client = VaultClient.boot('main', {
+    api: {
+        url: 'https://vault.example.com:8200/',
+        engines: {
+            'secret-v2': 2,   // KV v2 mount
+            // 'secret' is not listed → treated as KV v1 (passthrough)
+        },
+    },
+    auth: { type: 'token', config: { token: '...' } },
+});
+
+await client.read('secret/legacy/app');        // v1 → GET secret/legacy/app
+await client.read('secret-v2/app/config');     // v2 → GET secret-v2/data/app/config
+await client.read('database/creds/app-role');  // not KV  → passthrough, GET as-is
+```
+
+Or let the client figure it out with `autoDetect` (requires the token to read
+`sys/internal/ui/mounts`):
+
+```javascript
+const client = VaultClient.boot('main', {
+    api: { url: 'https://vault.example.com:8200/', kv: { autoDetect: true } },
+    auth: { type: 'token', config: { token: '...' } },
+});
+
+await client.read('secret/legacy/app');     // detected as v1
+await client.read('secret-v2/app/config');  // detected as v2
+```
+
+### Notes & caveats
+
+- **Do not include KV v2 segments in the path.** Pass `secret/foo`, not `secret/data/foo` — the
+  latter would be rewritten to `secret/data/data/foo` on a v2 mount.
+- **Vault policy must allow the v2 paths.** KV v2 reads hit `<mount>/data/...` (and `list` hits
+  `<mount>/metadata/...`), so the auth token's policy must grant capabilities on those paths, not
+  on the logical path.
+- Non-KV backends (database, transit, etc.) are always treated as passthrough — leave them out of
+  `api.engines`, and `autoDetect` recognises them as non-KV automatically.
+- If detection fails (e.g. permission denied) and no `api.engines` override matches, the read
+  rejects with a `VaultError` — set `api.engines` to bypass detection in that case.
+
 ## Supported Auth Backends
 
 * [AWS IAM](https://www.vaultproject.io/docs/auth/aws.html#iam-auth-method)
@@ -65,6 +173,9 @@ Client constructor function.
 | options.api | <code>Object</code> |  |  |
 | options.api.url | <code>String</code> |  | the url of the vault server |
 | [options.api.apiVersion] | <code>String</code> | `v1` |  |
+| [options.api.kv] | <code>Object</code> |  | KV engine options |
+| [options.api.kv.autoDetect] | <code>boolean</code> | `false` | Auto-detect the KV version per mount via `GET sys/internal/ui/mounts/<path>`. |
+| [options.api.engines] | <code>Object</code> | `{}` | Static mount-to-version map, e.g. `{ secret: 2, legacy: 1 }`. Overrides detection. |
 | options.auth | <code>Object</code> |  |  |
 | options.auth.type | <code>String</code> |  |  |
 | options.auth.config | <code>Object</code> |  | auth configuration variables |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"

--- a/src/Lease.js
+++ b/src/Lease.js
@@ -15,7 +15,7 @@ class Lease {
         this.__leaseId = leaseId;
         this.__leaseDuration = leaseDuration;
         this.__renewable = renewable;
-        this.__data = data === undefined ? {} : data;
+        this.__data = (data === undefined || data === null) ? {} : data;
         this.__metadata = metadata;
     }
 

--- a/src/Lease.js
+++ b/src/Lease.js
@@ -8,13 +8,15 @@ class Lease {
         leaseId,
         leaseDuration,
         renewable,
-        data
+        data,
+        metadata
     ) {
         this.__requestId = requestId;
         this.__leaseId = leaseId;
         this.__leaseDuration = leaseDuration;
         this.__renewable = renewable;
         this.__data = data === undefined ? {} : data;
+        this.__metadata = metadata;
     }
 
     static fromResponse(response) {
@@ -23,7 +25,8 @@ class Lease {
             response.lease_id,
             response.lease_duration,
             response.renewable,
-            response.data
+            response.data,
+            response.metadata
         );
     }
 
@@ -51,6 +54,16 @@ class Lease {
      */
     isRenewable() {
         return this.__renewable;
+    }
+
+    /**
+     * KV v2 version metadata object (created_time, version, etc.).
+     * Returns undefined for KV v1 / non-KV leases.
+     *
+     * @returns {Object|undefined}
+     */
+    getMetadata() {
+        return this.__metadata;
     }
 }
 

--- a/src/MountResolver.js
+++ b/src/MountResolver.js
@@ -132,7 +132,7 @@ class MountResolver {
                 const type = info.type || 'unknown';
                 const optVersion = info.options && info.options.version;
                 // Only kv v2 gets special treatment; everything else is passthrough
-                const version = (type === 'kv' && optVersion === '2') ? 2 : 1;
+                const version = (type === 'kv' && Number(optVersion) === 2) ? 2 : 1;
 
                 const entry = { mount: canonicalMount, version, type };
                 this.__log.debug('MountResolver: detected %s as type=%s version=%d', canonicalMount, type, version);

--- a/src/MountResolver.js
+++ b/src/MountResolver.js
@@ -1,0 +1,167 @@
+'use strict';
+
+const { VaultError } = require('./errors');
+
+/**
+ * Resolves the KV engine version for a given secret path.
+ *
+ * Responsibilities:
+ *  1. Check engines override map first (longest-prefix match, no I/O).
+ *  2. Auto-detect via detectFn(path) -> { data: { path, type, options } }.
+ *  3. Cache by canonical mount path; de-duplicate in-flight detections.
+ *  4. On failure, throw VaultError with actionable guidance.
+ *
+ * @param {Function} detectFn          - async (path: string) => Vault mount-info response
+ * @param {Object}   enginesOverride   - { [mountPrefix]: version }
+ * @param {Object}   logger            - logger with .debug(), .error() etc.
+ * @param {Object}   [opts]            - additional options
+ * @param {boolean}  [opts.disabled]   - if true, always return passthrough (version 1)
+ */
+class MountResolver {
+    constructor(detectFn, enginesOverride, logger, opts) {
+        this.__detectFn = detectFn;
+        this.__engines = enginesOverride || {};
+        this.__log = logger;
+        this.__disabled = opts && opts.disabled === true;
+
+        // Cache: canonical mount path (no trailing slash) -> { mount, version, type }
+        this.__cache = new Map();
+        // In-flight promises: canonical mount path -> Promise<{mount,version,type}>
+        this.__inflight = new Map();
+    }
+
+    /**
+     * Resolve the engine version for the given path.
+     *
+     * @param {string} path - full logical path (e.g. "secret/foo/bar")
+     * @returns {Promise<{mount: string, version: number, type: string}>}
+     */
+    resolve(path) {
+        // 1. Check engines override (longest-prefix match). This applies even when
+        //    auto-detection is disabled, so listed mounts resolve with no I/O.
+        const override = this.__enginesOverrideLookup(path);
+        if (override !== null) {
+            this.__log.debug('MountResolver: engines override for %s -> v%d', path, override.version);
+            return Promise.resolve(override);
+        }
+
+        // 2. When detection is disabled (autoDetect off), an unlisted mount is a
+        //    passthrough (v1) — never issue a sys/internal/ui/mounts round-trip.
+        //    engines is the documented fallback for Vaults that deny detection.
+        if (this.__disabled) {
+            return Promise.resolve({ mount: this.__extractMount(path), version: 1, type: 'kv' });
+        }
+
+        // 3. Auto-detect: use canonical mount path as cache key once we know it.
+        //    For the in-flight grouping key we use the first path segment so that
+        //    concurrent reads of sub-paths of the SAME mount (e.g. secret/a and
+        //    secret/b) share one detection.  After the shared promise resolves we
+        //    verify that the canonical mount returned actually prefixes this path;
+        //    if it does not (two distinct multi-segment mounts share a first segment,
+        //    e.g. team/kvA/* and team/kvB/*), we start a fresh detection using the
+        //    full path as key so each mount gets its own call.
+        const interimKey = path.split('/')[0];
+        return this.__detectWithCache(interimKey, path);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Longest-prefix match against the engines override map.
+     * Returns { mount, version } or null if no match found.
+     */
+    __enginesOverrideLookup(path) {
+        const entries = Object.entries(this.__engines);
+        if (entries.length === 0) return null;
+
+        // Sort by descending key length (longest first) for prefix match
+        entries.sort((a, b) => b[0].length - a[0].length);
+
+        for (const [prefix, version] of entries) {
+            const normalised = prefix.replace(/\/+$/, '');
+            if (path === normalised || path.startsWith(normalised + '/')) {
+                return { mount: normalised, version: Number(version), type: 'kv' };
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolve via cache or detectFn.  Groups concurrent calls by interimKey so
+     * only one detectFn call is in-flight per first-segment at a time.
+     *
+     * Followers that join a shared in-flight promise verify that the resolved
+     * canonical mount actually prefixes their path.  If it does not (two distinct
+     * multi-segment mounts share a first segment, e.g. "team/kvA" and "team/kvB"),
+     * the follower falls through to start its own fresh detection keyed on its
+     * full path, so each mount gets its own accurate detection result.
+     */
+    __detectWithCache(interimKey, path) {
+        // Check persistent cache first (keyed on canonical mount path)
+        for (const [mountKey, entry] of this.__cache) {
+            if (path === mountKey || path.startsWith(mountKey + '/')) {
+                return Promise.resolve(entry);
+            }
+        }
+
+        // Check in-flight for this interim key (first segment or full path)
+        if (this.__inflight.has(interimKey)) {
+            // Join the existing in-flight promise but verify the result matches our path.
+            // If the detection was for a different sub-mount, start a fresh detection.
+            return this.__inflight.get(interimKey).then((entry) => {
+                if (path === entry.mount || path.startsWith(entry.mount + '/')) {
+                    return entry;
+                }
+                // The shared detection resolved to a different mount — start our own.
+                // Use the full path as key so it won't collide with the first-segment key.
+                return this.__detectWithCache(path, path);
+            });
+        }
+
+        // Start a new detection
+        const promise = this.__detectFn(path)
+            .then((response) => {
+                const info = response && response.data;
+                if (!info) {
+                    throw new Error('Unexpected empty detection response');
+                }
+
+                const canonicalMount = (info.path || interimKey).replace(/\/+$/, '');
+                const type = info.type || 'unknown';
+                const optVersion = info.options && info.options.version;
+                // Only kv v2 gets special treatment; everything else is passthrough
+                const version = (type === 'kv' && optVersion === '2') ? 2 : 1;
+
+                const entry = { mount: canonicalMount, version, type };
+                this.__log.debug('MountResolver: detected %s as type=%s version=%d', canonicalMount, type, version);
+
+                // Store in persistent cache
+                this.__cache.set(canonicalMount, entry);
+                // Clear in-flight
+                this.__inflight.delete(interimKey);
+                return entry;
+            })
+            .catch((err) => {
+                // Clear in-flight so callers can retry
+                this.__inflight.delete(interimKey);
+                throw new VaultError(
+                    `Failed to detect KV engine version for mount "${interimKey}" (path: ${path}): ${err.message}. ` +
+                    'Set api.engines or disable autoDetect to bypass detection.'
+                );
+            });
+
+        this.__inflight.set(interimKey, promise);
+        return promise;
+    }
+
+    /**
+     * Simple first-segment extraction used only for the disabled path.
+     */
+    __extractMount(path) {
+        return path.split('/')[0];
+    }
+}
+
+module.exports = MountResolver;

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -9,6 +9,8 @@ const VaultTokenAuth = require('./auth/VaultTokenAuth');
 const VaultIAMAuth = require('./auth/VaultIAMAuth');
 const VaultNodeConfig = require('./VaultNodeConfig');
 const VaultKubernetesAuth = require('./auth/VaultKubernetesAuth');
+const MountResolver = require('./MountResolver');
+const { rewritePath, normalizeResponse } = require('./kvTransform');
 const vaultInstances = {};
 
 class VaultClient {
@@ -20,6 +22,14 @@ class VaultClient {
      * @param {Object} options.api
      * @param {String} options.api.url - the url of the vault server
      * @param {String} [options.api.apiVersion='v1']
+     * @param {Object} [options.api.kv] - KV engine options
+     * @param {boolean} [options.api.kv.autoDetect=false] - When true, auto-detect the KV version per mount
+     *      via a `sys/internal/ui/mounts/<path>` round-trip. When false (default) no detection call is
+     *      ever made and read/list/write behave byte-for-byte as before unless an engine is
+     *      listed in `options.api.engines`.
+     * @param {Object} [options.api.engines] - Static mount-to-version overrides, e.g. `{ secret: 2, legacy: 1 }`.
+     *      Listed mounts resolve without any detection round-trip (works even with autoDetect off), making
+     *      this a reliable fallback for Vaults that deny the detection endpoint.
      * @param {Object} options.auth
      * @param {String} options.auth.type
      * @param {Object} options.auth.config - auth configuration variables
@@ -43,6 +53,25 @@ class VaultClient {
         );
 
         this.__namespace = options.auth.config.namespace;
+
+        // KV v2 support (opt-in, non-breaking).
+        const kvOpts = (options.api && options.api.kv) || {};
+        const autoDetect = kvOpts.autoDetect === true;
+        const engines = (options.api && options.api.engines) || {};
+
+        // Detection (the sys/internal/ui/mounts round-trip) only happens when
+        // autoDetect is on. With engines set but autoDetect off, listed mounts use
+        // the override and any other mount is passthrough (v1) — no detection call
+        // is ever made. This keeps the default byte-for-byte and makes engines a
+        // working fallback for Vaults that deny the detection endpoint.
+        const resolverDisabled = !autoDetect;
+
+        // Build detectFn lazily — it uses __auth and __api which are already set above.
+        const detectFn = (path) => this.__detectMount(path);
+
+        this.__resolver = new MountResolver(detectFn, engines, this.__log, {
+            disabled: resolverDisabled,
+        });
     }
 
     /**
@@ -173,6 +202,81 @@ class VaultClient {
         return {'X-Vault-Token': token.getId()}
     }
 
+    // -------------------------------------------------------------------------
+    // Detection helper (used by MountResolver's detectFn)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Calls GET sys/internal/ui/mounts/<path> with the current auth token.
+     * Returns the parsed Vault response body.
+     * @private
+     */
+    __detectMount(path) {
+        return this.__auth.getAuthToken()
+            .then((token) => {
+                const detectPath = `sys/internal/ui/mounts/${path}`;
+                return this.__api.makeRequest('GET', detectPath, null, this.getHeaders(token));
+            });
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal resolve + request helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resolve the mount version for a path, rewrite the path, make the request,
+     * and return a { apiPath, body, version, mount } object.
+     *
+     * When the resolver is disabled (autoDetect:false, no matching engine), it
+     * preserves the caller's literal path byte-for-byte, keeping behaviour
+     * identical to the pre-KV-v2 client.
+     *
+     * @private
+     */
+    __resolveAndRequest(op, method, path, data) {
+        return this.__auth.getAuthToken()
+            .then((token) => {
+                const headers = this.getHeaders(token);
+
+                return this.__resolver.resolve(path)
+                    .then((resolved) => {
+                        const mount = resolved.mount;
+                        const version = resolved.version;
+                        let apiPath;
+                        let requestData = data;
+
+                        if (version === 2) {
+                            // Split the path into mount + logical sub-path and rewrite for KV v2
+                            const logicalPath = this.__logicalPath(path, mount);
+                            apiPath = rewritePath(version, op, mount, logicalPath);
+                            // Wrap data in { data: ... } on v2 writes
+                            if (op === 'write' && data !== null && data !== undefined) {
+                                requestData = { data };
+                            }
+                        } else {
+                            // v1 / disabled: preserve the caller's literal path byte-for-byte,
+                            // including any trailing slash, to maintain the old wire behaviour.
+                            apiPath = path;
+                        }
+
+                        return this.__api.makeRequest(method, apiPath, requestData, headers)
+                            .then((body) => ({ body, version, mount, apiPath }));
+                    });
+            });
+    }
+
+    /**
+     * Extract the logical path after the mount prefix.
+     * e.g. path='secret/foo/bar', mount='secret' => 'foo/bar'
+     * @private
+     */
+    __logicalPath(path, mount) {
+        const prefix = mount.replace(/\/+$/, '');
+        if (path === prefix) return '';
+        if (path.startsWith(prefix + '/')) return path.slice(prefix.length + 1);
+        return path;
+    }
+
     /**
      * Read secret from Vault
      * @param {string} path - path to the secret
@@ -180,11 +284,11 @@ class VaultClient {
      */
     read(path) {
         this.__log.debug('read secret %s', path);
-        return this.__auth.getAuthToken()
-            .then(token => this.__api.makeRequest('GET', path, null, this.getHeaders(token)))
-            .then(res => {
+        return this.__resolveAndRequest('read', 'GET', path, null)
+            .then(({ body, version }) => {
                 this.__log.debug('receive secret %s', path);
-                return Lease.fromResponse(res);
+                const normalised = normalizeResponse(version, 'read', body);
+                return Lease.fromResponse(normalised);
             })
             .catch((reason) => {
                 this.__log.error('read secret failed: %s', reason.message);
@@ -200,11 +304,11 @@ class VaultClient {
      */
     list(path) {
         this.__log.debug('list secrets %s', path);
-        return this.__auth.getAuthToken()
-            .then(token => this.__api.makeRequest('LIST', path, null, this.getHeaders(token)))
-            .then(res => {
+        return this.__resolveAndRequest('list', 'LIST', path, null)
+            .then(({ body, version }) => {
                 this.__log.debug('got secrets list %s', path);
-                return Lease.fromResponse(res);
+                const normalised = normalizeResponse(version, 'list', body);
+                return Lease.fromResponse(normalised);
             })
             .catch((reason) => {
                 this.__log.error('list secrets failed: %s', reason.message);
@@ -221,11 +325,10 @@ class VaultClient {
      */
     write(path, data) {
         this.__log.debug('write secret %s', path);
-        return this.__auth.getAuthToken()
-            .then((token) => this.__api.makeRequest('POST', path, data, this.getHeaders(token)))
-            .then((response) => {
+        return this.__resolveAndRequest('write', 'POST', path, data)
+            .then(({ body }) => {
                 this.__log.debug('secret %s was written', path);
-                return response;
+                return body;
             })
             .catch((reason) => {
                 this.__log.error('write secret failed: %s', reason.message);

--- a/src/kvTransform.js
+++ b/src/kvTransform.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * Pure KV path-rewriting and response-normalizing helpers.
+ * No I/O; fully testable in isolation.
+ *
+ * rewritePath(version, op, mount, logicalPath) -> apiPath
+ * normalizeResponse(version, op, body)         -> normalized body
+ */
+
+// Map of op -> v2 path segment inserted between mount and logical path.
+const V2_SEGMENT = {
+    read:            'data',
+    write:           'data',
+    delete:          'data',
+    update:          'data',
+    list:            'metadata',
+    readMetadata:    'metadata',
+    deleteMetadata:  'metadata',
+    deleteVersions:  'delete',
+    undeleteVersions:'undelete',
+    destroyVersions: 'destroy',
+};
+
+/**
+ * Rewrite a logical path to the correct API path for the given engine version.
+ *
+ * @param {number} version   - Engine version (2 = KV v2; anything else = passthrough)
+ * @param {string} op        - Operation name (read, write, list, delete, update, …)
+ * @param {string} mount     - Mount point (e.g. "secret" or "secret/")
+ * @param {string} logicalPath - Path relative to the mount (e.g. "team/svc")
+ * @returns {string}
+ */
+function rewritePath(version, op, mount, logicalPath) {
+    // Normalise trailing slash on mount
+    const m = mount.replace(/\/+$/, '');
+
+    if (version !== 2) {
+        // v1 / non-kv: simple concatenation
+        return logicalPath ? `${m}/${logicalPath}` : m;
+    }
+
+    const segment = V2_SEGMENT[op] || 'data';
+    return `${m}/${segment}/${logicalPath}`;
+}
+
+/**
+ * Normalise a Vault API response body for the given engine version and operation.
+ *
+ * For v1 / non-kv the body is always returned as-is.
+ * For v2:
+ *  - read:         body.data is replaced with body.data.data; body.metadata is set to body.data.metadata
+ *  - readMetadata: body.data is replaced with the original body.data (unwrapped one level)
+ *  - write/delete/update/…: body returned as-is
+ *
+ * @param {number} version
+ * @param {string} op
+ * @param {*}      body
+ * @returns {*}
+ */
+function normalizeResponse(version, op, body) {
+    if (version !== 2) {
+        return body;
+    }
+
+    if (op === 'read') {
+        if (!body || !body.data) {
+            return body;
+        }
+        // Promote inner data/metadata to top-level response fields
+        const result = Object.assign({}, body);
+        result.metadata = body.data.metadata;
+        result.data = body.data.data;
+        return result;
+    }
+
+    if (op === 'readMetadata') {
+        if (!body || !body.data) {
+            return body;
+        }
+        const result = Object.assign({}, body);
+        result.data = body.data;
+        return result;
+    }
+
+    // All other v2 ops (write, list, delete, update, deleteVersions, …): passthrough
+    return body;
+}
+
+module.exports = { rewritePath, normalizeResponse };

--- a/test/MountResolver.test.js
+++ b/test/MountResolver.test.js
@@ -1,0 +1,305 @@
+'use strict';
+
+/**
+ * Unit tests for MountResolver.
+ * Uses a mock detectFn so no real HTTP is performed.
+ */
+
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const sinonChai = require('sinon-chai');
+const MountResolver = require('../src/MountResolver');
+const errors = require('../src/errors');
+
+chai.use(sinonChai);
+
+// Helper that builds a detection response for a given version
+function mkDetect(mount, version, type = 'kv') {
+    return Promise.resolve({
+        data: {
+            path: mount.endsWith('/') ? mount : mount + '/',
+            type,
+            options: { version: String(version) },
+        },
+    });
+}
+
+describe('MountResolver', function () {
+    const logger = {
+        debug: sinon.stub(),
+        info: sinon.stub(),
+        warn: sinon.stub(),
+        error: sinon.stub(),
+        trace: sinon.stub(),
+    };
+
+    // -------------------------------------------------------------------------
+    // engines override — must skip detectFn entirely
+    // -------------------------------------------------------------------------
+    describe('engines override', function () {
+        it('returns version from engines map without calling detectFn', async function () {
+            const detectFn = sinon.stub().rejects(new Error('should not be called'));
+            const resolver = new MountResolver(detectFn, { secret: 2, legacy: 1 }, logger);
+
+            const result = await resolver.resolve('secret/foo');
+            expect(detectFn).to.not.have.been.called;
+            expect(result.version).to.equal(2);
+            expect(result.mount).to.equal('secret');
+        });
+
+        it('returns version 1 for a v1 engine override', async function () {
+            const detectFn = sinon.stub().rejects(new Error('should not be called'));
+            const resolver = new MountResolver(detectFn, { legacy: 1 }, logger);
+
+            const result = await resolver.resolve('legacy/path');
+            expect(detectFn).to.not.have.been.called;
+            expect(result.version).to.equal(1);
+            expect(result.mount).to.equal('legacy');
+        });
+
+        it('longest-prefix wins when multiple engines match', async function () {
+            const detectFn = sinon.stub().rejects(new Error('should not be called'));
+            // "secret/team" is more specific than "secret"
+            const resolver = new MountResolver(detectFn, { secret: 1, 'secret/team': 2 }, logger);
+
+            const r1 = await resolver.resolve('secret/team/svc');
+            expect(r1.version).to.equal(2);
+            expect(r1.mount).to.equal('secret/team');
+
+            const r2 = await resolver.resolve('secret/other/svc');
+            expect(r2.version).to.equal(1);
+            expect(r2.mount).to.equal('secret');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // auto-detection via detectFn
+    // -------------------------------------------------------------------------
+    describe('auto-detection', function () {
+        it('detects KV v2 by calling detectFn and returns correct result', async function () {
+            const detectFn = sinon.stub().callsFake((p) => mkDetect('secret', 2));
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            const result = await resolver.resolve('secret/foo');
+            expect(detectFn).to.have.been.calledOnce;
+            expect(result.version).to.equal(2);
+            expect(result.mount).to.equal('secret');
+            expect(result.type).to.equal('kv');
+        });
+
+        it('detects KV v1 by calling detectFn', async function () {
+            const detectFn = sinon.stub().callsFake(() => mkDetect('kvv1', 1));
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            const result = await resolver.resolve('kvv1/foo');
+            expect(result.version).to.equal(1);
+            expect(result.mount).to.equal('kvv1');
+        });
+
+        it('detects non-kv mounts as passthrough (version 1)', async function () {
+            const detectFn = sinon.stub().resolves({
+                data: { path: 'transit/', type: 'transit', options: {} },
+            });
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            const result = await resolver.resolve('transit/encrypt/key');
+            expect(result.version).to.equal(1);
+            expect(result.type).to.equal('transit');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // caching — detectFn must be called only once per canonical mount
+    // -------------------------------------------------------------------------
+    describe('caching', function () {
+        it('calls detectFn only once for the same mount', async function () {
+            const detectFn = sinon.stub().callsFake(() => mkDetect('secret', 2));
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            await resolver.resolve('secret/foo');
+            await resolver.resolve('secret/bar');
+            await resolver.resolve('secret/baz');
+
+            expect(detectFn).to.have.been.calledOnce;
+        });
+
+        it('caches independently for different mounts', async function () {
+            const detectFn = sinon.stub().callsFake((p) => {
+                if (p.startsWith('secret/')) return mkDetect('secret', 2);
+                if (p.startsWith('legacy/')) return mkDetect('legacy', 1);
+                return Promise.reject(new Error('unexpected'));
+            });
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            const r1 = await resolver.resolve('secret/foo');
+            const r2 = await resolver.resolve('legacy/bar');
+
+            expect(detectFn).to.have.been.calledTwice;
+            expect(r1.version).to.equal(2);
+            expect(r2.version).to.equal(1);
+
+            // Further calls must not re-detect
+            await resolver.resolve('secret/baz');
+            await resolver.resolve('legacy/qux');
+            expect(detectFn).to.have.been.calledTwice;
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // in-flight dedupe — concurrent first-touch must only call detectFn once
+    // -------------------------------------------------------------------------
+    describe('in-flight dedupe', function () {
+        it('does not issue concurrent detectFn calls for the same mount', async function () {
+            let resolve;
+            const pending = new Promise((res) => { resolve = res; });
+            const detectFn = sinon.stub().callsFake(() =>
+                pending.then(() => ({
+                    data: { path: 'secret/', type: 'kv', options: { version: '2' } },
+                }))
+            );
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            // Fire three concurrent resolves before detection completes
+            const p1 = resolver.resolve('secret/a');
+            const p2 = resolver.resolve('secret/b');
+            const p3 = resolver.resolve('secret/c');
+
+            // Unblock the detection
+            resolve();
+            const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+            // detectFn must have been called exactly once
+            expect(detectFn).to.have.been.calledOnce;
+            expect(r1.version).to.equal(2);
+            expect(r2.version).to.equal(2);
+            expect(r3.version).to.equal(2);
+        });
+
+        it('concurrent resolutions of distinct multi-segment mounts sharing a first segment each get the correct version (regression)', async function () {
+            // "team/kvA" is v2; "team/kvB" is v1.  Both share first segment "team".
+            // Previously, interimKey = "team" for both, collapsing them into one detection call
+            // and returning the wrong version for the second mount.
+            let resolveA, resolveB;
+            const pendingA = new Promise((res) => { resolveA = res; });
+            const pendingB = new Promise((res) => { resolveB = res; });
+
+            let callIndex = 0;
+            const detectFn = sinon.stub().callsFake((p) => {
+                callIndex++;
+                if (p.startsWith('team/kvA')) {
+                    return pendingA.then(() => ({
+                        data: { path: 'team/kvA/', type: 'kv', options: { version: '2' } },
+                    }));
+                }
+                return pendingB.then(() => ({
+                    data: { path: 'team/kvB/', type: 'kv', options: { version: '1' } },
+                }));
+            });
+
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            const pA = resolver.resolve('team/kvA/secret1');
+            const pB = resolver.resolve('team/kvB/secret2');
+
+            // Unblock both detections
+            resolveA();
+            resolveB();
+            const [rA, rB] = await Promise.all([pA, pB]);
+
+            // Each mount must resolve to its own correct version
+            expect(rA.mount).to.equal('team/kvA');
+            expect(rA.version).to.equal(2);
+            expect(rB.mount).to.equal('team/kvB');
+            expect(rB.version).to.equal(1);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // failure handling
+    // -------------------------------------------------------------------------
+    describe('failure handling', function () {
+        it('throws VaultError when detectFn rejects', async function () {
+            const detectFn = sinon.stub().rejects(new Error('403 Forbidden'));
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            try {
+                await resolver.resolve('secret/foo');
+                throw new Error('expected rejection');
+            } catch (err) {
+                expect(err).to.be.instanceOf(errors.VaultError);
+                expect(err.message).to.include('secret');
+            }
+        });
+
+        it('clears the in-flight entry on failure so future calls retry', async function () {
+            let callCount = 0;
+            const detectFn = sinon.stub().callsFake(() => {
+                callCount++;
+                if (callCount === 1) return Promise.reject(new Error('transient'));
+                return mkDetect('secret', 2);
+            });
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            // First call fails
+            await resolver.resolve('secret/foo').catch(() => {});
+
+            // Second call should succeed (retry after failure)
+            const result = await resolver.resolve('secret/foo');
+            expect(result.version).to.equal(2);
+            expect(detectFn).to.have.been.calledTwice;
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // longest-prefix detection with auto-detect
+    // -------------------------------------------------------------------------
+    describe('longest-prefix matching from detection response', function () {
+        it('uses the canonical mount path from data.path for cache key', async function () {
+            // Vault returns canonical path with trailing slash
+            const detectFn = sinon.stub().resolves({
+                data: { path: 'secret/', type: 'kv', options: { version: '2' } },
+            });
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            await resolver.resolve('secret/foo');
+            await resolver.resolve('secret/bar');
+
+            expect(detectFn).to.have.been.calledOnce;
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // disabled resolver (no autoDetect, no engines)
+    // -------------------------------------------------------------------------
+    describe('disabled resolver', function () {
+        it('resolve() returns passthrough (version 1) without calling detectFn when disabled', async function () {
+            const detectFn = sinon.stub().rejects(new Error('should not be called'));
+            const resolver = new MountResolver(detectFn, {}, logger, { disabled: true });
+
+            const result = await resolver.resolve('secret/foo');
+            expect(detectFn).to.not.have.been.called;
+            expect(result.version).to.equal(1);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // engines-only mode (autoDetect off, engines set) — how VaultClient wires it
+    // -------------------------------------------------------------------------
+    describe('engines-only mode (autoDetect off, engines set)', function () {
+        it('applies the engines override for listed mounts but passes unlisted mounts through without detection', async function () {
+            const detectFn = sinon.stub().rejects(new Error('should not be called'));
+            // VaultClient sets disabled:true whenever autoDetect is off, but still
+            // passes the engines map so listed mounts resolve without a detection call.
+            const resolver = new MountResolver(detectFn, { secret: 2 }, logger, { disabled: true });
+
+            const listed = await resolver.resolve('secret/foo');
+            expect(listed.version).to.equal(2);
+            expect(listed.mount).to.equal('secret');
+
+            const unlisted = await resolver.resolve('other/bar');
+            expect(unlisted.version).to.equal(1);
+            expect(detectFn).to.not.have.been.called;
+        });
+    });
+});

--- a/test/VaultClient.kv2.test.js
+++ b/test/VaultClient.kv2.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+/**
+ * Integration-style unit tests for the KV v2 awareness wired into VaultClient.
+ *
+ * The VaultApiClient.makeRequest and the auth provider's getAuthToken are stubbed,
+ * so no real HTTP happens. These tests assert path rewriting, data wrapping and
+ * response normalization for read/list/write across v1 (passthrough),
+ * engines override and autoDetect.
+ */
+
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const sinonChai = require('sinon-chai');
+
+const VaultClient = require('../src/VaultClient');
+
+chai.use(sinonChai);
+
+const FAKE_TOKEN = { getId: () => 'test-token' };
+
+function buildClient(apiOverrides) {
+    const options = {
+        api: Object.assign({ url: 'https://vault.example.com/' }, apiOverrides),
+        logger: false,
+        auth: {
+            type: 'token',
+            config: { token: 'XXXXXXXX-eb8e-5f25-fad2-79274fa13a64' },
+        },
+    };
+
+    const client = new VaultClient(options);
+
+    // Avoid any real auth network round-trip.
+    sinon.stub(client.__auth, 'getAuthToken').resolves(FAKE_TOKEN);
+
+    const makeRequest = sinon.stub(client.__api, 'makeRequest');
+    return { client, makeRequest };
+}
+
+// Each test builds a fresh `new VaultClient`, so stubs live on per-test instances
+// and need no global teardown (sinon 2 has no global sinon.restore()).
+describe('VaultClient KV v2 awareness', function () {
+
+    // -------------------------------------------------------------------------
+    // Default (no kv config) — byte-for-byte passthrough (v1 behaviour)
+    // -------------------------------------------------------------------------
+    describe('default (no kv options) — passthrough', function () {
+        it('read uses the literal path and never issues a detection call', async function () {
+            const { client, makeRequest } = buildClient();
+            makeRequest.resolves({ data: { foo: 'bar' } });
+
+            const lease = await client.read('secret/app/cfg');
+
+            expect(makeRequest).to.have.been.calledOnce;
+            expect(makeRequest).to.have.been.calledWith('GET', 'secret/app/cfg', null);
+            expect(lease.getData()).to.deep.equal({ foo: 'bar' });
+        });
+
+        it('write posts the raw data to the literal path (no { data } wrapping)', async function () {
+            const { client, makeRequest } = buildClient();
+            makeRequest.resolves({});
+
+            await client.write('secret/app/cfg', { foo: 'bar' });
+
+            expect(makeRequest).to.have.been.calledWith('POST', 'secret/app/cfg', { foo: 'bar' });
+        });
+
+        it('list uses the literal path', async function () {
+            const { client, makeRequest } = buildClient();
+            makeRequest.resolves({ data: { keys: ['a', 'b'] } });
+
+            const lease = await client.list('secret');
+
+            expect(makeRequest).to.have.been.calledWith('LIST', 'secret', null);
+            expect(lease.getData()).to.deep.equal({ keys: ['a', 'b'] });
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // engines override (autoDetect off) — no detection call, version from map
+    // -------------------------------------------------------------------------
+    describe('engines override', function () {
+        it('read rewrites to data/ and unwraps body.data.data + metadata for a v2 mount', async function () {
+            const { client, makeRequest } = buildClient({ engines: { secret: 2 } });
+            makeRequest.resolves({
+                request_id: 'rid',
+                data: {
+                    data: { username: 'admin', password: 's3cr3t' },
+                    metadata: { version: 4, created_time: '2024-01-01' },
+                },
+            });
+
+            const lease = await client.read('secret/app/cfg');
+
+            expect(makeRequest).to.have.been.calledOnce;
+            expect(makeRequest).to.have.been.calledWith('GET', 'secret/data/app/cfg', null);
+            expect(lease.getData()).to.deep.equal({ username: 'admin', password: 's3cr3t' });
+            expect(lease.getMetadata()).to.deep.equal({ version: 4, created_time: '2024-01-01' });
+        });
+
+        it('write wraps data in { data } and targets data/ for a v2 mount', async function () {
+            const { client, makeRequest } = buildClient({ engines: { secret: 2 } });
+            makeRequest.resolves({ data: { version: 1 } });
+
+            await client.write('secret/app/cfg', { foo: 'bar' });
+
+            expect(makeRequest).to.have.been.calledWith('POST', 'secret/data/app/cfg', { data: { foo: 'bar' } });
+        });
+
+        it('list targets metadata/ for a v2 mount', async function () {
+            const { client, makeRequest } = buildClient({ engines: { secret: 2 } });
+            makeRequest.resolves({ data: { keys: ['app/'] } });
+
+            const lease = await client.list('secret');
+
+            expect(makeRequest).to.have.been.calledWith('LIST', 'secret/metadata/', null);
+            expect(lease.getData()).to.deep.equal({ keys: ['app/'] });
+        });
+
+        it('a v1 engine override behaves as passthrough', async function () {
+            const { client, makeRequest } = buildClient({ engines: { legacy: 1 } });
+            makeRequest.resolves({ data: { foo: 'bar' } });
+
+            await client.read('legacy/app/cfg');
+
+            expect(makeRequest).to.have.been.calledWith('GET', 'legacy/app/cfg', null);
+        });
+
+        it('mounts not listed in engines stay passthrough and trigger no detection', async function () {
+            const { client, makeRequest } = buildClient({ engines: { secret: 2 } });
+            makeRequest.resolves({ data: { foo: 'bar' } });
+
+            await client.read('other/app/cfg');
+
+            expect(makeRequest).to.have.been.calledOnce;
+            expect(makeRequest).to.have.been.calledWith('GET', 'other/app/cfg', null);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // autoDetect — one sys/internal/ui/mounts round-trip, then the rewritten op
+    // -------------------------------------------------------------------------
+    describe('autoDetect', function () {
+        it('detects a v2 mount, then reads from data/ and unwraps the payload', async function () {
+            const { client, makeRequest } = buildClient({ kv: { autoDetect: true } });
+
+            makeRequest
+                .withArgs('GET', 'sys/internal/ui/mounts/secret/app/cfg')
+                .resolves({ data: { path: 'secret/', type: 'kv', options: { version: '2' } } });
+            makeRequest
+                .withArgs('GET', 'secret/data/app/cfg')
+                .resolves({ data: { data: { foo: 'bar' }, metadata: { version: 2 } } });
+
+            const lease = await client.read('secret/app/cfg');
+
+            expect(makeRequest).to.have.been.calledWith('GET', 'sys/internal/ui/mounts/secret/app/cfg');
+            expect(makeRequest).to.have.been.calledWith('GET', 'secret/data/app/cfg', null);
+            expect(lease.getData()).to.deep.equal({ foo: 'bar' });
+            expect(lease.getMetadata()).to.deep.equal({ version: 2 });
+        });
+
+        it('detects a v1 mount and reads from the literal path', async function () {
+            const { client, makeRequest } = buildClient({ kv: { autoDetect: true } });
+
+            makeRequest
+                .withArgs('GET', 'sys/internal/ui/mounts/kv1/app/cfg')
+                .resolves({ data: { path: 'kv1/', type: 'kv', options: { version: '1' } } });
+            makeRequest
+                .withArgs('GET', 'kv1/app/cfg')
+                .resolves({ data: { foo: 'bar' } });
+
+            const lease = await client.read('kv1/app/cfg');
+
+            expect(makeRequest).to.have.been.calledWith('GET', 'kv1/app/cfg', null);
+            expect(lease.getData()).to.deep.equal({ foo: 'bar' });
+        });
+
+        it('caches detection — a second op on the same mount issues no new detection call', async function () {
+            const { client, makeRequest } = buildClient({ kv: { autoDetect: true } });
+
+            makeRequest
+                .withArgs('GET', 'sys/internal/ui/mounts/secret/a')
+                .resolves({ data: { path: 'secret/', type: 'kv', options: { version: '2' } } });
+            makeRequest.resolves({ data: { data: { foo: 'bar' } } });
+
+            await client.read('secret/a');
+            await client.read('secret/b');
+
+            const detectionCalls = makeRequest.getCalls()
+                .filter((c) => c.args[1].startsWith('sys/internal/ui/mounts/'));
+            expect(detectionCalls).to.have.length(1);
+        });
+    });
+});

--- a/test/kvTransform.test.js
+++ b/test/kvTransform.test.js
@@ -1,0 +1,243 @@
+'use strict';
+
+/**
+ * Exhaustive pure unit tests for kvTransform: rewritePath + normalizeResponse.
+ * Every op x {v1, v2}.
+ */
+
+const chai = require('chai');
+const expect = chai.expect;
+const { rewritePath, normalizeResponse } = require('../src/kvTransform');
+
+describe('kvTransform', function () {
+
+    // -------------------------------------------------------------------------
+    // rewritePath(version, op, mount, logicalPath)
+    // -------------------------------------------------------------------------
+    describe('rewritePath', function () {
+
+        // v1 (or non-kv) — always passthrough: mount + logicalPath
+        describe('v1 / non-kv (version !== 2)', function () {
+            const cases = [
+                ['read',           'secret', 'foo',        'secret/foo'],
+                ['read',           'secret', 'foo/bar',    'secret/foo/bar'],
+                ['list',           'secret', 'foo',        'secret/foo'],
+                ['list',           'secret', '',           'secret'],
+                ['write',          'secret', 'foo',        'secret/foo'],
+                ['delete',         'secret', 'foo',        'secret/foo'],
+                ['update',         'secret', 'foo',        'secret/foo'],
+            ];
+            cases.forEach(([op, mount, lp, expected]) => {
+                it(`${op}('${mount}','${lp}') => '${expected}'`, function () {
+                    expect(rewritePath(1, op, mount, lp)).to.equal(expected);
+                });
+            });
+
+            // v2-only ops on v1 => still return a path (caller throws; rewritePath is pure)
+            it('deleteVersions on v1 still produces a path (caller decides to throw)', function () {
+                expect(rewritePath(1, 'deleteVersions', 'secret', 'foo')).to.equal('secret/foo');
+            });
+        });
+
+        // v2 rewriting
+        describe('v2 path rewriting', function () {
+            it('read: inserts data/ segment', function () {
+                expect(rewritePath(2, 'read', 'secret', 'foo')).to.equal('secret/data/foo');
+            });
+
+            it('read: nested path', function () {
+                expect(rewritePath(2, 'read', 'secret', 'team/svc')).to.equal('secret/data/team/svc');
+            });
+
+            it('read: empty logical path', function () {
+                expect(rewritePath(2, 'read', 'secret', '')).to.equal('secret/data/');
+            });
+
+            it('write: inserts data/ segment', function () {
+                expect(rewritePath(2, 'write', 'secret', 'foo')).to.equal('secret/data/foo');
+            });
+
+            it('list: inserts metadata/ segment', function () {
+                expect(rewritePath(2, 'list', 'secret', 'foo')).to.equal('secret/metadata/foo');
+            });
+
+            it('list: empty logical path', function () {
+                expect(rewritePath(2, 'list', 'secret', '')).to.equal('secret/metadata/');
+            });
+
+            it('delete: inserts data/ segment (soft-delete latest)', function () {
+                expect(rewritePath(2, 'delete', 'secret', 'foo')).to.equal('secret/data/foo');
+            });
+
+            it('update: inserts data/ segment', function () {
+                expect(rewritePath(2, 'update', 'secret', 'foo')).to.equal('secret/data/foo');
+            });
+
+            it('deleteVersions: inserts delete/ segment', function () {
+                expect(rewritePath(2, 'deleteVersions', 'secret', 'foo')).to.equal('secret/delete/foo');
+            });
+
+            it('undeleteVersions: inserts undelete/ segment', function () {
+                expect(rewritePath(2, 'undeleteVersions', 'secret', 'foo')).to.equal('secret/undelete/foo');
+            });
+
+            it('destroyVersions: inserts destroy/ segment', function () {
+                expect(rewritePath(2, 'destroyVersions', 'secret', 'foo')).to.equal('secret/destroy/foo');
+            });
+
+            it('readMetadata: inserts metadata/ segment', function () {
+                expect(rewritePath(2, 'readMetadata', 'secret', 'foo')).to.equal('secret/metadata/foo');
+            });
+
+            it('deleteMetadata: inserts metadata/ segment', function () {
+                expect(rewritePath(2, 'deleteMetadata', 'secret', 'foo')).to.equal('secret/metadata/foo');
+            });
+
+            it('mount with trailing slash is handled', function () {
+                expect(rewritePath(2, 'read', 'secret/', 'foo')).to.equal('secret/data/foo');
+            });
+
+            it('mount without trailing slash, nested lp', function () {
+                expect(rewritePath(2, 'read', 'kv', 'a/b/c')).to.equal('kv/data/a/b/c');
+            });
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // normalizeResponse(version, op, body)
+    // -------------------------------------------------------------------------
+    describe('normalizeResponse', function () {
+
+        // v1 — always return body unchanged
+        describe('v1 / non-kv (version !== 2)', function () {
+            const ops = ['read', 'list', 'write', 'delete', 'update',
+                'deleteVersions', 'undeleteVersions', 'destroyVersions',
+                'readMetadata', 'deleteMetadata'];
+
+            ops.forEach((op) => {
+                it(`${op} on v1 returns body unchanged`, function () {
+                    const body = { data: { k: 'v' }, request_id: 'r' };
+                    expect(normalizeResponse(1, op, body)).to.equal(body);
+                });
+            });
+        });
+
+        // v2 responses
+        describe('v2 response normalization', function () {
+
+            it('read: returns body with data replaced by body.data.data and metadata added', function () {
+                const body = {
+                    request_id: 'rid',
+                    data: {
+                        data: { username: 'admin', password: 'secret' },
+                        metadata: { version: 3, created_time: '2024-01-01' },
+                    },
+                };
+                const result = normalizeResponse(2, 'read', body);
+                // Should look like a standard Vault read response with data = inner data
+                expect(result.data).to.deep.equal({ username: 'admin', password: 'secret' });
+                expect(result.metadata).to.deep.equal({ version: 3, created_time: '2024-01-01' });
+                expect(result.request_id).to.equal('rid');
+            });
+
+            it('read: handles missing inner data gracefully', function () {
+                const body = { data: {} };
+                const result = normalizeResponse(2, 'read', body);
+                expect(result.data).to.be.undefined;
+                expect(result.metadata).to.be.undefined;
+            });
+
+            it('read: returns null unchanged when body is null', function () {
+                const body = null;
+                const result = normalizeResponse(2, 'read', body);
+                expect(result).to.equal(null);
+            });
+
+            it('read: returns body unchanged when body.data is null', function () {
+                const body = { data: null };
+                const result = normalizeResponse(2, 'read', body);
+                expect(result).to.equal(body);
+            });
+
+            it('read: returns body unchanged when body.data is undefined', function () {
+                const body = { data: undefined };
+                const result = normalizeResponse(2, 'read', body);
+                expect(result).to.equal(body);
+            });
+
+            it('write: returns raw body unchanged', function () {
+                const body = { data: { version: 1 }, request_id: 'r' };
+                const result = normalizeResponse(2, 'write', body);
+                expect(result).to.equal(body);
+            });
+
+            it('list: returns body unchanged (keys already at body.data.keys)', function () {
+                const body = { data: { keys: ['foo', 'bar/'] } };
+                const result = normalizeResponse(2, 'list', body);
+                expect(result).to.equal(body);
+            });
+
+            it('delete: returns body unchanged', function () {
+                const body = null;
+                const result = normalizeResponse(2, 'delete', body);
+                expect(result).to.equal(null);
+            });
+
+            it('update: returns body unchanged', function () {
+                const body = { data: { version: 2 } };
+                const result = normalizeResponse(2, 'update', body);
+                expect(result).to.equal(body);
+            });
+
+            it('deleteVersions: returns body unchanged', function () {
+                const body = {};
+                const result = normalizeResponse(2, 'deleteVersions', body);
+                expect(result).to.equal(body);
+            });
+
+            it('undeleteVersions: returns body unchanged', function () {
+                const body = {};
+                const result = normalizeResponse(2, 'undeleteVersions', body);
+                expect(result).to.equal(body);
+            });
+
+            it('destroyVersions: returns body unchanged', function () {
+                const body = {};
+                const result = normalizeResponse(2, 'destroyVersions', body);
+                expect(result).to.equal(body);
+            });
+
+            it('readMetadata: preserves envelope and metadata payload in data', function () {
+                const body = {
+                    request_id: 'r',
+                    data: { current_version: 2, versions: { '1': {}, '2': {} } },
+                };
+                const result = normalizeResponse(2, 'readMetadata', body);
+                expect(result).to.deep.equal({
+                    request_id: 'r',
+                    data: { current_version: 2, versions: { '1': {}, '2': {} } },
+                });
+                expect(result).to.not.equal(body);
+                // readMetadata only re-creates the envelope; the metadata payload
+                // is preserved (by reference) in result.data — it is not deep-copied.
+                expect(result.data).to.equal(body.data);
+            });
+
+            it('deleteMetadata: returns body unchanged', function () {
+                const body = null;
+                const result = normalizeResponse(2, 'deleteMetadata', body);
+                expect(result).to.equal(null);
+            });
+        });
+
+        // null/undefined body edge cases
+        describe('null/undefined body edge cases', function () {
+            it('v1 read with null body returns null', function () {
+                expect(normalizeResponse(1, 'read', null)).to.equal(null);
+            });
+            it('v2 delete with undefined body returns undefined', function () {
+                expect(normalizeResponse(2, 'delete', undefined)).to.equal(undefined);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Backport the opt-in, non-breaking KV v2 awareness from the 2.x line onto the request-promise based 1.0.x line, which still supports Node 16 (the 2.x line requires Node 18 via native fetch).

Scope is intentionally core only: version-aware read/list/write. The delete()/update() methods, raw request() and the v2-only version verbs (deleteVersions/undeleteVersions/destroyVersions/readMetadata/ deleteMetadata) are NOT backported.

src:
- kvTransform.js, MountResolver.js: ported verbatim from master (pure CommonJS, no fetch dependency)
- VaultClient: read/list/write become version-aware when enabled via api.kv.autoDetect or api.engines; with neither set behaviour is byte-for-byte identical to 1.0.2 and no sys/internal/ui/mounts call is ever made
- Lease: optional v2 metadata + getMetadata() (undefined on v1)

tests: no toolchain changes. Existing devDependencies and test files are left exactly as in 1.0.2; new kvTransform/MountResolver/VaultClient KV v2 unit tests are written for the same chai 3 / mocha 3 / sinon 2 stack.

document KV v2 support and v1/v2/mixed usage in README.

bump version to 1.0.3.

## Summary

<!-- What does this PR do? Why? -->

## Changes

<!-- List the files changed and why -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI / tooling

## Checklist

- [ ] Tests added or updated
- [ ] `npm run lint && npm test` passes locally
- [ ] User-facing changes recorded under `# Unreleased` in `CHANGELOG.md`
- [ ] All commits have a `Signed-off-by:` trailer (`git commit -s`)
