### PR TITLE
refactor: unify the request pipeline in VaultClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   many/dynamic mounts get bounded memory and lookup cost. Measured at 200k worst-case resolves:
   engines lookup 1191ms → 34ms (50 entries), cache lookup 1019ms → 149ms (500 mounts). Also adds
   test coverage for the previously untested empty-detection-response error. Closes #108.
+- Internal refactor: unify the copy-pasted request pipeline in `VaultClient`. `update()`, the raw
+  `request()`, and the KV v2-only helpers now delegate to the single `__resolveAndRequest` entry
+  point (one `resolver.resolve()` call site instead of three). No behavior change — the pipeline
+  is locked by new characterization tests across v1/v2 mounts, namespaces, and extra headers.
+  Closes #110.
 
 # 2.0.4 Release notes (2026-07-02)
 

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -246,40 +246,74 @@ class VaultClient {
     }
 
     // -------------------------------------------------------------------------
-    // Internal resolve + request helper
+    // Internal resolve + request pipeline — the single entry point
     // -------------------------------------------------------------------------
 
     /**
-     * Resolve the mount version for a path, rewrite the path, make the request,
-     * and normalise the response.  Returns a { apiPath, body, version, mount } object.
+     * The unified request pipeline: fetch an auth token, build headers, resolve
+     * the mount version, rewrite the path for the engine version, make the
+     * request, and return a { body, version, mount, apiPath } object.
      *
-     * When the resolver is disabled (autoDetect:false, no engines), it skips
-     * resolution and passes through raw, preserving identical behavior to before.
+     * When the resolver is disabled (autoDetect:false, no engines), resolution
+     * yields a v1 passthrough, preserving identical behavior to before.
      *
+     * @param {string} op - logical operation (read, write, list, delete, update, deleteVersions, …)
+     * @param {string} method - HTTP method
+     * @param {string} path - caller-supplied secret path
+     * @param {Object|null} data - request body
+     * @param {Object} [extraHeaders] - extra HTTP headers merged over the token header
+     * @param {Object} [options]
+     * @param {boolean} [options.raw=false] - skip mount resolution and path rewriting;
+     *      the literal path and data are sent as-is (raw request() semantics)
+     * @param {boolean} [options.v2Only=false] - reject with UnsupportedOperationError
+     *      unless the resolved mount is a KV v2 engine
+     * @param {boolean} [options.wrapData=false] - force the { data } envelope on every
+     *      engine version (merge-patch update() semantics); by default only v2
+     *      write/update wrap non-null data and everything else passes through
+     * @returns {Promise<{body: *, version: (number|undefined), mount: (string|undefined), apiPath: string}>}
      * @private
      */
