### PR TITLE
Expand test coverage and scope CI to release/1.0.x (Node 16/18/20)

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -2,30 +2,41 @@ name: Node.js CI
 on:
   push:
     branches:
-      - '**'
+      - release/1.0.x
   pull_request:
     branches:
-      - master
+      - release/1.0.x
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/release/1.0.x' }}
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [16, 18, 20]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Build the Docker Compose stack
-        run: docker compose up -d
+      - name: Start Vault (docker compose)
+        run: docker compose up -d --wait
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci && npm install 'config@<4'
+        run: npm ci && npm install config
 
       - name: Run tests
         run: npm test

--- a/test/auth.kubernetes.test.js
+++ b/test/auth.kubernetes.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const _ = require('lodash');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+const VaultApiClient = require('../src/VaultApiClient');
+const VaultKubernetesAuth = require('../src/auth/VaultKubernetesAuth');
+
+const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], function (prop) { return [prop, _.noop]; }));
+
+describe('Kubernetes auth backend', function () {
+    function getApiStub() {
+        return sinon.createStubInstance(VaultApiClient);
+    }
+
+    const jwt = 'header.payload.signature';
+    let tokenFile;
+
+    beforeEach(function () {
+        tokenFile = path.join(os.tmpdir(), 'k8s-jwt-' + Date.now() + '-' + Math.floor(Math.random() * 1e6));
+        fs.writeFileSync(tokenFile, jwt);
+    });
+
+    afterEach(function () {
+        try { fs.unlinkSync(tokenFile); } catch (e) { /* ignore */ }
+    });
+
+    it('logs in against the default "kubernetes" mount with role + jwt from the token file', async function () {
+        const api = getApiStub();
+        const auth = new VaultKubernetesAuth(api, logger, { role: 'my-role', tokenPath: tokenFile });
+        api.makeRequest.withArgs('POST').resolves({ auth: { client_token: 'fake_token' } });
+        sinon.stub(auth, '_getTokenEntity');
+
+        await auth._authenticate();
+
+        expect(api.makeRequest.calledWith(
+            'POST',
+            '/auth/kubernetes/login',
+            { role: 'my-role', jwt: jwt }
+        )).to.be.true;
+        expect(auth._getTokenEntity.calledWith('fake_token')).to.be.true;
+    });
+
+    it('uses a custom mount point when provided', async function () {
+        const api = getApiStub();
+        const auth = new VaultKubernetesAuth(api, logger, { role: 'my-role', tokenPath: tokenFile }, 'k8s-custom');
+        api.makeRequest.withArgs('POST').resolves({ auth: { client_token: 'fake_token' } });
+        sinon.stub(auth, '_getTokenEntity');
+
+        await auth._authenticate();
+
+        expect(api.makeRequest.calledWith(
+            'POST',
+            '/auth/k8s-custom/login',
+            { role: 'my-role', jwt: jwt }
+        )).to.be.true;
+    });
+
+    it('reads the JWT from a custom tokenPath', async function () {
+        const api = getApiStub();
+        const customPath = path.join(os.tmpdir(), 'k8s-jwt-custom-' + Date.now() + '-' + Math.floor(Math.random() * 1e6));
+        fs.writeFileSync(customPath, 'custom-jwt-value');
+        const auth = new VaultKubernetesAuth(api, logger, { role: 'r', tokenPath: customPath });
+        api.makeRequest.withArgs('POST').resolves({ auth: { client_token: 'fake_token' } });
+        sinon.stub(auth, '_getTokenEntity');
+
+        await auth._authenticate();
+
+        const body = api.makeRequest.getCall(0).args[2];
+        expect(body.jwt).to.equal('custom-jwt-value');
+        fs.unlinkSync(customPath);
+    });
+
+    it('propagates an error when the token file is missing', function () {
+        const api = getApiStub();
+        const auth = new VaultKubernetesAuth(api, logger, { role: 'r', tokenPath: '/no/such/path/token-' + Date.now() });
+        sinon.stub(auth, '_getTokenEntity');
+
+        expect(function () { auth._authenticate(); }).to.throw();
+    });
+});

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -190,4 +190,44 @@ describe('E2E', function () {
         });
     });
 
