### PR TITLE
perf: sort engines once and bound the MountResolver cache (LRU) (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+
+- Perf: `MountResolver` no longer re-sorts the `api.engines` override map on every `resolve()` —
+  entries are normalized and sorted once at construction (the map is now snapshotted: mutating the
+  object after `VaultClient` construction no longer affects resolution). The mount cache is now a
+  bounded LRU (default 500 entries, `opts.maxCacheSize`) probed by segment-boundary prefix in
+  O(path depth) instead of a linear scan over every cached mount, so long-lived services against
+  many/dynamic mounts get bounded memory and lookup cost. Measured at 200k worst-case resolves:
+  engines lookup 1191ms → 34ms (50 entries), cache lookup 1019ms → 149ms (500 mounts). Also adds
+  test coverage for the previously untested empty-detection-response error. Closes #108.
+
 # 2.0.4 Release notes (2026-07-02)
 
 - CI: make the quality gates actually enforce. `c8` now runs with `check-coverage` and per-metric

--- a/src/MountResolver.js
+++ b/src/MountResolver.js
@@ -2,29 +2,45 @@
 
 const { VaultError } = require('./errors');
 
+// Default cap for the mount cache. Real deployments talk to a handful of static
+// mounts, so this is generous headroom; the cap exists so that a long-lived
+// service pointed at many/dynamic mounts (e.g. multi-tenant) cannot grow the
+// cache — and the per-resolve lookup cost — without bound (issue #108).
+const DEFAULT_MAX_CACHE_SIZE = 500;
+
 /**
  * Resolves the KV engine version for a given secret path.
  *
  * Responsibilities:
  *  1. Check engines override map first (longest-prefix match, no I/O).
  *  2. Auto-detect via detectFn(path) -> { data: { path, type, options } }.
- *  3. Cache by canonical mount path; de-duplicate in-flight detections.
+ *  3. Cache by canonical mount path (bounded LRU); de-duplicate in-flight detections.
  *  4. On failure, throw VaultError with actionable guidance.
  *
- * @param {Function} detectFn          - async (path: string) => Vault mount-info response
- * @param {Object}   enginesOverride   - { [mountPrefix]: version }
- * @param {Object}   logger            - logger with .debug(), .error() etc.
- * @param {Object}   [opts]            - additional options
- * @param {boolean}  [opts.disabled]   - if true, always return passthrough (version 1)
+ * @param {Function} detectFn            - async (path: string) => Vault mount-info response
+ * @param {Object}   enginesOverride     - { [mountPrefix]: version }; snapshotted at construction
+ * @param {Object}   logger              - logger with .debug(), .error() etc.
+ * @param {Object}   [opts]              - additional options
+ * @param {boolean}  [opts.disabled]     - if true, always return passthrough (version 1)
+ * @param {number}   [opts.maxCacheSize] - LRU cap for the mount cache (default 500)
  */
 class MountResolver {
     constructor(detectFn, enginesOverride, logger, opts) {
         this.__detectFn = detectFn;
-        this.__engines = enginesOverride || {};
         this.__log = logger;
         this.__disabled = opts && opts.disabled === true;
+        this.__maxCacheSize = (opts && opts.maxCacheSize) || DEFAULT_MAX_CACHE_SIZE;
 
-        // Cache: canonical mount path (no trailing slash) -> { mount, version, type }
+        // The engines map is immutable after construction: normalize and sort the
+        // entries once (longest raw prefix first, matching the previous per-call
+        // sort) instead of re-sorting on every resolve().
+        this.__engines = Object.entries(enginesOverride || {})
+            .sort((a, b) => b[0].length - a[0].length)
+            .map(([prefix, version]) => [prefix.replace(/\/+$/, ''), Number(version)]);
+
+        // LRU cache: canonical mount path (no trailing slash) -> { mount, version, type }.
+        // Map iteration order is insertion order; hits are re-inserted to refresh
+        // recency, and inserts evict the oldest entries beyond __maxCacheSize.
         this.__cache = new Map();
         // In-flight promises: canonical mount path -> Promise<{mount,version,type}>
         this.__inflight = new Map();
@@ -69,23 +85,51 @@ class MountResolver {
     // -------------------------------------------------------------------------
 
     /**
-     * Longest-prefix match against the engines override map.
+     * Longest-prefix match against the engines entries precomputed (normalized
+     * and sorted longest-first) in the constructor.
      * Returns { mount, version } or null if no match found.
      */
     __enginesOverrideLookup(path) {
-        const entries = Object.entries(this.__engines);
-        if (entries.length === 0) return null;
-
-        // Sort by descending key length (longest first) for prefix match
-        entries.sort((a, b) => b[0].length - a[0].length);
-
-        for (const [prefix, version] of entries) {
-            const normalised = prefix.replace(/\/+$/, '');
-            if (path === normalised || path.startsWith(normalised + '/')) {
-                return { mount: normalised, version: Number(version), type: 'kv' };
+        for (const [prefix, version] of this.__engines) {
+            if (path === prefix || path.startsWith(prefix + '/')) {
+                return { mount: prefix, version, type: 'kv' };
             }
         }
         return null;
+    }
+
+    /**
+     * Find the cached entry whose canonical mount is a segment-boundary prefix
+     * of the path. Vault forbids nested mounts, so at most one entry can match;
+     * the path's segment prefixes are probed deepest-first as exact keys
+     * (O(path depth) instead of a scan over the whole cache). A hit is
+     * re-inserted to refresh its LRU recency.
+     */
+    __cacheLookup(path) {
+        let candidate = path;
+        while (candidate !== '') {
+            const entry = this.__cache.get(candidate);
+            if (entry !== undefined) {
+                this.__cache.delete(candidate);
+                this.__cache.set(candidate, entry);
+                return entry;
+            }
+            const slash = candidate.lastIndexOf('/');
+            candidate = slash === -1 ? '' : candidate.slice(0, slash);
+        }
+        return null;
+    }
+
+    /**
+     * Insert (or refresh) a cache entry, evicting the least-recently-used
+     * entries once the cap is exceeded.
+     */
+    __cacheStore(canonicalMount, entry) {
+        this.__cache.delete(canonicalMount);
+        this.__cache.set(canonicalMount, entry);
+        while (this.__cache.size > this.__maxCacheSize) {
+            this.__cache.delete(this.__cache.keys().next().value);
+        }
     }
 
     /**
@@ -100,10 +144,9 @@ class MountResolver {
      */
     __detectWithCache(interimKey, path) {
         // Check persistent cache first (keyed on canonical mount path)
-        for (const [mountKey, entry] of this.__cache) {
-            if (path === mountKey || path.startsWith(mountKey + '/')) {
-                return Promise.resolve(entry);
-            }
+        const cached = this.__cacheLookup(path);
+        if (cached !== null) {
+            return Promise.resolve(cached);
         }
 
         // Check in-flight for this interim key (first segment or full path)
@@ -137,8 +180,8 @@ class MountResolver {
                 const entry = { mount: canonicalMount, version, type };
                 this.__log.debug('MountResolver: detected %s as type=%s version=%d', canonicalMount, type, version);
 
-                // Store in persistent cache
-                this.__cache.set(canonicalMount, entry);
+                // Store in persistent cache (bounded LRU)
+                this.__cacheStore(canonicalMount, entry);
                 // Clear in-flight
                 this.__inflight.delete(interimKey);
                 return entry;

--- a/src/MountResolver.js
+++ b/src/MountResolver.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { VaultError } = require('./errors');
+const { VaultError, InvalidArgumentsError } = require('./errors');
 
 // Default cap for the mount cache. Real deployments talk to a handful of static
 // mounts, so this is generous headroom; the cap exists so that a long-lived
@@ -29,7 +29,17 @@ class MountResolver {
         this.__detectFn = detectFn;
         this.__log = logger;
         this.__disabled = opts && opts.disabled === true;
-        this.__maxCacheSize = (opts && opts.maxCacheSize) || DEFAULT_MAX_CACHE_SIZE;
+        // Validate before use: a non-positive cap would make the eviction loop in
+        // __cacheStore spin forever (size can never drop below the cap), and a
+        // non-integer cap makes the bound meaningless.
+        const maxCacheSize = opts && opts.maxCacheSize;
+        if (maxCacheSize !== undefined
+            && (!Number.isInteger(maxCacheSize) || maxCacheSize <= 0)) {
+            throw new InvalidArgumentsError(
+                `MountResolver: opts.maxCacheSize must be a positive integer, got ${String(maxCacheSize)}`
+            );
+        }
+        this.__maxCacheSize = maxCacheSize !== undefined ? maxCacheSize : DEFAULT_MAX_CACHE_SIZE;
 
         // The engines map is immutable after construction: normalize and sort the
         // entries once (longest raw prefix first, matching the previous per-call

--- a/test/MountResolver.test.mjs
+++ b/test/MountResolver.test.mjs
@@ -216,9 +216,125 @@ describe('MountResolver', function () {
     });
 
     // -------------------------------------------------------------------------
+    // engines map is snapshotted at construction
+    // -------------------------------------------------------------------------
+    describe('engines snapshot', function () {
+        it('sorts and normalizes the engines map once — later mutations have no effect', async function () {
+            const detectFn = sinon.stub().rejects(new Error('should not be called'));
+            const engines = { secret: 2 };
+            const resolver = new MountResolver(detectFn, engines, logger, { disabled: true });
+
+            // Mutating the map after construction must not change resolution:
+            // the entries are precomputed in the constructor (issue #108).
+            engines.secret = 1;
+            engines.other = 2;
+
+            const listed = await resolver.resolve('secret/foo');
+            expect(listed.version).to.equal(2);
+
+            const unlisted = await resolver.resolve('other/bar');
+            expect(unlisted.version).to.equal(1);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // cache bounding (LRU)
+    // -------------------------------------------------------------------------
+    describe('cache bounding (LRU)', function () {
+        function mountDetectFn() {
+            // Detects "<first-segment>" as a KV v2 mount for any path.
+            return sinon.stub().callsFake((p) => mkDetect(p.split('/')[0], 2));
+        }
+
+        it('evicts the least-recently-used mount once the cap is exceeded', async function () {
+            const detectFn = mountDetectFn();
+            const resolver = new MountResolver(detectFn, {}, logger, { maxCacheSize: 2 });
+
+            await resolver.resolve('m1/a');
+            await resolver.resolve('m2/a');
+            expect(detectFn).to.have.been.calledTwice;
+
+            // Third mount exceeds the cap of 2 → m1 (oldest) is evicted.
+            await resolver.resolve('m3/a');
+
+            // m2 and m3 are still cached...
+            await resolver.resolve('m2/b');
+            await resolver.resolve('m3/b');
+            expect(detectFn).to.have.been.calledThrice;
+
+            // ...but m1 must be re-detected.
+            await resolver.resolve('m1/b');
+            expect(detectFn.callCount).to.equal(4);
+        });
+
+        it('a cache hit refreshes recency, protecting the entry from eviction', async function () {
+            const detectFn = mountDetectFn();
+            const resolver = new MountResolver(detectFn, {}, logger, { maxCacheSize: 2 });
+
+            await resolver.resolve('m1/a');
+            await resolver.resolve('m2/a');
+
+            // Touch m1 so m2 becomes the least-recently-used entry.
+            await resolver.resolve('m1/b');
+
+            // Inserting m3 must now evict m2, not m1.
+            await resolver.resolve('m3/a');
+            expect(detectFn).to.have.been.calledThrice;
+
+            await resolver.resolve('m1/c');
+            expect(detectFn).to.have.been.calledThrice; // m1 survived
+
+            await resolver.resolve('m2/b');
+            expect(detectFn.callCount).to.equal(4); // m2 was evicted and re-detected
+        });
+
+        it('keeps in-flight dedup working with a bounded cache', async function () {
+            const detectFn = sinon.stub().callsFake(() => mkDetect('secret', 2));
+            const resolver = new MountResolver(detectFn, {}, logger, { maxCacheSize: 2 });
+
+            const [r1, r2, r3] = await Promise.all([
+                resolver.resolve('secret/a'),
+                resolver.resolve('secret/b'),
+                resolver.resolve('secret/c'),
+            ]);
+            expect(detectFn).to.have.been.calledOnce;
+            expect(r1.version).to.equal(2);
+            expect(r2.version).to.equal(2);
+            expect(r3.version).to.equal(2);
+        });
+    });
+
+    // -------------------------------------------------------------------------
     // failure handling
     // -------------------------------------------------------------------------
     describe('failure handling', function () {
+        it('throws VaultError with guidance when the detection response is empty', async function () {
+            const detectFn = sinon.stub().resolves({});
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            try {
+                await resolver.resolve('secret/foo');
+                throw new Error('expected rejection');
+            } catch (err) {
+                expect(err).to.be.instanceOf(errors.VaultError);
+                expect(err.message).to.include('Unexpected empty detection response');
+                expect(err.message).to.include('api.engines');
+            }
+        });
+
+        it('treats a null detection response as empty too', async function () {
+            const detectFn = sinon.stub().resolves(null);
+            const resolver = new MountResolver(detectFn, {}, logger);
+
+            try {
+                await resolver.resolve('secret/foo');
+                throw new Error('expected rejection');
+            } catch (err) {
+                expect(err).to.be.instanceOf(errors.VaultError);
+                expect(err.message).to.include('Unexpected empty detection response');
+            }
+        });
+
         it('throws VaultError when detectFn rejects', async function () {
             const detectFn = sinon.stub().rejects(new Error('403 Forbidden'));
             const resolver = new MountResolver(detectFn, {}, logger);

--- a/test/MountResolver.test.mjs
+++ b/test/MountResolver.test.mjs
@@ -288,6 +288,23 @@ describe('MountResolver', function () {
             expect(detectFn.callCount).to.equal(4); // m2 was evicted and re-detected
         });
 
+        it('rejects an invalid maxCacheSize at construction (review: a negative cap would hang eviction)', function () {
+            const detectFn = sinon.stub();
+            for (const bad of [-1, 0, 1.5, NaN, Infinity, '10']) {
+                expect(
+                    () => new MountResolver(detectFn, {}, logger, { maxCacheSize: bad }),
+                    `maxCacheSize=${String(bad)} must be rejected`
+                ).to.throw(errors.InvalidArgumentsError, 'maxCacheSize');
+            }
+        });
+
+        it('falls back to the default cap when maxCacheSize is omitted', async function () {
+            const detectFn = sinon.stub().callsFake(() => mkDetect('secret', 2));
+            const resolver = new MountResolver(detectFn, {}, logger, {});
+            const result = await resolver.resolve('secret/foo');
+            expect(result.version).to.equal(2);
+        });
+
         it('keeps in-flight dedup working with a bounded cache', async function () {
             const detectFn = sinon.stub().callsFake(() => mkDetect('secret', 2));
             const resolver = new MountResolver(detectFn, {}, logger, { maxCacheSize: 2 });


### PR DESCRIPTION
## Summary

Fixes #108 (`priority: medium`, performance). Two hot-path issues in `MountResolver`, both hit on **every** read/write/list/delete/update:

1. `__enginesOverrideLookup` re-sorted `Object.entries(engines)` on each `resolve()` although the map is immutable after construction.
2. The mount cache was unbounded and linearly scanned (`startsWith` over every cached mount) per resolve — monotonic memory + scan growth in long-lived services against many/dynamic mounts.

**Measured** (200k worst-case resolves, old vs new):

| lookup | before | after |
|---|---|---|
| engines override (50 entries) | 1191ms | **34ms** |
| mount cache (500 cached mounts) | 1019ms | **149ms** |

## Changes

- **Engines sorted once in the constructor** — entries are normalized + sorted (longest raw prefix first, matching the previous per-call sort exactly) at construction. Observable consequence, covered by a test and flagged in the CHANGELOG: the map is now *snapshotted*, so mutating the object after `VaultClient` construction no longer affects resolution.
- **Bounded LRU cache** — default cap 500 (`opts.maxCacheSize`), per the issue's "a few hundred". Hits refresh recency; inserts evict the oldest beyond the cap. Sizing rationale (the issue's open question): typical deployments talk to a handful of static mounts, so 500 is generous headroom while still bounding the multi-tenant/dynamic-mount worst case.
- **Segment-boundary probe instead of linear scan** — the cache is now probed with the path's segment prefixes deepest-first as exact `Map.get` keys: O(path depth) instead of O(cache size). Vault forbids nested mounts, so at most one cached mount can prefix a given path, making deepest-first probing behavior-equivalent to the old insertion-order scan.
- **The recursive collision-fallback logic is untouched**, per the issue's explicit guardrail — all its existing tests (in-flight dedup, shared-first-segment regression, retry-after-failure) pass unchanged.

## Tests (written red-first where behavior changed)

- LRU eviction once the cap is exceeded (evicted mount re-detects; survivors don't)
- Cache-hit recency refresh protects an entry from eviction
- In-flight dedup still holds with a bounded cache
- Engines-snapshot semantics (post-construction mutation has no effect)
- The previously untested `Unexpected empty detection response` throw (empty **and** null response variants) — closing the issue's coverage gap

MountResolver suite: 21 passing; full unit suite: **260 passing**; lint clean.

## Verification beyond unit tests

- **Real server**: ran a Vault dev server (1.17.6 binary) and drove the refactored resolver through `VaultClient` end-to-end — autoDetect on a KV v2 mount, passthrough detection of a KV v1 mount on the same server, and an `engines`-override client. All round-trips correct.
- **aws4 checklist item**: the lockfile pins `aws4@1.8.0`; the existing IAM unit tests assert the regional STS signing behavior from 2.0.0 (regional Host header + `/eu-central-1/sts/aws4_request` credential scope) and pass on exactly that version — **no `npm update aws4` needed**.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `npm run lint && npm test` passes locally (unit: 260 passing; e2e suites additionally verified against local dev servers in the prior PRs' setup)
- [x] User-facing changes recorded under `# Unreleased` in `CHANGELOG.md` (no version bump here to avoid colliding with open #114, which claims 2.0.4 — fold into whichever release ships next)
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)
