### PR TITLE
fix: stop logging raw Vault client_token at debug level (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.0.2 Release notes (2026-07-02)
+
+- Security: stop logging the raw Vault `client_token` at debug level. The AppRole (`VaultAppRoleAuth`)
+  and AWS IAM (`VaultIAMAuth`) backends logged `auth.client_token` verbatim on every successful
+  login, and `VaultBaseAuth` logged the raw token id when arming the renewal timer. With a custom
+  debug logger wired up — exactly what the README recommends — this wrote a replayable Vault token
+  into durable logs on every authentication. These sites now log the non-sensitive token
+  `accessor` instead. This completes the same class of fix shipped for the Kubernetes backend and
+  response bodies in 2.0.1. Closes #104.
+
 # 2.0.1 Release notes (2026-06-16)
 
 - Security: stop logging secrets at debug level. The Kubernetes auth backend no longer logs the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-vault-client",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.382.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"

--- a/src/auth/VaultAppRoleAuth.js
+++ b/src/auth/VaultAppRoleAuth.js
@@ -37,8 +37,8 @@ class VaultAppRoleAuth extends VaultBaseAuth {
             secret_id: this.__secretId,
         }, headers).then(res => {
             this._log.debug(
-                'receive token: %s',
-                res.auth.client_token
+                'received token (accessor=%s)',
+                res.auth.accessor
             );
             return this._getTokenEntity(res.auth.client_token);
         });

--- a/src/auth/VaultBaseAuth.js
+++ b/src/auth/VaultBaseAuth.js
@@ -64,8 +64,8 @@ class VaultBaseAuth {
 
                 if (this.__authToken.isRenewable()) {
                     this._log.debug(
-                        'setting refresh timer for token %s',
-                        authToken.getId()
+                        'setting refresh timer for token (accessor=%s)',
+                        authToken.getAccessor()
                     );
                     this.__setupTokenRefreshTimer(this.__authToken);
                 }

--- a/src/auth/VaultIAMAuth.js
+++ b/src/auth/VaultIAMAuth.js
@@ -106,8 +106,8 @@ class VaultIAMAuth extends VaultBaseAuth {
             })
             .then((response) => {
                 this._log.debug(
-                    'receive token: %s',
-                    response.auth.client_token
+                    'received token (accessor=%s)',
+                    response.auth.accessor
                 );
                 return this._getTokenEntity(response.auth.client_token)
             })

--- a/test/auth.appRole.test.mjs
+++ b/test/auth.appRole.test.mjs
@@ -7,9 +7,21 @@ import VaultAppRoleAuth from '../src/auth/VaultAppRoleAuth.js';
 
 use(sinonChai);
 
-const logger = _.fromPairs(
-  _.map(['error', 'warn', 'info', 'debug', 'trace'], (prop) => [prop, _.noop]),
-);
+const LOG_METHODS = ['error', 'warn', 'info', 'debug', 'trace'];
+
+const logger = _.fromPairs(_.map(LOG_METHODS, (prop) => [prop, _.noop]));
+
+function spyLogger() {
+  return _.fromPairs(_.map(LOG_METHODS, (prop) => [prop, sinon.spy()]));
+}
+
+// Flatten every argument passed to a logger call into a single searchable string,
+// covering both printf-style args and object logging (%j / %o).
+function loggedText(log) {
+  return _.flatMap(LOG_METHODS, (m) => _.flatMap(log[m].getCalls(), (c) => c.args))
+    .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+    .join(' ');
+}
 
 describe('AppRole auth backend', function () {
   function getApiStub() {
@@ -103,6 +115,36 @@ describe('AppRole auth backend', function () {
           {},
         ),
       ).to.be.true;
+    });
+  });
+
+  describe('does not leak the client_token to the logger (regression #104)', function () {
+    const CLIENT_TOKEN = 's.RAWAPPROLETOKENSHOULDNEVERBELOGGED';
+    const ACCESSOR = 'approle-accessor-1234';
+
+    it('never passes the raw client_token to any log level, and logs the accessor instead', async () => {
+      const api = getApiStub();
+      const log = spyLogger();
+
+      const auth = new VaultAppRoleAuth(
+        api,
+        log,
+        { role_id: 'role123', secret_id: 'secret456' },
+        'approle',
+      );
+
+      api.makeRequest
+        .withArgs('POST')
+        .resolves({ auth: { client_token: CLIENT_TOKEN, accessor: ACCESSOR } });
+      sinon.stub(auth, '_getTokenEntity');
+
+      await auth._authenticate();
+
+      expect(loggedText(log), 'raw client_token must never reach the logger').to.not.contain(
+        CLIENT_TOKEN,
+      );
+      // The non-sensitive accessor is logged instead, so the debug line stays useful.
+      expect(loggedText(log)).to.contain(ACCESSOR);
     });
   });
 });

