### PR TITLE
ci: enforce coverage thresholds and lint test files (#105)

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -35,6 +35,10 @@ jobs:
         run: npm ci
 
       - name: Audit dependencies
+        # Gate on high/critical only: moderate advisories are usually in dev/transitive
+        # tooling (mocha/eslint/sinon) and would block release CI with noise unrelated to
+        # the shipped runtime (deps: @aws-sdk/credential-providers, aws4, long-timeout).
+        # Snyk and CodeQL run as additional, broader security gates on every PR.
         run: npm audit --audit-level=high
 
   lint:
@@ -69,9 +73,14 @@ jobs:
         run: npm ci && npm install config
 
       - name: Run coverage
+        # `npm run coverage` enforces the c8 thresholds in package.json (check-coverage),
+        # so a coverage regression below the pinned floor fails this job.
         run: npm run coverage
 
       - name: Upload coverage report
+        # Upload even when the threshold gate fails, so the HTML/lcov report is available
+        # to diagnose which file regressed.
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.0.4 Release notes (2026-07-02)
+
+- CI: make the quality gates actually enforce. `c8` now runs with `check-coverage` and per-metric
+  thresholds (statements/branches/functions/lines) pinned just below the current measured coverage,
+  so a coverage regression fails the `coverage` job instead of silently passing. Linting now covers
+  `test/` in addition to `src/` (`eslint src/ test/`), catching stray unused imports/vars in the
+  ~19 test files that were previously unchecked. The `npm audit --audit-level=high` choice is now
+  documented in the workflow. No runtime behavior change.
+- `VaultError` now accepts the standard `{ cause }` option (`new VaultError(msg, { cause })`) and
+  exposes it as `error.cause`, so wrapped/underlying errors can be chained. Backward compatible —
+  omitting the option leaves `cause` undefined.
+
 # 2.0.3 Release notes (2026-07-02)
 
 - Fix (behavior change): apply `X-Vault-Namespace` to **every** request. The header was previously

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,17 @@ module.exports = [
     },
   },
   {
+    // Test files are ESM (.mjs) and run under Mocha, so they need the BDD globals
+    // (describe/it/before/after/…) on top of the Node globals above.
+    files: ['test/**/*.mjs'],
+    languageOptions: {
+      sourceType: 'module',
+      globals: {
+        ...globals.mocha,
+      },
+    },
+  },
+  {
     ignores: ['node_modules/', 'coverage/'],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-vault-client",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.382.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit": "mocha \"test/*.test.mjs\"",
     "test:e2e": "mocha --exit \"test/e2e/**/*.test.mjs\"",
     "coverage": "c8 npm run test:unit",
-    "lint": "eslint src/",
+    "lint": "eslint src/ test/",
     "version": "git add -A ."
   },
   "c8": {
@@ -29,7 +29,12 @@
       "html",
       "lcov"
     ],
