### PR TITLE
fix: send X-Vault-Namespace on token lookup/renew and Kubernetes login (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.0.3 Release notes (2026-07-02)
+
+- Fix (behavior change): apply `X-Vault-Namespace` to **every** request. The header was previously
+  built independently by the AppRole and IAM backends and by `VaultClient` for KV operations, but was
+  **missing from token lookup/renewal (`/auth/token/lookup-self`, `/auth/token/renew-self`) for all
+  backends, and from Kubernetes login entirely**. Against a namespaced Vault this silently sent those
+  requests to the **root** namespace, so Token and Kubernetes auth were effectively broken with
+  namespaces. The namespace is now injected in a single place — `VaultApiClient` — so login, lookup,
+  renewal, and secret operations all inherit it for every auth backend. `Token` and `Kubernetes`
+  gain namespace support as a result. `api.namespace` is now the canonical config location;
+  `auth.config.namespace` continues to work. If you relied on the previous (buggy) behavior where
+  lookup/renewal hit the root namespace, this changes which namespace those calls target. Closes #106.
+
 # 2.0.2 Release notes (2026-07-02)
 
 - Security: stop logging the raw Vault `client_token` at debug level. The AppRole (`VaultAppRoleAuth`)

--- a/README.md
+++ b/README.md
@@ -156,11 +156,12 @@ Client constructor function.
 | options.api.url | <code>String</code> |  | the url of the vault server |
 | [options.api.apiVersion] | <code>String</code> | `v1` |  |
 | [options.api.requestOptions] | <code>Object</code> |  | extra options merged into every HTTP request (see [Custom transport](#custom-transport-proxy--self-signed-tls)) |
+| [options.api.namespace] | <code>String</code> |  | Optional. Vault namespace, sent as the `X-Vault-Namespace` header on **every** request — login, token lookup/renewal, and all secret operations — for every auth type. This is the canonical location; `auth.config.namespace` is still honored for backward compatibility. |
 | options.auth | <code>Object</code> |  |  |
 | options.auth.type | <code>String</code> |  |  |
 | [options.auth.mount] | <code>String</code> |  | Vault auth backend mount point; default varies per method (e.g. "aws" for iam, "approle", "token", "kubernetes") |
 | options.auth.config | <code>Object</code> |  | auth configuration variables |
-| [options.auth.config.namespace] | <code>String</code> |  | Optional. Vault namespace, sent as the `X-Vault-Namespace` header on all secret read/list/write requests. Applies to every auth type, not just IAM. |
+| [options.auth.config.namespace] | <code>String</code> |  | Optional. Legacy location for the Vault namespace (see `api.namespace`). Sent as the `X-Vault-Namespace` header on **every** request for every auth type. |
 | options.logger | <code>Object</code> | `false` |  | Logger that supports "error", "info", "warn", "trace", "debug" methods. Uses `console` by default. Pass `false` to disable logging. |
 
 ##### Custom transport (proxy / self-signed TLS)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-vault-client",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.382.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"

--- a/src/VaultApiClient.js
+++ b/src/VaultApiClient.js
@@ -33,8 +33,12 @@ class VaultApiClient {
      *      per-request headers winning. Stored by reference (not deep-cloned) so live
      *      objects such as a Dispatcher keep their prototype and remain usable.
      * @param {Object} logger
+     * @param {String} [namespace] - Vault namespace. When set, `X-Vault-Namespace` is added to
+     *      every request (login, token lookup/renewal, and secret operations) so namespacing is
+     *      owned in one place instead of being reapplied per auth backend. An explicit
+     *      `X-Vault-Namespace` passed to {@link VaultApiClient#makeRequest} overrides it.
      */
-    constructor(config, logger) {
+    constructor(config, logger, namespace) {
         const requestOptions = config && config.requestOptions;
 
         const baseConfig = { ...(config || {}) };
@@ -48,6 +52,7 @@ class VaultApiClient {
             this.__config.requestOptions = requestOptions;
         }
 
+        this.__namespace = namespace !== undefined ? namespace : this.__config.namespace;
         this._logger = logger;
     }
 
@@ -59,6 +64,11 @@ class VaultApiClient {
 
         const requestOptions = this.__config.requestOptions || {};
 
+        // Inject the namespace as a low-priority default so every request (login, token
+        // lookup/renewal, secret ops) is namespaced from a single place, while an explicit
+        // per-request or requestOptions X-Vault-Namespace still wins.
+        const namespaceHeader = this.__namespace ? { 'X-Vault-Namespace': this.__namespace } : {};
+
         const options = Object.assign(
             { redirect: 'follow' },
             requestOptions,
@@ -66,6 +76,7 @@ class VaultApiClient {
                 method: method,
                 headers: Object.assign(
                     { Accept: 'application/json' },
+                    namespaceHeader,
                     requestOptions.headers,
                     headers
                 ),

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -29,6 +29,9 @@ class VaultClient {
      * @param {Object} [options.api.kv] - KV engine options
      * @param {boolean} [options.api.kv.autoDetect=false] - When true, auto-detect KV version per mount
      * @param {Object} [options.api.engines] - Mount-to-version overrides, e.g. { secret: 2, legacy: 1 }
+     * @param {String} [options.api.namespace] - Vault namespace applied (as `X-Vault-Namespace`) to
+     *      every request across all auth backends. For backward compatibility `options.auth.config.namespace`
+     *      is also honored when this is not set.
      * @param {Object} options.auth
      * @param {String} options.auth.type
      * @param {Object} options.auth.config - auth configuration variables
@@ -37,9 +40,18 @@ class VaultClient {
     constructor(options) {
         this.__log = this.__setupLogger(options.logger);
 
+        // Namespace is a server-routing concern that applies to every request, so it is resolved
+        // once here and owned by the API client (see VaultApiClient#makeRequest) rather than being
+        // reapplied in each auth backend. `api.namespace` is the canonical location; the legacy
+        // `auth.config.namespace` is still honored for backward compatibility.
+        const namespace = (options.api && options.api.namespace !== undefined)
+            ? options.api.namespace
+            : (options.auth && options.auth.config ? options.auth.config.namespace : undefined);
+
         this.__api = new VaultApiClient(
             options.api,
-            this.__log
+            this.__log,
+            namespace
         );
 
         /**
@@ -50,8 +62,6 @@ class VaultClient {
             options.auth,
             this.__api
         );
-
-        this.__namespace = options.auth.config.namespace;
 
         // KV v2 support
         const kvOpts = (options.api && options.api.kv) || {};
@@ -213,13 +223,8 @@ class VaultClient {
     }
 
     getHeaders(token) {
-        if (this.__namespace) {
-            return {
-                'X-Vault-Token': token.getId(),
-                'X-Vault-Namespace': this.__namespace
-            }
-        }
-
+        // Namespace is injected centrally by VaultApiClient#makeRequest, so callers only
+        // need to supply the token here.
         return {'X-Vault-Token': token.getId()}
     }
 

--- a/src/auth/VaultAppRoleAuth.js
+++ b/src/auth/VaultAppRoleAuth.js
@@ -10,7 +10,8 @@ class VaultAppRoleAuth extends VaultBaseAuth {
      * @param {Object} config
      * @param {String} config.role_id - RoleID of the AppRole.
      * @param {String} [config.secret_id] - required when bind_secret_id is enabled SecretID belonging to AppRole.
-     * @param {String} [config.namespace] - Optional. Vault namespace, sent as the X-Vault-Namespace header.
+     * @param {String} [config.namespace] - Optional. Vault namespace. Applied as the X-Vault-Namespace
+     *   header to every request by {@link VaultApiClient}; see {@link VaultClient#constructor}.
      * @param {String} mount - Vault's  mount point ("approle" by default)
      */
     constructor(apiClient, logger, config, mount) {
@@ -18,7 +19,6 @@ class VaultAppRoleAuth extends VaultBaseAuth {
 
         this.__roleId = config.role_id;
         this.__secretId = config.secret_id;
-        this.__namespace = config.namespace;
     }
 
     _authenticate() {
@@ -27,15 +27,10 @@ class VaultAppRoleAuth extends VaultBaseAuth {
             this.__roleId
         );
 
-        const headers = {};
-        if (this.__namespace) {
-            headers['X-Vault-Namespace'] = this.__namespace;
-        }
-
         return this.__apiClient.makeRequest('POST', `/auth/${this._mount}/login`, {
             role_id: this.__roleId,
             secret_id: this.__secretId,
-        }, headers).then(res => {
+        }).then(res => {
             this._log.debug(
                 'received token (accessor=%s)',
                 res.auth.accessor

--- a/src/auth/VaultIAMAuth.js
+++ b/src/auth/VaultIAMAuth.js
@@ -48,7 +48,8 @@ class VaultIAMAuth extends VaultBaseAuth {
      * @typedef {Object} VaultIAMAuthConfig
      * @property {String} role - Role name of the auth/{mount}/role/{name} backend.
      * @property {AWSCredentials} [credentials] - Optional. AWS Credentials
-     * @property {String} [namespace] - Optional. Vault namespace, sent as the X-Vault-Namespace header.
+     * @property {String} [namespace] - Optional. Vault namespace. Applied as the X-Vault-Namespace
+     *   header to every request by {@link VaultApiClient}; see {@link VaultClient#constructor}.
      * @property {String} [iam_server_id_header_value] - Optional. Header's value X-Vault-AWS-IAM-Server-ID.
      * @property {String} [region] - Optional. AWS region used to sign the STS GetCallerIdentity
      *   request. When set, the request is signed against the regional STS endpoint
@@ -66,7 +67,6 @@ class VaultIAMAuth extends VaultBaseAuth {
 
         this.__role = config.role;
         this.__iam_server_id_header_value = config.iam_server_id_header_value;
-        this.__namespace = config.namespace;
         this.__region = config.region;
 
 
@@ -85,23 +85,13 @@ class VaultIAMAuth extends VaultBaseAuth {
             this.__role
         );
 
-        var headers = {};
-
-        if (this.__namespace) {
-            headers = {
-                'X-Vault-Namespace': this.__namespace,
-            }
-        }
-
-
         return Promise.resolve()
             .then(() => this.__getCredentials())
             .then((credentials) => {
                 return this.__apiClient.makeRequest(
                     'POST',
                     `/auth/${this._mount}/login`,
-                    this.__getVaultAuthRequestBody(this.__getStsRequest(credentials)),
-                    headers
+                    this.__getVaultAuthRequestBody(this.__getStsRequest(credentials))
                 );
             })
             .then((response) => {

--- a/src/auth/VaultKubernetesAuth.js
+++ b/src/auth/VaultKubernetesAuth.js
@@ -8,6 +8,8 @@ class VaultKubernetesAuth extends VaultBaseAuth {
      * @param {Object} config
      * @param {String} config.role - Role configured in Vault Kubernetes Auth backend under which we want to issue Vault token.
      * @param {String} [config.tokenPath] - Path to the Kube JWT token. If omitted - default will be used.
+     * @param {String} [config.namespace] - Optional. Vault namespace. Applied as the X-Vault-Namespace
+     *   header to every request by {@link VaultApiClient}; see {@link VaultClient#constructor}.
      * @param {String} mount - Vault's  mount point ("kubernetes" by default)
      */
     constructor(apiClient, logger, config, mount) {

--- a/test/VaultClient.test.mjs
+++ b/test/VaultClient.test.mjs
@@ -125,17 +125,29 @@ describe('VaultClient', function () {
     describe('#getHeaders()', function () {
         const token = { getId: () => 'tid' };
 
-        it('returns only the token header without a namespace', function () {
+        it('returns only the token header', function () {
             const client = new VaultClient(bootOpts());
             expect(client.getHeaders(token)).to.deep.equal({ 'X-Vault-Token': 'tid' });
         });
 
-        it('adds the namespace header when configured', function () {
+        it('does not add the namespace header (namespace is injected centrally by VaultApiClient)', function () {
             const client = new VaultClient(bootOpts({ auth: { config: { namespace: 'ns1' } } }));
-            expect(client.getHeaders(token)).to.deep.equal({
-                'X-Vault-Token': 'tid',
-                'X-Vault-Namespace': 'ns1',
-            });
+            // The namespace is applied to every request inside VaultApiClient#makeRequest, so
+            // getHeaders itself no longer carries it (see test/namespace.test.mjs for the wire-level proof).
+            expect(client.getHeaders(token)).to.deep.equal({ 'X-Vault-Token': 'tid' });
+        });
+
+        it('resolves the namespace from auth.config.namespace onto the API client', function () {
+            const client = new VaultClient(bootOpts({ auth: { config: { namespace: 'ns1' } } }));
+            expect(client.__api.__namespace).to.equal('ns1');
+        });
+
+        it('prefers api.namespace over the legacy auth.config.namespace', function () {
+            const client = new VaultClient(bootOpts({
+                api: { namespace: 'from-api' },
+                auth: { config: { namespace: 'from-auth' } },
+            }));
+            expect(client.__api.__namespace).to.equal('from-api');
         });
     });
 

--- a/test/auth.appRole.test.mjs
+++ b/test/auth.appRole.test.mjs
@@ -31,7 +31,38 @@ describe('AppRole auth backend', function () {
   describe('Vault Request', function () {
     const mount = 'approle';
 
-    it('Should make a correct vault login request with namespace', async () => {
+    it('makes the login request with role_id/secret_id and no per-backend headers', async () => {
+      const api = getApiStub();
+
+      const auth = new VaultAppRoleAuth(
+        api,
+        logger,
+        {
+          role_id: 'role123',
+          secret_id: 'secret456',
+        },
+        mount,
+      );
+
+      api.makeRequest
+        .withArgs('POST')
+        .resolves({ auth: { client_token: 'fake_token' } });
+      sinon.stub(auth, '_getTokenEntity');
+
+      await auth._authenticate();
+
+      // The namespace header is injected centrally by VaultApiClient (see test/namespace.test.mjs),
+      // so the backend passes no headers of its own.
+      expect(
+        api.makeRequest.calledWithExactly(
+          'POST',
+          '/auth/approle/login',
+          { role_id: 'role123', secret_id: 'secret456' },
+        ),
+      ).to.be.true;
+    });
+
+    it('does not attach an X-Vault-Namespace header itself, even when namespace is configured', async () => {
       const api = getApiStub();
 
       const auth = new VaultAppRoleAuth(
@@ -52,44 +83,9 @@ describe('AppRole auth backend', function () {
 
       await auth._authenticate();
 
-      expect(
-        api.makeRequest.calledWith(
-          'POST',
-          '/auth/approle/login',
-          { role_id: 'role123', secret_id: 'secret456' },
-          { 'X-Vault-Namespace': 'ns1' },
-        ),
-      ).to.be.true;
-    });
-
-    it('Should not set namespace header if not provided', async () => {
-      const api = getApiStub();
-
-      const auth = new VaultAppRoleAuth(
-        api,
-        logger,
-        {
-          role_id: 'role123',
-          secret_id: 'secret456',
-        },
-        mount,
-      );
-
-      api.makeRequest
-        .withArgs('POST')
-        .resolves({ auth: { client_token: 'fake_token' } });
-      sinon.stub(auth, '_getTokenEntity');
-
-      await auth._authenticate();
-
-      expect(
-        api.makeRequest.calledWith(
-          'POST',
-          '/auth/approle/login',
-          { role_id: 'role123', secret_id: 'secret456' },
-          {},
-        ),
-      ).to.be.true;
+      // Namespacing is centralized in VaultApiClient; the backend must not reintroduce a copy.
+      const headers = api.makeRequest.getCall(0).args[3];
+      expect(headers).to.equal(undefined);
     });
 
     it("defaults the mount to 'approle' when none is provided", async () => {
@@ -108,11 +104,10 @@ describe('AppRole auth backend', function () {
       await auth._authenticate();
 
       expect(
-        api.makeRequest.calledWith(
+        api.makeRequest.calledWithExactly(
           'POST',
           '/auth/approle/login',
           { role_id: 'role123', secret_id: 'secret456' },
-          {},
         ),
       ).to.be.true;
     });

--- a/test/auth.iam.test.mjs
+++ b/test/auth.iam.test.mjs
@@ -186,7 +186,7 @@ describe('Unit AWS auth backend :: IAM', function () {
             expect(headers['Authorization'][0]).to.contain('/us-east-1/sts/aws4_request');
         });
 
-        it('Should set the namespace header when configured', async function () {
+        it('does not attach an X-Vault-Namespace header itself, even when namespace is configured', async function () {
             const api = getApiStub();
 
             const auth = new VaultIAMAuth(
@@ -208,8 +208,10 @@ describe('Unit AWS auth backend :: IAM', function () {
 
             await auth._authenticate();
 
+            // Namespacing is injected centrally by VaultApiClient (see test/namespace.test.mjs);
+            // the backend must not pass headers of its own.
             const args = api.makeRequest.getCall(0).args;
-            expect(args[3]).to.deep.equal({'X-Vault-Namespace': 'ns1'});
+            expect(args[3]).to.equal(undefined);
         });
 
         it('never passes the raw client_token to any log level, and logs the accessor instead (regression #104)', async function () {

--- a/test/conformance.vault-api.test.mjs
+++ b/test/conformance.vault-api.test.mjs
@@ -198,27 +198,36 @@ describe('Vault API conformance', function () {
     });
 
     describe('namespaces', function () {
-        it('selects a namespace with the X-Vault-Namespace header on KV requests', function () {
+        // Namespacing is owned by VaultApiClient#makeRequest, so it applies uniformly to login,
+        // token lookup/renewal and secret operations. The full per-backend matrix lives in
+        // test/namespace.test.mjs; here we validate the documented header on the wire and the
+        // config resolution.
+        it('sends the X-Vault-Namespace header on the wire when configured', function () {
+            const fetchStub = sinon.stub(global, 'fetch').resolves(
+                new Response(JSON.stringify({ data: {} }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+            const api = new VaultApiClient({ url: 'https://vault.example' }, logger, 'team-a');
+            return api.makeRequest('GET', '/secret/data/foo', null, { 'X-Vault-Token': 'tid' })
+                .then(() => {
+                    const headers = fetchStub.firstCall.args[1].headers;
+                    expect(headers['X-Vault-Namespace']).to.equal('team-a');
+                    expect(headers['X-Vault-Token']).to.equal('tid');
+                })
+                .finally(() => fetchStub.restore());
+        });
+
+        it('resolves auth.config.namespace onto the shared API client', function () {
             const client = new VaultClient({
                 api: { url: 'https://vault.example/' },
                 logger: false,
                 auth: { type: 'token', config: { token: 't', namespace: 'team-a' } },
             });
-            expect(client.getHeaders({ getId: () => 'tid' })).to.deep.equal({
-                'X-Vault-Token': 'tid',
-                'X-Vault-Namespace': 'team-a',
-            });
-        });
-
-        it('sends X-Vault-Namespace on the AppRole login request', function () {
-            const api = apiStub();
-            api.makeRequest.resolves({ auth: { client_token: 'ct' } });
-            const auth = new VaultAppRoleAuth(api, logger, { role_id: 'r', secret_id: 's', namespace: 'team-a' }, 'approle');
-            sinon.stub(auth, '_getTokenEntity').resolves();
-            return auth._authenticate().then(() => {
-                const headers = api.makeRequest.getCall(0).args[3];
-                expect(headers).to.deep.equal({ 'X-Vault-Namespace': 'team-a' });
-            });
+            expect(client.__api.__namespace).to.equal('team-a');
+            // getHeaders no longer carries the namespace — the transport injects it.
+            expect(client.getHeaders({ getId: () => 'tid' })).to.deep.equal({ 'X-Vault-Token': 'tid' });
         });
     });
 

--- a/test/namespace.test.mjs
+++ b/test/namespace.test.mjs
@@ -1,0 +1,132 @@
+/**
+ * Namespace conformance (regression #106).
+ *
+ * X-Vault-Namespace must be applied to *every* request — login, token
+ * lookup-self, and renewal — for all four auth backends, not just the two
+ * (AppRole/IAM) that used to build the header themselves. These tests drive a
+ * real VaultApiClient with a stubbed global fetch and assert the header on the
+ * wire for each request, so a backend that skips namespacing (as token and
+ * kubernetes did on lookup-self / login) fails here.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import _ from 'lodash';
+import sinon from 'sinon';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import VaultApiClient from '../src/VaultApiClient.js';
+import VaultTokenAuth from '../src/auth/VaultTokenAuth.js';
+import VaultAppRoleAuth from '../src/auth/VaultAppRoleAuth.js';
+import VaultIAMAuth from '../src/auth/VaultIAMAuth.js';
+import VaultKubernetesAuth from '../src/auth/VaultKubernetesAuth.js';
+
+use(sinonChai);
+
+const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+
+// Canned Vault responses keyed by request path.
+function bodyFor(pathname) {
+    if (pathname.endsWith('/auth/token/lookup-self')) {
+        return { data: { id: 'tok', accessor: 'acc', creation_time: 1600000000, ttl: 0, renewable: false } };
+    }
+    if (pathname.endsWith('/login')) {
+        return { auth: { client_token: 'tok', accessor: 'acc' } };
+    }
+    return {};
+}
+
+function stubFetch() {
+    return sinon.stub(global, 'fetch').callsFake((url) => {
+        const pathname = new URL(url).pathname;
+        return Promise.resolve(new Response(JSON.stringify(bodyFor(pathname)), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        }));
+    });
+}
+
+const TYPES = ['token', 'appRole', 'iam', 'kubernetes'];
+
+describe('X-Vault-Namespace is applied to every request (regression #106)', function () {
+    let fetchStub;
+    let jwtPath;
+
+    before(function () {
+        jwtPath = path.join(os.tmpdir(), 'node-vault-client-k8s-jwt.test');
+        fs.writeFileSync(jwtPath, 'fake.kubernetes.jwt');
+    });
+
+    after(function () {
+        try { fs.unlinkSync(jwtPath); } catch { /* ignore */ }
+    });
+
+    beforeEach(function () {
+        fetchStub = stubFetch();
+    });
+
+    afterEach(function () {
+        fetchStub.restore();
+    });
+
+    function makeAuth(type, api) {
+        switch (type) {
+            case 'token':
+                return new VaultTokenAuth(api, logger, { token: 'tok' });
+            case 'appRole':
+                return new VaultAppRoleAuth(api, logger, { role_id: 'r', secret_id: 's' });
+            case 'iam':
+                return new VaultIAMAuth(api, logger, {
+                    role: 'r',
+                    credentials: { accessKeyId: 'AK', secretAccessKey: 'SK' },
+                });
+            case 'kubernetes':
+                return new VaultKubernetesAuth(api, logger, { role: 'r', tokenPath: jwtPath });
+            default:
+                throw new Error(`unknown type ${type}`);
+        }
+    }
+
+    function requests() {
+        return fetchStub.getCalls().map((c) => ({
+            path: new URL(c.args[0]).pathname,
+            namespace: c.args[1].headers['X-Vault-Namespace'],
+        }));
+    }
+
+    TYPES.forEach((type) => {
+        it(`sends the namespace header on every request for the "${type}" backend`, async function () {
+            const api = new VaultApiClient({ url: 'https://vault.example' }, logger, 'team-a');
+
+            await makeAuth(type, api).getAuthToken();
+
+            const reqs = requests();
+            expect(reqs.length, `${type} should make at least one request`).to.be.greaterThan(0);
+            // The token lookup-self path is exactly what used to bypass the namespace.
+            expect(
+                reqs.some((r) => r.path.endsWith('/auth/token/lookup-self')),
+                `${type} should look the token up via /auth/token/lookup-self`,
+            ).to.equal(true);
+            reqs.forEach((r) => {
+                expect(r.namespace, `namespace missing on ${r.path} for ${type}`).to.equal('team-a');
+            });
+        });
+
+        it(`sends no namespace header for the "${type}" backend when none is configured`, async function () {
+            const api = new VaultApiClient({ url: 'https://vault.example' }, logger);
+
+            await makeAuth(type, api).getAuthToken();
+
+            requests().forEach((r) => {
+                expect(r.namespace, `unexpected namespace on ${r.path} for ${type}`).to.equal(undefined);
+            });
+        });
+    });
+
+    it('lets an explicit per-request X-Vault-Namespace header override the configured default', async function () {
+        const api = new VaultApiClient({ url: 'https://vault.example' }, logger, 'team-a');
+        await api.makeRequest('GET', '/sys/health', null, { 'X-Vault-Namespace': 'team-b' });
+        expect(requests()[0].namespace).to.equal('team-b');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #106 (`priority: high`, bug). `X-Vault-Namespace` was constructed in **three** independent places and **missing from two more**:

| Request | Namespace before | Namespace after |
|---|---|---|
| KV / secret ops | ✅ `VaultClient.getHeaders` | ✅ central |
| AppRole login | ✅ `VaultAppRoleAuth` | ✅ central |
| IAM login | ✅ `VaultIAMAuth` | ✅ central |
| **Token lookup-self / renew-self (all backends)** | ❌ **missing** | ✅ central |
| **Kubernetes login** | ❌ **missing** | ✅ central |

Against a namespaced Vault, `/auth/token/lookup-self` and `/auth/token/renew-self` were sent to the **root** namespace for every backend, and Kubernetes login was entirely un-namespaced — so **Token and Kubernetes auth were effectively broken with namespaces**, and even AppRole/IAM renewed their tokens against the wrong namespace.

## Fix — centralize instead of adding a fourth copy

The namespace is now injected in exactly one place — `VaultApiClient#makeRequest` — so login, lookup, renewal, and secret operations all inherit it for every auth backend.

- `VaultApiClient` gains a `namespace` constructor arg and injects `X-Vault-Namespace` as a low-priority default (an explicit per-request or `requestOptions` header still overrides it).
- `VaultClient` resolves the namespace once and passes it in. `api.namespace` is the new canonical location; the legacy `auth.config.namespace` is still honored (no breaking change).
- The three scattered copies are deleted (`VaultClient.getHeaders`, `VaultAppRoleAuth`, `VaultIAMAuth`).
- `VaultTokenAuth` and `VaultKubernetesAuth` gain namespace support as a side effect.

`VaultApiClient` is DI-injected per `VaultClient` instance, so the stored namespace cannot leak across tenants.

## Changes

- `src/VaultApiClient.js` — `namespace` ctor arg + central injection in `makeRequest`.
- `src/VaultClient.js` — resolve namespace once (`api.namespace` ?? `auth.config.namespace`), drop `getHeaders`' namespace branch and the `__namespace` field.
- `src/auth/VaultAppRoleAuth.js`, `src/auth/VaultIAMAuth.js` — remove the per-backend header copies; `VaultKubernetesAuth.js` — JSDoc only (now namespaced via the transport).
- `test/namespace.test.mjs` (new) — parameterized wire-level suite: all four backends × namespaced/non-namespaced, asserting the header on **login and lookup/renew** (written first, confirmed red for token/kubernetes/appRole/iam before the fix), plus explicit-override precedence.
- Updated `test/auth.appRole.test.mjs`, `test/auth.iam.test.mjs`, `test/VaultClient.test.mjs`, `test/conformance.vault-api.test.mjs` to match the centralized architecture.
- `README.md` — document `api.namespace` (canonical) and correct the scope of `auth.config.namespace`.
- `CHANGELOG.md`, `package.json`, `package-lock.json` — patch release `2.0.3` (same structure as the `chore(release): 2.0.2` precedent; fold into a batched release if preferred).

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `npm run lint` and `npm run test:unit` pass locally (254 passing); `npm test` also runs the Vault-backed e2e suite, which requires a live server and was not run in this environment. The change is backward-compatible for the non-namespaced default e2e uses.
- [x] User-facing change recorded in `CHANGELOG.md` (this repo uses versioned headings rather than `# Unreleased`; added under `# 2.0.3` and flagged as a behavior change)
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)

## Acceptance criteria (from #106)

- The namespace header is constructed in exactly one file (`VaultApiClient.js`; other files only mention it in JSDoc) ✅
- `VaultTokenAuth` and `VaultKubernetesAuth` gain namespace support ✅
- `grep -rn "fetch(" src/` hits only `VaultApiClient.js` ✅
- Parameterized suite across all four backends × namespaced/non-namespaced, asserting the header on login **and** lookup/renew ✅
- CHANGELOG flags the behavior change (lookup/renew previously hit the root namespace silently) ✅

## Open question from the issue

The issue asked whether namespaced Vault is officially supported for **all** backends or only AppRole/IAM. This PR takes the "all backends" interpretation (centralizing makes token/kubernetes work too) and documents it in the README. Happy to scope it down if the intent was AppRole/IAM only.