--- a/test/auth.base.test.mjs
+++ b/test/auth.base.test.mjs
@@ -9,7 +9,21 @@ import errors from '../src/errors.js';
 
 use(sinonChai);
 
-const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+const LOG_METHODS = ['error', 'warn', 'info', 'debug', 'trace'];
+
+const logger = _.fromPairs(_.map(LOG_METHODS, (p) => [p, _.noop]));
+
+function spyLogger() {
+    return _.fromPairs(_.map(LOG_METHODS, (p) => [p, sinon.spy()]));
+}
+
+// Flatten every argument passed to a logger call into a single searchable string,
+// covering both printf-style args and object logging (%j / %o).
+function loggedText(log) {
+    return _.flatMap(LOG_METHODS, (m) => _.flatMap(log[m].getCalls(), (c) => c.args))
+        .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+        .join(' ');
+}
 
 function apiStub() {
     return sinon.createStubInstance(VaultApiClient);
@@ -208,6 +222,25 @@ describe('VaultBaseAuth', function () {
             expect(auth.__refreshTimeout).to.equal(null);
             expect(() => { auth.cancelTokenRefresh(); auth.cancelTokenRefresh(); }).to.not.throw();
             expect(auth.__refreshTimeout).to.equal(null);
+        });
+
+        it('logs the accessor, never the raw token id, when arming the refresh timer (regression #104)', function () {
+            const RAW_ID = 's.RAWBASETOKENSHOULDNEVERBELOGGED';
+            const ACCESSOR = 'base-accessor-1234';
+            const renewable = new AuthToken(RAW_ID, ACCESSOR, 0, 100, 0, 0, true);
+            const api = apiStub();
+            api.makeRequest.resolves({});
+            const log = spyLogger();
+            const auth = new TestAuth(api, 'mount', { authStub: sinon.stub().resolves(renewable) });
+            auth._log = log;
+            sinon.stub(auth, '_getTokenEntity').resolves(nonRenewableToken('rid2'));
+
+            return auth.getAuthToken().then(() => {
+                auth.cancelTokenRefresh();
+                expect(loggedText(log), 'raw token id must never reach the logger').to.not.contain(RAW_ID);
+                // The non-sensitive accessor is logged instead, so the debug line stays useful.
+                expect(loggedText(log)).to.contain(ACCESSOR);
+            });
         });
 
         it('logs and reschedules when a renewal fails', function () {

--- a/test/auth.iam.test.mjs
+++ b/test/auth.iam.test.mjs
@@ -8,7 +8,21 @@ import errors from '../src/errors.js';
 
 use(sinonChai);
 
-const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (prop) => [prop, _.noop]));
+const LOG_METHODS = ['error', 'warn', 'info', 'debug', 'trace'];
+
+const logger = _.fromPairs(_.map(LOG_METHODS, (prop) => [prop, _.noop]));
+
+function spyLogger() {
+    return _.fromPairs(_.map(LOG_METHODS, (prop) => [prop, sinon.spy()]));
+}
+
+// Flatten every argument passed to a logger call into a single searchable string,
+// covering both printf-style args and object logging (%j / %o).
+function loggedText(log) {
+    return _.flatMap(LOG_METHODS, (m) => _.flatMap(log[m].getCalls(), (c) => c.args))
+        .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+        .join(' ');
+}
 
 describe('Unit AWS auth backend :: IAM', function () {
 
@@ -196,6 +210,35 @@ describe('Unit AWS auth backend :: IAM', function () {
 
             const args = api.makeRequest.getCall(0).args;
             expect(args[3]).to.deep.equal({'X-Vault-Namespace': 'ns1'});
+        });
+
+        it('never passes the raw client_token to any log level, and logs the accessor instead (regression #104)', async function () {
+            const CLIENT_TOKEN = 's.RAWIAMTOKENSHOULDNEVERBELOGGED';
+            const ACCESSOR = 'iam-accessor-1234';
+            const api = getApiStub();
+            const log = spyLogger();
+
+            const auth = new VaultIAMAuth(
+                api,
+                log,
+                {
+                    role: 'MyRole',
+                    credentials: {
+                        accessKeyId: 'FAKE_AWS_ACCESS_KEY',
+                        secretAccessKey: 'FAKE_AWS_SECRET_KEY',
+                    },
+                },
+                'fake_aws'
+            );
+
+            api.makeRequest.withArgs('POST').resolves({auth: {client_token: CLIENT_TOKEN, accessor: ACCESSOR}});
+            sinon.stub(auth, '_getTokenEntity');
+
+            await auth._authenticate();
+
+            expect(loggedText(log), 'raw client_token must never reach the logger').to.not.contain(CLIENT_TOKEN);
+            // The non-sensitive accessor is logged instead, so the debug line stays useful.
+            expect(loggedText(log)).to.contain(ACCESSOR);
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes #104 (critical / security). Three auth call sites passed a live Vault bearer credential to the pluggable `debug` logger. The README recommends wiring a custom logger (pino/winston/bunyan), and `VaultClient.__setupLogger` forwards `debug` verbatim — so in a common production setup shipping debug logs to central storage, **every authentication wrote a replayable Vault token into durable, broadly-accessible logs**.

The transport layer already deliberately declines to log response bodies for exactly this reason (`VaultApiClient.js`), so this was an inconsistency, not a design decision. This PR completes the same class of fix shipped for the Kubernetes backend and response bodies in 2.0.1.

The safe token **accessor** is logged at each site instead — it is a first-class field of Vault's `auth` login-response stanza (and of the token-lookup `data` shape already relied on across the codebase), so no observability is lost.

| Site | Was logged | Now logged |
|---|---|---|
| `VaultAppRoleAuth.js` | `res.auth.client_token` | `res.auth.accessor` |
| `VaultIAMAuth.js` | `response.auth.client_token` | `response.auth.accessor` |
| `VaultBaseAuth.js` | `authToken.getId()` (raw token) | `authToken.getAccessor()` |

The Kubernetes backend was already safe (it logs a generic message), and `getId()` calls that build `X-Vault-Token` request headers are unchanged — only logging sites were touched.

## Changes

- `src/auth/VaultAppRoleAuth.js`, `src/auth/VaultIAMAuth.js`, `src/auth/VaultBaseAuth.js` — log the accessor instead of the raw token at the three debug sites.
- `test/auth.appRole.test.mjs`, `test/auth.iam.test.mjs`, `test/auth.base.test.mjs` — added regression tests (written first, confirmed red before the fix) that stub the logger, flatten every logged argument, and assert the raw token value never reaches any log level while the accessor still does.
- `CHANGELOG.md`, `package.json`, `package-lock.json` — patch release `2.0.2` (same structure as the `chore(release): 2.0.1` precedent; fold into a batched release if preferred).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `npm run lint` and `npm run test:unit` pass locally (243 passing); `npm test` also runs the Vault-backed e2e suite, which requires a live server and was not run in this environment
- [x] User-facing change recorded in `CHANGELOG.md` (this repo uses versioned headings rather than `# Unreleased`; added under `# 2.0.2`)
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)

## Acceptance criteria (from #104)

- `grep -rn "client_token" src/ | grep "_log"` → nothing; no `getId()` inside any `_log.*` call ✅
- Per-backend regression tests pass in the default (`test:unit`) suite ✅
- CHANGELOG entry; released as a patch ✅