+    describe('Read/Write/List edge cases', function () {
+        it('read() of a non-existent secret rejects', function* () {
+            const vaultClient = new VaultClient(this.bootOpts);
+            let threw = false;
+            try {
+                yield vaultClient.read('secret/does-not-exist-' + Date.now());
+            } catch (e) {
+                threw = true;
+            }
+            expect(threw).to.equal(true);
+        });
+
+        it('write() then read() round-trips on a nested path', function* () {
+            const vaultClient = new VaultClient(this.bootOpts);
+            const data = { a: 'first', n: 1 };
+            yield vaultClient.write('/secret/nested/path/key', data);
+            const res = yield vaultClient.read('secret/nested/path/key');
+            expect(res.getData()).to.deep.equal(data);
+        });
+
+        it('write() overwrites and read() returns the latest value', function* () {
+            const vaultClient = new VaultClient(this.bootOpts);
+            yield vaultClient.write('/secret/overwrite-me', { v: 'one' });
+            yield vaultClient.write('/secret/overwrite-me', { v: 'two' });
+            const res = yield vaultClient.read('secret/overwrite-me');
+            expect(res.getData()).to.deep.equal({ v: 'two' });
+        });
+
+        it('list() of a non-existent path rejects', function* () {
+            const vaultClient = new VaultClient(this.bootOpts);
+            let threw = false;
+            try {
+                yield vaultClient.list('secret/no-such-prefix-' + Date.now());
+            } catch (e) {
+                threw = true;
+            }
+            expect(threw).to.equal(true);
+        });
+    });
+
 });

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const errors = require('../src/errors');
+
+describe('errors', function () {
+    it('exposes the expected error constructors', function () {
+        expect(errors.VaultError).to.be.a('function');
+        expect(errors.InvalidArgumentsError).to.be.a('function');
+        expect(errors.InvalidAWSCredentialsError).to.be.a('function');
+        expect(errors.AuthTokenExpiredError).to.be.a('function');
+    });
+
+    it('VaultError is an Error and sets name to the class name', function () {
+        const e = new errors.VaultError('boom');
+        expect(e).to.be.instanceof(Error);
+        expect(e.name).to.equal('VaultError');
+        expect(e.message).to.equal('boom');
+    });
+
+    it('InvalidArgumentsError extends VaultError', function () {
+        const e = new errors.InvalidArgumentsError('bad args');
+        expect(e).to.be.instanceof(errors.VaultError);
+        expect(e).to.be.instanceof(Error);
+        expect(e.name).to.equal('InvalidArgumentsError');
+        expect(e.message).to.equal('bad args');
+    });
+
+    it('InvalidAWSCredentialsError extends InvalidArgumentsError and VaultError', function () {
+        const e = new errors.InvalidAWSCredentialsError('no creds');
+        expect(e).to.be.instanceof(errors.InvalidArgumentsError);
+        expect(e).to.be.instanceof(errors.VaultError);
+        expect(e.name).to.equal('InvalidAWSCredentialsError');
+    });
+
+    it('AuthTokenExpiredError extends VaultError', function () {
+        const e = new errors.AuthTokenExpiredError('expired');
+        expect(e).to.be.instanceof(errors.VaultError);
+        expect(e.name).to.equal('AuthTokenExpiredError');
+    });
+});

--- a/test/lease.test.js
+++ b/test/lease.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const Lease = require('../src/Lease');
+
+describe('Lease', function () {
+    const response = {
+        request_id: 'req-1',
+        lease_id: 'lease-1',
+        lease_duration: 3600,
+        renewable: true,
+        data: { foo: 'bar', n: 42 },
+    };
+
+    it('fromResponse() maps fields and exposes data via getData()', function () {
+        const lease = Lease.fromResponse(response);
+        expect(lease).to.be.instanceof(Lease);
+        expect(lease.getData()).to.deep.equal({ foo: 'bar', n: 42 });
+        expect(lease.isRenewable()).to.equal(true);
+    });
+
+    it('getValue() returns the value for an existing key', function () {
+        const lease = Lease.fromResponse(response);
+        expect(lease.getValue('foo')).to.equal('bar');
+        expect(lease.getValue('n')).to.equal(42);
+    });
+
+    it('getValue() throws for a missing key', function () {
+        const lease = Lease.fromResponse(response);
+        expect(function () { lease.getValue('nope'); }).to.throw('Requested key does not exist');
+    });
+
+    it('getData() returns a deep clone (mutating the result does not affect the lease)', function () {
+        const lease = Lease.fromResponse(response);
+        const data = lease.getData();
+        data.foo = 'mutated';
+        expect(lease.getData().foo).to.equal('bar');
+    });
+
+    it('defaults data to an empty object when the response has no data', function () {
+        const lease = Lease.fromResponse({ request_id: 'r', lease_id: 'l', lease_duration: 0, renewable: false });
+        expect(lease.getData()).to.deep.equal({});
+        expect(lease.isRenewable()).to.equal(false);
+    });
+
+    it('constructor with undefined data yields an empty object', function () {
+        const lease = new Lease('r', 'l', 0, false, undefined);
+        expect(lease.getData()).to.deep.equal({});
+    });
+});


### PR DESCRIPTION
## What
- Add unit tests: Kubernetes auth (mocked API + temp JWT file), Lease behavior, error class hierarchy.
- Add real-Vault e2e tests: read/list of non-existent paths reject, nested write→read round-trip, overwrite returns latest.
- Scope CI (`.github/workflows/pipeline.yaml`) to the `release/1.0.x` branch only; modernize actions to checkout/setup-node v6 (SHA-pinned); Node matrix 16/18/20 (drop EOL 14); add concurrency.

## Why
Guarantee the 1.0.x line works against a real Vault and that public interfaces are not broken.

## Notes
- No `src/` changes. No new dependencies.
- Kubernetes/IAM auth are unit-only (cannot e2e without a real k8s/AWS).