### PR TITLE
test: run the KV v2 feature area against a real Vault server (#107)

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -134,3 +134,28 @@ jobs:
 
       - name: Run e2e tests
         run: npm run test:e2e
+
+  # KV v2 integration suite — exercises mount auto-detection, data/metadata path
+  # rewriting, merge-patch update, version ops and metadata ops against a real
+  # KV v2 Vault (the vault-server-kv2 compose service). A single Node version is
+  # enough: the KV v2 code paths have no Node-version-specific behavior, and the
+  # matrix above already covers runtime compatibility.
+  e2e-kv2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Start Vault (docker compose)
+        run: docker compose up -d --wait
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run KV v2 e2e tests
+        run: npm run test:e2e:kv2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+  # Both services are ephemeral dev-mode servers for the e2e suites.
+  #
+  # VAULT_DEV_ROOT_TOKEN_ID is a throwaway dev-mode credential: it only ever
+  # unlocks an in-memory, localhost-bound test instance and is committed on
+  # purpose so the tests can authenticate. Never reuse these values (or this
+  # pattern) for a real Vault deployment.
+
+  # KV v1 server, used by test/e2e/e2e.test.mjs (npm run test:e2e).
+  # Note: -dev-kv-v1 implicitly enables dev mode.
   vault-server:
     image: vault:1.13.3
     environment:
@@ -8,3 +17,15 @@ services:
       - IPC_LOCK
     ports:
       - 127.0.0.1:8200:8200
+
+  # KV v2 server (dev mode mounts secret/ as KV v2 by default), used by
+  # test/e2e/e2e.kv2.test.mjs (npm run test:e2e:kv2).
+  vault-server-kv2:
+    image: vault:1.13.3
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: 34c9c953-4ff5-368a-ac5c-a1e1a8e13a52
+    command: [ "server", "-dev" ]
+    cap_add:
+      - IPC_LOCK
+    ports:
+      - 127.0.0.1:8202:8200

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "test": "mocha --exit \"test/**/*.test.mjs\"",
     "test:unit": "mocha \"test/*.test.mjs\"",
-    "test:e2e": "mocha --exit \"test/e2e/**/*.test.mjs\"",
+    "test:e2e": "mocha --exit \"test/e2e/e2e.test.mjs\"",
+    "test:e2e:kv2": "mocha --exit \"test/e2e/e2e.kv2.test.mjs\"",
     "coverage": "c8 npm run test:unit",
     "lint": "eslint src/ test/",
     "version": "git add -A ."

--- a/test/e2e/e2e.kv2.test.mjs
+++ b/test/e2e/e2e.kv2.test.mjs
@@ -1,0 +1,194 @@
+/**
+ * KV v2 end-to-end suite (issue #107).
+ *
+ * Runs against the `vault-server-kv2` service from docker-compose.yml — a dev-mode
+ * Vault that mounts `secret/` as KV v2 — and exercises the whole v2 feature area
+ * that is otherwise only unit/mock-tested: mount auto-detection, data/metadata
+ * path rewriting, merge-patch update, version operations and metadata operations.
+ *
+ * Start the server with `docker compose up -d`, then `npm run test:e2e:kv2`.
+ */
+import deepFreeze from 'deep-freeze';
+import _ from 'lodash';
+import { expect } from 'chai';
+import VaultClient from '../../src/VaultClient.js';
+import errors from '../../src/errors.js';
+
+// Unique per-run prefix: dev-mode Vault state survives between local runs of the
+// suite against the same container, so version counters must not accumulate.
+const RUN = `e2e-kv2-${Date.now().toString(36)}-${process.pid}`;
+
+describe('E2E KV v2', function () {
+    // Several tests perform a detection round-trip plus a handful of writes.
+    this.timeout(15000);
+
+    beforeEach(function () {
+        this.bootOpts = deepFreeze({
+            api: {
+                url: 'http://127.0.0.1:8202/',
+                kv: { autoDetect: true },
+            },
+            logger: false,
+            auth: {
+                type: 'token',
+                config: {
+                    token: '34c9c953-4ff5-368a-ac5c-a1e1a8e13a52', // see docker-compose.yml (vault-server-kv2)
+                },
+            },
+        });
+        this.client = new VaultClient(this.bootOpts);
+    });
+
+    describe('path rewriting + auto-detection', function () {
+        it('writes and reads through the rewritten data/ path', async function () {
+            const testData = { tst: 'testData', tstInt: 12345 };
+            const path = `secret/${RUN}/rw`;
+
+            const writeRes = await this.client.write(path, testData);
+            // v2 write responses carry the created version in the envelope.
+            expect(writeRes.data.version).to.equal(1);
+
+            const res = await this.client.read(path);
+            expect(res.getData()).to.deep.equal(testData);
+        });
+
+        it('actually stores the secret under <mount>/data/<path> on the server', async function () {
+            const testData = { probe: 'wire-level' };
+            const path = `secret/${RUN}/probe`;
+
+            await this.client.write(path, testData);
+
+            // Raw request bypasses all rewriting: the v2 envelope must exist at data/.
+            const raw = await this.client.request('GET', `/secret/data/${RUN}/probe`);
+            expect(raw.data.data).to.deep.equal(testData);
+            expect(raw.data.metadata.version).to.equal(1);
+        });
+
+        it('lists keys through the rewritten metadata/ path', async function () {
+            await this.client.write(`secret/${RUN}/list/a`, { v: 1 });
+            await this.client.write(`secret/${RUN}/list/b`, { v: 2 });
+
+            const list = await this.client.list(`secret/${RUN}/list`);
+            expect(list.getData().keys.sort()).to.deep.equal(['a', 'b']);
+        });
+
+        it('honours an explicit engines override without auto-detection', async function () {
+            const client = new VaultClient(_.merge({}, this.bootOpts, {
+                api: { kv: { autoDetect: false }, engines: { secret: 2 } },
+            }));
+            const testData = { via: 'engines-override' };
+            const path = `secret/${RUN}/engines`;
+
+            await client.write(path, testData);
+            const res = await client.read(path);
+            expect(res.getData()).to.deep.equal(testData);
+        });
+
+        it('detects a KV v1 mount on the same server and passes paths through raw', async function () {
+            const mount = `kv1-${RUN}`;
+            await this.client.request('POST', `/sys/mounts/${mount}`, { type: 'kv', options: { version: '1' } });
+
+            const testData = { engine: 'kv-v1' };
+            await this.client.write(`${mount}/foo`, testData);
+
+            const res = await this.client.read(`${mount}/foo`);
+            expect(res.getData()).to.deep.equal(testData);
+
+            // v1 stores at the literal path — no data/ segment.
+            const raw = await this.client.request('GET', `/${mount}/foo`);
+            expect(raw.data).to.deep.equal(testData);
+
+            // v2-only helpers must refuse to run against it.
+            try {
+                await this.client.deleteVersions(`${mount}/foo`, [1]);
+                throw new Error('expected UnsupportedOperationError');
+            } catch (e) {
+                expect(e).to.be.instanceOf(errors.UnsupportedOperationError);
+            }
+        });
+    });
+
+    describe('update (merge-patch)', function () {
+        it('merges new fields into the existing secret and bumps the version', async function () {
+            const path = `secret/${RUN}/patch`;
+            await this.client.write(path, { keep: 'original', overwrite: 'old' });
+
+            const patchRes = await this.client.update(path, { overwrite: 'new', added: 'yes' });
+            expect(patchRes.data.version).to.equal(2);
+
+            const res = await this.client.read(path);
+            expect(res.getData()).to.deep.equal({ keep: 'original', overwrite: 'new', added: 'yes' });
+        });
+    });
+
+    describe('delete + version operations', function () {
+        it('delete() soft-deletes the latest version', async function () {
+            const path = `secret/${RUN}/del`;
+            await this.client.write(path, { v: 1 });
+
+            await this.client.delete(path);
+
+            // Reading a soft-deleted latest version yields 404 from Vault.
+            try {
+                await this.client.read(path);
+                throw new Error('expected read of deleted secret to fail');
+            } catch (e) {
+                expect(e.statusCode).to.equal(404);
+            }
+
+            // ...but the version history survives in metadata.
+            const meta = await this.client.readMetadata(path);
+            expect(meta.data.versions['1'].deletion_time).to.not.equal('');
+        });
+
+        it('deleteVersions / undeleteVersions / destroyVersions drive per-version state', async function () {
+            const path = `secret/${RUN}/versions`;
+            await this.client.write(path, { rev: 1 });
+            await this.client.write(path, { rev: 2 });
+
+            // Soft-delete version 1 only: latest (2) must stay readable.
+            await this.client.deleteVersions(path, [1]);
+            let meta = await this.client.readMetadata(path);
+            expect(meta.data.versions['1'].deletion_time).to.not.equal('');
+            expect(meta.data.versions['2'].deletion_time).to.equal('');
+            expect((await this.client.read(path)).getData()).to.deep.equal({ rev: 2 });
+
+            // Undelete restores version 1.
+            await this.client.undeleteVersions(path, [1]);
+            meta = await this.client.readMetadata(path);
+            expect(meta.data.versions['1'].deletion_time).to.equal('');
+
+            // Destroy is permanent and flagged in metadata.
+            await this.client.destroyVersions(path, [1]);
+            meta = await this.client.readMetadata(path);
+            expect(meta.data.versions['1'].destroyed).to.equal(true);
+            expect(meta.data.versions['2'].destroyed).to.equal(false);
+        });
+    });
+
+    describe('metadata operations', function () {
+        it('readMetadata() exposes current_version and the versions map', async function () {
+            const path = `secret/${RUN}/meta`;
+            await this.client.write(path, { rev: 1 });
+            await this.client.write(path, { rev: 2 });
+
+            const meta = await this.client.readMetadata(path);
+            expect(meta.data.current_version).to.equal(2);
+            expect(Object.keys(meta.data.versions).sort()).to.deep.equal(['1', '2']);
+        });
+
+        it('deleteMetadata() permanently removes the secret and its history', async function () {
+            const path = `secret/${RUN}/meta-del`;
+            await this.client.write(path, { doomed: true });
+
+            await this.client.deleteMetadata(path);
+
+            try {
+                await this.client.readMetadata(path);
+                throw new Error('expected readMetadata of removed secret to fail');
+            } catch (e) {
+                expect(e.statusCode).to.equal(404);
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #107 (`priority: high`, ci/testing). The e2e suite only ever ran Vault in `-dev-kv-v1` mode, so the entire KV v2 feature area shipped in 2.x — mount auto-detection, `data/`/`metadata/` path rewriting, merge-patch `update`, version operations, metadata operations — had never touched a real Vault server. This adds a KV v2 dev server to compose and a dedicated e2e suite + CI job for it, as the prerequisite safety net for the planned request-pipeline refactor (#110).

## Changes

- **`docker-compose.yml`** — new `vault-server-kv2` service on `127.0.0.1:8202` running plain `server -dev` (dev mode mounts `secret/` as KV v2 by default; the existing service only gets dev mode because `-dev-kv-v1` is itself a dev flag, so the new one passes `-dev` explicitly). Also adds the requested comment documenting `VAULT_DEV_ROOT_TOKEN_ID` as a throwaway, dev-mode-only, localhost-bound credential.
- **`test/e2e/e2e.kv2.test.mjs`** (new, 10 tests) — against the real server:
  - write/read round-trip through the rewritten `data/` path (asserting the v2 version envelope)
  - a **wire-level probe**: after a rewritten `write`, a raw `request('GET', '/secret/data/…')` proves the secret physically landed at the v2 data path
  - `list` through the `metadata/` path
  - an `engines: { secret: 2 }` override client (no detection round-trip)
  - a KV v1 mount enabled on the same server: auto-detected as passthrough, raw-path storage verified, and `deleteVersions` correctly rejects with `UnsupportedOperationError`
  - `update` merge-patch (fields merged, version bumped)
  - `delete` (soft-delete → read 404 → history survives in metadata)
  - `deleteVersions` / `undeleteVersions` / `destroyVersions` with per-version `deletion_time`/`destroyed` state asserted via `readMetadata`
  - `readMetadata` (`current_version`, versions map) and `deleteMetadata` (permanent, 404 after)
  - Paths are prefixed with a per-run id so re-runs against a long-lived local dev server don't interfere.
- **`package.json`** — `test:e2e` now targets `e2e.test.mjs` explicitly and new `test:e2e:kv2` runs the v2 file, so the existing 4× node-matrix job doesn't pick the new suite up.
- **`.github/workflows/pipeline.yaml`** — one dedicated `e2e-kv2` job (Node 20, no matrix, per the issue): compose up → `npm run test:e2e:kv2`.

## Verification (real server, not mocks)

No Docker in my environment, so I verified with the actual Vault binary (1.17.6) running **two local dev servers mirroring the compose topology exactly** (v1 on 8200, v2 on 8202, same tokens):

- `npm run test:e2e:kv2` → **10 passing**
- `npm run test:e2e` (narrowed script) → 6 passing, 1 pending (the pre-existing skip) — v1 suite unaffected
- **Regression-detection proof** (the issue's acceptance criterion): deliberately corrupting `rewritePath`'s `read` data segment → **4 failing**; corrupting the `undeleteVersions` segment → **1 failing**; reverted → 10 passing. A v2 path-rewriting or version-op regression fails this job.
- `npm run test:unit` (254 passing) and lint unaffected.

The `e2e-kv2` CI job on this PR is the authoritative check for the compose mechanics.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `npm run lint && npm test` pass locally (`npm test` = unit + both e2e suites against the two local dev servers)
- [x] No `# Unreleased`/CHANGELOG entry: test- and CI-only change, nothing ships to npm (no version bump for the same reason — happy to add one if you prefer batching it into the next release)
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)

## Maintainer follow-up (repo settings, not code)

Per the acceptance criteria: mark the new **`e2e-kv2`** job as a **required status check** in branch protection once this merges.

## Note on #114

This PR is independent of #114 (quality gates), but both touch `package.json` scripts and `pipeline.yaml` in adjacent hunks — whichever merges second may need a trivial rebase. The new test file is already clean under #114's stricter lint (`eslint src/ test/` with mocha globals).