-    __resolveAndRequest(op, method, path, data, extraHeaders) {
+    __resolveAndRequest(op, method, path, data, extraHeaders, options) {
+        const { raw = false, v2Only = false, wrapData = false } = options || {};
+
         return this.__auth.getAuthToken()
             .then((token) => {
                 const headers = Object.assign({}, this.getHeaders(token), extraHeaders || {});
 
+                if (raw) {
+                    return this.__api.makeRequest(method, path, data, headers)
+                        .then((body) => ({ body, version: undefined, mount: undefined, apiPath: path }));
+                }
+
                 return this.__resolver.resolve(path)
                     .then(({ mount, version }) => {
-                        let apiPath;
-                        let requestData = data;
+                        if (v2Only && version !== 2) {
+                            throw new errors.UnsupportedOperationError(
+                                `Operation "${op}" is only supported on KV v2 mounts. ` +
+                                `Mount "${mount}" is not a KV v2 engine.`
+                            );
+                        }
 
+                        let apiPath;
                         if (version === 2) {
                             // Split the path into mount + logical sub-path and rewrite for KV v2
                             const logicalPath = this.__logicalPath(path, mount);
                             apiPath = rewritePath(version, op, mount, logicalPath);
-                            // Wrap data in { data: ... } on v2 write/update
-                            if ((op === 'write' || op === 'update') && data !== null && data !== undefined) {
-                                requestData = { data };
-                            }
                         } else {
                             // v1 / disabled: preserve the caller's literal path byte-for-byte,
                             // including any trailing slash, to maintain the old wire behavior.
                             apiPath = path;
+                        }
+
+                        // Data envelope: wrapData forces { data } on every engine version
+                        // (merge-patch update() semantics — v1 mounts reject PATCH anyway);
+                        // otherwise only v2 write/update wrap non-null data.
+                        let requestData = data;
+                        if (wrapData) {
+                            requestData = { data };
+                        } else if (version === 2 && (op === 'write' || op === 'update')
+                                && data !== null && data !== undefined) {
+                            requestData = { data };
                         }
 
                         return this.__api.makeRequest(method, apiPath, requestData, headers)
@@ -399,29 +433,11 @@ class VaultClient {
      */
     update(path, data) {
         this.__log.debug('update (patch) secret %s', path);
-        const patchHeaders = { 'Content-Type': 'application/merge-patch+json' };
-        return this.__auth.getAuthToken()
-            .then((token) => {
-                const headers = Object.assign({}, this.getHeaders(token), patchHeaders);
-
-                return this.__resolver.resolve(path)
-                    .then(({ mount, version }) => {
-                        let apiPath;
-                        if (version === 2) {
-                            const logicalPath = this.__logicalPath(path, mount);
-                            apiPath = rewritePath(version, 'update', mount, logicalPath);
-                        } else {
-                            // v1: preserve the caller's literal path byte-for-byte
-                            apiPath = path;
-                        }
-
-                        // Always wrap in { data } for PATCH (update() is a KV v2 merge-patch operation;
-                        // v1 mounts do not support PATCH and Vault will return 405)
-                        const requestData = { data };
-
-                        return this.__api.makeRequest('PATCH', apiPath, requestData, headers);
-                    });
-            })
+        // wrapData: update() is a KV v2 merge-patch operation, so the { data } envelope
+        // is always applied (v1 mounts do not support PATCH and Vault will return 405)
+        return this.__resolveAndRequest('update', 'PATCH', path, data,
+            { 'Content-Type': 'application/merge-patch+json' }, { wrapData: true })
+            .then(({ body }) => body)
             .catch((reason) => {
                 this.__log.error('update secret failed: %s', reason.message);
                 throw reason;
@@ -439,8 +455,8 @@ class VaultClient {
      */
     request(method, path, data) {
         this.__log.debug('raw request %s %s', method, path);
-        return this.__auth.getAuthToken()
-            .then((token) => this.__api.makeRequest(method, path, data === undefined ? null : data, this.getHeaders(token)))
+        return this.__resolveAndRequest('request', method, path, data === undefined ? null : data, null, { raw: true })
+            .then(({ body }) => body)
             .catch((reason) => {
                 this.__log.error('raw request failed: %s', reason.message);
                 throw reason;
@@ -538,28 +554,13 @@ class VaultClient {
     }
 
     /**
-     * Shared implementation for v2-only operations.
-     * Resolves the mount, verifies it is v2, rewrites the path, makes the request.
+     * Shared implementation for v2-only operations: delegates to the unified
+     * pipeline with the KV v2 version assertion enabled.
      * @private
      */
     __v2Only(op, method, path, data) {
-        return this.__auth.getAuthToken()
-            .then((token) => {
-                const headers = this.getHeaders(token);
-
-                return this.__resolver.resolve(path)
-                    .then(({ mount, version }) => {
-                        if (version !== 2) {
-                            throw new errors.UnsupportedOperationError(
-                                `Operation "${op}" is only supported on KV v2 mounts. ` +
-                                `Mount "${mount}" is not a KV v2 engine.`
-                            );
-                        }
-                        const logicalPath = this.__logicalPath(path, mount);
-                        const apiPath = rewritePath(version, op, mount, logicalPath);
-                        return this.__api.makeRequest(method, apiPath, data, headers);
-                    });
-            });
+        return this.__resolveAndRequest(op, method, path, data, null, { v2Only: true })
+            .then(({ body }) => body);
     }
 
     /**

--- a/test/VaultClient.pipeline.test.mjs
+++ b/test/VaultClient.pipeline.test.mjs
@@ -1,0 +1,278 @@
+import _ from 'lodash';
+import sinon from 'sinon';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import VaultClient from '../src/VaultClient.js';
+import errors from '../src/errors.js';
+
+use(sinonChai);
+
+function bootOpts(overrides) {
+    return _.merge({
+        api: { url: 'https://example.com/' },
+        logger: false,
+        auth: {
+            type: 'token',
+            config: { token: 'tok-123' },
+        },
+    }, overrides);
+}
+
+/**
+ * Characterization tests for the request pipeline (issue #110).
+ *
+ * They pin the observable behavior of __resolveAndRequest / update() /
+ * request() / the v2-only helpers across v1/v2 mounts, namespaces and
+ * extra headers, so the pipeline can be unified without behavior change.
+ */
+describe('VaultClient request pipeline (characterization, #110)', function () {
+    const token = { getId: () => 'tid' };
+
+    afterEach(function () {
+        VaultClient.clear();
+    });
+
+    function makeClient(overrides) {
+        const client = new VaultClient(bootOpts(overrides));
+        client.__auth = { getAuthToken: sinon.stub().resolves(token) };
+        return client;
+    }
+
+    describe('#__resolveAndRequest() contract', function () {
+        it('resolves { body, version, mount, apiPath } on a KV v2 mount', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            const body = { data: { data: { k: 'v' } } };
+            client.__api = { makeRequest: sinon.stub().resolves(body) };
+            return client.__resolveAndRequest('read', 'GET', 'secret/foo', null).then((result) => {
+                expect(result.body).to.equal(body);
+                expect(result.version).to.equal(2);
+                expect(result.mount).to.equal('secret');
+                expect(result.apiPath).to.equal('secret/data/foo');
+                expect(client.__api.makeRequest).to.have.been.calledWith(
+                    'GET', 'secret/data/foo', null, { 'X-Vault-Token': 'tid' }
+                );
+            });
+        });
+
+        it('merges extraHeaders over the token header', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.__resolveAndRequest('read', 'GET', 'secret/foo', null, { 'X-Extra': '1' }).then(() => {
+                expect(client.__api.makeRequest).to.have.been.calledWith(
+                    'GET', 'secret/data/foo', null, { 'X-Vault-Token': 'tid', 'X-Extra': '1' }
+                );
+            });
+        });
+
+        it('lets extraHeaders win over the token header on a key collision', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.__resolveAndRequest('read', 'GET', 'secret/foo', null, { 'X-Vault-Token': 'other' }).then(() => {
+                expect(client.__api.makeRequest).to.have.been.calledWith(
+                    'GET', 'secret/data/foo', null, { 'X-Vault-Token': 'other' }
+                );
+            });
+        });
+
+        it('wraps non-null data in { data } for the update op on v2', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.__resolveAndRequest('update', 'PATCH', 'secret/foo', { a: 1 }).then(() => {
+                expect(client.__api.makeRequest).to.have.been.calledWith(
+                    'PATCH', 'secret/data/foo', { data: { a: 1 } }, { 'X-Vault-Token': 'tid' }
+                );
+            });
+        });
+
+        it('does not wrap null data for the write op on v2', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.__resolveAndRequest('write', 'POST', 'secret/foo', null).then(() => {
+                expect(client.__api.makeRequest.getCall(0).args[2]).to.equal(null);
+            });
+        });
+
+        it('does not wrap undefined data for the write op on v2', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.__resolveAndRequest('write', 'POST', 'secret/foo', undefined).then(() => {
+                expect(client.__api.makeRequest.getCall(0).args[2]).to.equal(undefined);
+            });
+        });
+
+        it('keeps the literal path (incl. trailing slash) and unwrapped data on v1', function () {
+            const client = makeClient({ api: { engines: { legacy: 1 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.__resolveAndRequest('write', 'POST', 'legacy/foo/', { a: 1 }).then((result) => {
+                expect(result.version).to.equal(1);
+                expect(result.apiPath).to.equal('legacy/foo/');
+                expect(client.__api.makeRequest).to.have.been.calledWith(
+                    'POST', 'legacy/foo/', { a: 1 }, { 'X-Vault-Token': 'tid' }
+                );
+            });
+        });
+
+        it('resolves the mount exactly once per call', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({ data: { data: {} } }) };
+            const resolve = sinon.spy(client.__resolver, 'resolve');
+            return client.read('secret/foo').then(() => {
+                expect(resolve).to.have.been.calledOnceWith('secret/foo');
+            });
+        });
+    });
+
+    describe('#update() across mount versions', function () {
+        it('returns the raw response body on v2', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            const response = { data: { version: 4 } };
+            client.__api = { makeRequest: sinon.stub().resolves(response) };
+            return client.update('secret/foo', { a: 1 }).then((res) => {
+                expect(res).to.equal(response);
+            });
+        });
+
+        it('keeps the literal path and still wraps the body in { data } on a v1 mount', function () {
+            const client = makeClient({ api: { engines: { legacy: 1 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.update('legacy/foo', { a: 1 }).then(() => {
+                const [method, path, data, headers] = client.__api.makeRequest.getCall(0).args;
+                expect(method).to.equal('PATCH');
+                expect(path).to.equal('legacy/foo');
+                expect(data).to.deep.equal({ data: { a: 1 } });
+                expect(headers).to.deep.equal({
+                    'X-Vault-Token': 'tid',
+                    'Content-Type': 'application/merge-patch+json',
+                });
+            });
+        });
+
+        it('passes through byte-for-byte (with the { data } envelope) when the resolver is disabled', function () {
+            const client = makeClient();
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.update('any/path/', { a: 1 }).then(() => {
+                const [method, path, data, headers] = client.__api.makeRequest.getCall(0).args;
+                expect(method).to.equal('PATCH');
+                expect(path).to.equal('any/path/');
+                expect(data).to.deep.equal({ data: { a: 1 } });
+                expect(headers['Content-Type']).to.equal('application/merge-patch+json');
+            });
+        });
+
+        it('rejects with the underlying error', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            const boom = new Error('boom');
+            client.__api = { makeRequest: sinon.stub().rejects(boom) };
+            return client.update('secret/foo', { a: 1 }).then(
+                () => { throw new Error('expected rejection'); },
+                (err) => { expect(err).to.equal(boom); }
+            );
+        });
+    });
+
+    describe('#request() raw passthrough', function () {
+        it('never consults the mount resolver', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const resolve = sinon.spy(client.__resolver, 'resolve');
+            return client.request('GET', 'secret/x').then(() => {
+                expect(resolve).to.not.have.been.called;
+                // Even though "secret" is a v2 mount, the raw path is sent untouched
+                expect(client.__api.makeRequest).to.have.been.calledWith(
+                    'GET', 'secret/x', null, { 'X-Vault-Token': 'tid' }
+                );
+            });
+        });
+
+        it('preserves a leading slash in the literal path', function () {
+            const client = makeClient();
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.request('GET', '/sys/mounts', { type: 'kv' }).then(() => {
+                expect(client.__api.makeRequest).to.have.been.calledWith(
+                    'GET', '/sys/mounts', { type: 'kv' }, { 'X-Vault-Token': 'tid' }
+                );
+            });
+        });
+
+        it('rejects with the underlying error', function () {
+            const client = makeClient();
+            const boom = new Error('boom');
+            client.__api = { makeRequest: sinon.stub().rejects(boom) };
+            return client.request('GET', 'sys/health').then(
+                () => { throw new Error('expected rejection'); },
+                (err) => { expect(err).to.equal(boom); }
+            );
+        });
+    });
+
+    describe('v2-only version assertion', function () {
+        it('rejects before making any HTTP request on a v1 mount', function () {
+            const client = makeClient({ api: { engines: { secret: 1 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.deleteVersions('secret/foo', [1]).then(
+                () => { throw new Error('expected rejection'); },
+                (err) => {
+                    expect(err).to.be.instanceOf(errors.UnsupportedOperationError);
+                    expect(err.message).to.equal(
+                        'Operation "deleteVersions" is only supported on KV v2 mounts. ' +
+                        'Mount "secret" is not a KV v2 engine.'
+                    );
+                    expect(client.__api.makeRequest).to.not.have.been.called;
+                }
+            );
+        });
+
+        it('rejects on a passthrough mount when the resolver is disabled', function () {
+            const client = makeClient();
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.destroyVersions('secret/foo', [1]).then(
+                () => { throw new Error('expected rejection'); },
+                (err) => {
+                    expect(err).to.be.instanceOf(errors.UnsupportedOperationError);
+                    expect(err.message).to.include('destroyVersions');
+                    expect(err.message).to.include('Mount "secret"');
+                }
+            );
+        });
+
+        it('returns the raw response body without an envelope', function () {
+            const client = makeClient({ api: { engines: { secret: 2 } } });
+            const response = { request_id: 'r' };
+            client.__api = { makeRequest: sinon.stub().resolves(response) };
+            return client.deleteMetadata('secret/foo').then((res) => {
+                expect(res).to.equal(response);
+            });
+        });
+    });
+
+    describe('namespace stays out of per-request headers', function () {
+        // The namespace is injected centrally by VaultApiClient#makeRequest, so none of
+        // the pipeline entry points may add an X-Vault-Namespace header of their own.
+        it('read() on a namespaced client sends only the token header', function () {
+            const client = makeClient({ api: { namespace: 'ns1', engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({ data: { data: {} } }) };
+            return client.read('secret/foo').then(() => {
+                expect(client.__api.makeRequest.getCall(0).args[3]).to.deep.equal({ 'X-Vault-Token': 'tid' });
+            });
+        });
+
+        it('update() on a namespaced client sends only token + content-type headers', function () {
+            const client = makeClient({ api: { namespace: 'ns1', engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.update('secret/foo', { a: 1 }).then(() => {
+                expect(client.__api.makeRequest.getCall(0).args[3]).to.deep.equal({
+                    'X-Vault-Token': 'tid',
+                    'Content-Type': 'application/merge-patch+json',
+                });
+            });
+        });
+
+        it('deleteVersions() on a namespaced client sends only the token header', function () {
+            const client = makeClient({ api: { namespace: 'ns1', engines: { secret: 2 } } });
+            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            return client.deleteVersions('secret/foo', [1]).then(() => {
+                expect(client.__api.makeRequest.getCall(0).args[3]).to.deep.equal({ 'X-Vault-Token': 'tid' });
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #110. The resolve-mount → rewrite-path → make-request pipeline was implemented three times in `src/VaultClient.js` (`__resolveAndRequest`, `update()`, `__v2Only()`), with `request()` carrying a partial fourth copy. Any cross-cutting change (retries, per-request headers, a new engine version) had to be applied identically in each copy. This PR extends `__resolveAndRequest(op, method, path, data, extraHeaders, options)` into the single entry point and makes the other three delegate to it. Pure refactor — zero behavior change.

## Changes

- `src/VaultClient.js`
  - `__resolveAndRequest` gains an `options` parameter: `{ raw }` (skip resolution/rewriting — literal passthrough), `{ v2Only }` (KV v2 version assertion before any HTTP request), `{ wrapData }` (force the `{ data }` envelope on every engine version — merge-patch semantics)
  - `update()` is now a delegation passing the `application/merge-patch+json` header and `{ wrapData: true }` (its envelope has always applied on v1 too — preserved)
  - `__v2Only()` delegates with `{ v2Only: true }`, keeping the exact `UnsupportedOperationError` message and its assert-before-request ordering
  - `request()` routes through `{ raw: true }`
  - `grep -c "resolver.resolve(" src/VaultClient.js` drops to **1** (was 3)
  - The ~8× catch/log/rethrow in the public methods is intentionally untouched — that extraction is the follow-up called out in #110
- `test/VaultClient.pipeline.test.mjs` (new) — 21 characterization tests written **before** the refactor and verified green against the old code, pinning v1/v2 × namespace × extra-headers behavior: byte-for-byte v1 path passthrough (incl. trailing slash), `update()`'s always-on envelope on v1, raw `request()` never consulting the resolver, exact v2-only error message, no `X-Vault-Namespace` leakage into per-request headers
- `CHANGELOG.md` — bullet under a new `# Unreleased` heading (no version bump)

Note: sibling PRs (#116 and the in-flight PRs for #109/#111) also add `# Unreleased` bullets, so a trivial CHANGELOG rebase conflict is possible.

## Verification

- `npm run lint` — clean
- `npm run test:unit` — 276 passing (255 pre-existing tests unmodified + 21 new)
- `npm run coverage` — 98.5% statements / 95.57% branches / 100% functions / 98.5% lines (thresholds 97/93/100/97)
- `npm run test:e2e` against a real Vault 1.17.6 dev server (KV v1) — 6 passing, 1 pending
- `npm run test:e2e:kv2` against a real Vault dev server (KV v2) — 10 passing

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `npm run lint && npm test` passes locally
- [x] User-facing changes recorded under `# Unreleased` in `CHANGELOG.md`
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)