-    "all": true
+    "all": true,
+    "check-coverage": true,
+    "statements": 97,
+    "branches": 93,
+    "functions": 100,
+    "lines": 97
   },
   "author": "Namecheap <opensource@namecheap.com>",
   "license": "Apache-2.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,8 +1,13 @@
 'use strict';
 
 class VaultError extends Error {
-    constructor(message) {
-        super(message);
+    /**
+     * @param {string} message
+     * @param {{cause?: *}} [options] - standard `Error` options. Pass `{ cause }` to chain the
+     *   underlying error (e.g. a wrapped HTTP/transport failure); it is exposed as `error.cause`.
+     */
+    constructor(message, options) {
+        super(message, options);
         this.name = this.constructor.name;
         this.message = message;
 

--- a/test/MountResolver.test.mjs
+++ b/test/MountResolver.test.mjs
@@ -80,7 +80,7 @@ describe('MountResolver', function () {
     // -------------------------------------------------------------------------
     describe('auto-detection', function () {
         it('detects KV v2 by calling detectFn and returns correct result', async function () {
-            const detectFn = sinon.stub().callsFake((p) => mkDetect('secret', 2));
+            const detectFn = sinon.stub().callsFake(() => mkDetect('secret', 2));
             const resolver = new MountResolver(detectFn, {}, logger);
 
             const result = await resolver.resolve('secret/foo');
@@ -186,9 +186,7 @@ describe('MountResolver', function () {
             const pendingA = new Promise((res) => { resolveA = res; });
             const pendingB = new Promise((res) => { resolveB = res; });
 
-            let callIndex = 0;
             const detectFn = sinon.stub().callsFake((p) => {
-                callIndex++;
                 if (p.startsWith('team/kvA')) {
                     return pendingA.then(() => ({
                         data: { path: 'team/kvA/', type: 'kv', options: { version: '2' } },

--- a/test/conformance.vault-api.test.mjs
+++ b/test/conformance.vault-api.test.mjs
@@ -401,7 +401,7 @@ describe('Vault API conformance', function () {
             // Regression: VaultApiClient must NOT override Content-Type when already set
             let server;
             let seen = {};
-            return new Promise((resolve, reject) => {
+            return new Promise((resolve) => {
                 server = http.createServer((req, res) => {
                     seen.contentType = req.headers['content-type'];
                     res.statusCode = 200;

--- a/test/errors.test.mjs
+++ b/test/errors.test.mjs
@@ -21,10 +21,16 @@ describe('errors', function () {
             expect(err.stack).to.be.a('string');
         });
 
-        it('accepts an optional wrapped error argument', function () {
-            const cause = new Error('cause');
-            const err = new errors.VaultError('boom', cause);
+        it('chains a wrapped error via the standard { cause } option', function () {
+            const cause = new Error('root cause');
+            const err = new errors.VaultError('boom', { cause });
             expect(err.message).to.equal('boom');
+            expect(err.cause).to.equal(cause);
+        });
+
+        it('has no cause when constructed with only a message', function () {
+            const err = new errors.VaultError('boom');
+            expect(err.cause).to.equal(undefined);
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes #105 (`priority: high`, ci). Three CI jobs existed but could not fail in the ways that matter — a PR could regress coverage or introduce lint errors in `test/` and still merge green. This makes the gates enforce.

## Changes

**1. Coverage is now enforced (was informational only).**
Enabled `c8` `check-coverage` with per-metric thresholds in `package.json`, pinned just below the **measured** numbers (statements/lines 98.02%, branches 95.1%, functions 100%) with a small buffer to avoid sub-percent flakiness:

| metric | threshold | measured |
|---|---|---|
| statements | 97 | 98.02 |
| branches | 93 | 95.10 |
| functions | 100 | 100 |
| lines | 97 | 98.02 |

The `coverage` job runs `npm run coverage`, which now fails on a regression below the floor. I verified locally that the gate **passes** at the current numbers (exit 0) and **fails** when tightened (e.g. `--lines 99` → `ERROR: Coverage for lines (98.02%) does not meet global threshold (99%)`, exit 1). The report also uploads on failure (`if: always()`) so a regressing file can be diagnosed.

**2. Lint now covers `test/` (was `eslint src/` only).**
Changed the script to `eslint src/ test/` and taught the flat config the Mocha BDD globals for `test/**/*.mjs`. This immediately surfaced **3 real `no-unused-vars` errors** (in `MountResolver.test.mjs` ×2 and `conformance.vault-api.test.mjs`), now fixed.

**3. `npm audit --audit-level=high` is now documented.**
Added a comment explaining the deliberate choice: moderate advisories are almost always in dev/transitive tooling (mocha/eslint/sinon) and would block release CI with noise unrelated to the three shipped runtime deps; Snyk and CodeQL run as additional broader gates. (Both `moderate` and prod-only audits are currently clean, so this is documentation of intent rather than a loosening.)

**4. Fixed the vacuous `cause` test.**
`test/errors.test.mjs` passed a second constructor argument that `VaultError` silently ignored, so it asserted nothing about wrapping. `VaultError` now accepts the standard ES2022 `{ cause }` option and exposes it as `error.cause` (backward compatible — omitting it leaves `cause` undefined), and the test asserts real chaining. Added a companion test for the no-cause path.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `npm run lint` (now `src/ test/`) and `npm run test:unit` pass locally (255 passing); `npm run coverage` passes the new enforcing gate
- [x] User-facing change recorded in `CHANGELOG.md` (this repo uses versioned headings; added under `# 2.0.4`)
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)

## Acceptance criteria (from #105)

- A PR that drops coverage below the pinned thresholds fails the `coverage` job ✅ (verified locally)
- A PR that introduces a lint error in `test/` fails the `lint` job ✅ (lint now includes `test/`; 3 pre-existing errors fixed)
- Vacuous `cause` test fixed ✅
- `--audit-level=high` documented ✅

## Maintainer follow-up (out of band, not code)

Per the issue: **mark the `lint` and `coverage` jobs as required status checks** in branch-protection settings so the enforcement is binding on merge. I can't change repo settings from a PR.
