### PR TITLE
chore: quality backlog from the 2026-07 audit (typed HTTP errors, config validation, untested paths, release hygiene)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Release-time guard (issue #111): publishing x.y.z requires a matching "# x.y.z ..."
+      # release-notes heading in CHANGELOG.md, so the changelog cannot silently fall out of
+      # date. Keeping the check here (instead of on every PR) avoids blocking non-user-facing
+      # PRs while still enforcing the CONTRIBUTING.md convention where it matters.
+      - name: Check CHANGELOG.md covers this release
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if ! grep -Eq "^# ${VERSION//./\\.}( |$)" CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::No release-notes heading for version ${VERSION}. Move the '# Unreleased' notes into a '# ${VERSION} Release notes (YYYY-MM-DD)' section before publishing."
+            exit 1
+          fi
+
       - name: Publish
         run: npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
   point (one `resolver.resolve()` call site instead of three). No behavior change — the pipeline
   is locked by new characterization tests across v1/v2 mounts, namespaces, and extra headers.
   Closes #110.
+- Non-2xx Vault responses are now rejected with a typed `VaultHttpError` (part of the `VaultError`
+  hierarchy, exported from the errors module), so callers can `instanceof`-check HTTP failures.
+  Backward compatible: the message (`"<status> - <body text>"`) and the `statusCode`/`error`
+  properties are unchanged, and the thrown value is still an `instanceof Error`.
+- Auth backends now fail fast with `InvalidArgumentsError` when a required config field is missing:
+  `role_id` for AppRole, `role` for IAM and Kubernetes (previously only Token auth validated its
+  input, and a missing/empty config surfaced later as an unhelpful login failure or `TypeError`).
+  Valid configurations behave exactly as before.
 
 # 2.0.4 Release notes (2026-07-02)
 

--- a/src/VaultApiClient.js
+++ b/src/VaultApiClient.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const errors = require('./errors');
+
 /**
  * Joins URL segments with single slashes while preserving the leading
  * protocol (e.g. "https://"). Replaces the former `url-join` dependency.
@@ -111,10 +113,7 @@ class VaultApiClient {
                 }
 
                 if (!response.ok) {
-                    const error = new Error(`${response.status} - ${text}`);
-                    error.statusCode = response.status;
-                    error.error = body;
-                    throw error;
+                    throw new errors.VaultHttpError(response.status, text, body);
                 }
 
                 // Do not log the response body: Vault responses carry secret

--- a/src/VaultNodeConfig.js
+++ b/src/VaultNodeConfig.js
@@ -148,3 +148,6 @@ class VaultNodeConfig {
 }
 
 module.exports = VaultNodeConfig;
+// The prototype-pollution guard in deepMerge is a deliberate security control;
+// the helper is exported so tests can exercise it directly.
+module.exports.deepMerge = deepMerge;

--- a/src/auth/VaultAppRoleAuth.js
+++ b/src/auth/VaultAppRoleAuth.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const VaultBaseAuth = require('./VaultBaseAuth');
+const errors = require('../errors');
 
 class VaultAppRoleAuth extends VaultBaseAuth {
 
@@ -16,6 +17,10 @@ class VaultAppRoleAuth extends VaultBaseAuth {
      */
     constructor(apiClient, logger, config, mount) {
         super(apiClient, logger, mount || 'approle');
+
+        if (!config || !config.role_id) {
+            throw new errors.InvalidArgumentsError('"role_id" should be provided for VaultAppRoleAuth');
+        }
 
         this.__roleId = config.role_id;
         this.__secretId = config.secret_id;

--- a/src/auth/VaultBaseAuth.js
+++ b/src/auth/VaultBaseAuth.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// `long-timeout` is unmaintained (last release 2016) but tiny (~50 LOC), dependency-free and
+// stable: it only works around setTimeout's 32-bit signed-int limit (~24.8 days), which real
+// Vault token TTLs can exceed. Audited and deliberately kept as-is (see issue #111); revisit
+// only if a maintained alternative or a Node.js core fix appears.
 const lt = require('long-timeout');
 const AuthToken = require('./AuthToken');
 const errors = require('../errors');

--- a/src/auth/VaultIAMAuth.js
+++ b/src/auth/VaultIAMAuth.js
@@ -65,6 +65,10 @@ class VaultIAMAuth extends VaultBaseAuth {
     constructor(api, logger, config, mount) {
         super(api, logger, mount || 'aws');
 
+        if (!config || !config.role) {
+            throw new errors.InvalidArgumentsError('"role" should be provided for VaultIAMAuth');
+        }
+
         this.__role = config.role;
         this.__iam_server_id_header_value = config.iam_server_id_header_value;
         this.__region = config.region;

--- a/src/auth/VaultKubernetesAuth.js
+++ b/src/auth/VaultKubernetesAuth.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const VaultBaseAuth = require('./VaultBaseAuth');
+const errors = require('../errors');
 
 class VaultKubernetesAuth extends VaultBaseAuth {
     /**
@@ -14,6 +15,10 @@ class VaultKubernetesAuth extends VaultBaseAuth {
      */
     constructor(apiClient, logger, config, mount) {
         super(apiClient, logger, mount || 'kubernetes');
+
+        if (!config || !config.role) {
+            throw new errors.InvalidArgumentsError('"role" should be provided for VaultKubernetesAuth');
+        }
 
         this.__role = config.role;
         this.__tokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token';

--- a/src/auth/VaultTokenAuth.js
+++ b/src/auth/VaultTokenAuth.js
@@ -15,7 +15,7 @@ class VaultTokenAuth extends VaultBaseAuth {
     constructor(apiClient, logger, config, mount) {
         super(apiClient, logger, mount || 'token');
 
-        if (!config.token) {
+        if (!config || !config.token) {
             throw new errors.InvalidArgumentsError('Auth token should be provided for VaultTokenAuth');
         }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -19,10 +19,33 @@ class InvalidAWSCredentialsError extends InvalidArgumentsError {}
 class AuthTokenExpiredError extends VaultError {}
 class UnsupportedOperationError extends VaultError {}
 
+/**
+ * A non-2xx HTTP response from the Vault server.
+ *
+ * Preserves the legacy plain-`Error` shape previously thrown by
+ * {@link VaultApiClient#makeRequest} — the message stays `"<status> - <raw body text>"` and the
+ * `statusCode`/`error` properties keep their meaning — while letting callers
+ * `instanceof`-check HTTP failures against the `VaultError` hierarchy.
+ */
+class VaultHttpError extends VaultError {
+    /**
+     * @param {number} statusCode - HTTP status code of the response.
+     * @param {string} text - raw response body text, used in the message.
+     * @param {*} [body] - parsed JSON body when the response was valid JSON, the raw text
+     *   otherwise, or `undefined` for an empty body. Exposed as `error.error`.
+     */
+    constructor(statusCode, text, body) {
+        super(`${statusCode} - ${text}`);
+        this.statusCode = statusCode;
+        this.error = body;
+    }
+}
+
 module.exports = {
     VaultError,
     InvalidArgumentsError,
     InvalidAWSCredentialsError,
     AuthTokenExpiredError,
     UnsupportedOperationError,
+    VaultHttpError,
 };

--- a/test/Lease.test.mjs
+++ b/test/Lease.test.mjs
@@ -55,6 +55,25 @@ describe('Lease', function () {
         });
     });
 
+    describe('#getMetadata()', function () {
+        const metadata = { created_time: '2026-07-02T00:00:00Z', version: 3 };
+
+        it('returns the KV v2 version metadata when present', function () {
+            const lease = new Lease('r', 'l', 10, false, { a: 1 }, metadata);
+            expect(lease.getMetadata()).to.equal(metadata);
+        });
+
+        it('is mapped from response.metadata by fromResponse', function () {
+            const lease = Lease.fromResponse({ ...response, metadata });
+            expect(lease.getMetadata()).to.deep.equal(metadata);
+        });
+
+        it('returns undefined for KV v1 / non-KV leases', function () {
+            expect(Lease.fromResponse(response).getMetadata()).to.equal(undefined);
+            expect(new Lease('r', 'l', 10, false, {}).getMetadata()).to.equal(undefined);
+        });
+    });
+
     describe('#isRenewable()', function () {
         it('reflects the renewable flag', function () {
             expect(new Lease('r', 'l', 10, true, {}).isRenewable()).to.equal(true);

--- a/test/VaultApiClient.test.mjs
+++ b/test/VaultApiClient.test.mjs
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
+import errors from '../src/errors.js';
 
 use(sinonChai);
 
@@ -122,6 +123,61 @@ describe('VaultApiClient', function () {
             return api.makeRequest('GET', '/secret/foo').then(
                 () => { throw new Error('expected rejection'); },
                 (err) => { expect(err.statusCode).to.equal(500); }
+            );
+        });
+
+        it('rejects a non-2xx JSON response with a VaultHttpError carrying the parsed body on err.error', function () {
+            responder = (req, res) => {
+                res.statusCode = 403;
+                res.setHeader('Content-Type', 'application/json');
+                res.end('{"errors":["permission denied"]}');
+            };
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('GET', '/secret/foo').then(
+                () => { throw new Error('expected rejection'); },
+                (err) => {
+                    expect(err).to.be.instanceOf(errors.VaultHttpError);
+                    expect(err).to.be.instanceOf(errors.VaultError);
+                    expect(err).to.be.instanceOf(Error);
+                    // Legacy plain-Error shape is preserved: same message, same properties.
+                    expect(err.message).to.equal('403 - {"errors":["permission denied"]}');
+                    expect(err.statusCode).to.equal(403);
+                    expect(err.error).to.deep.equal({ errors: ['permission denied'] });
+                }
+            );
+        });
+
+        it('falls back to the raw text on err.error when the error body is not JSON', function () {
+            responder = (req, res) => {
+                res.statusCode = 500;
+                res.end('boom');
+            };
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('GET', '/secret/foo').then(
+                () => { throw new Error('expected rejection'); },
+                (err) => {
+                    expect(err).to.be.instanceOf(errors.VaultHttpError);
+                    expect(err.message).to.equal('500 - boom');
+                    expect(err.statusCode).to.equal(500);
+                    expect(err.error).to.equal('boom');
+                }
+            );
+        });
+
+        it('leaves err.error undefined when the error body is empty', function () {
+            responder = (req, res) => {
+                res.statusCode = 500;
+                res.end();
+            };
+            const api = new VaultApiClient({ url: baseUrl }, logger);
+            return api.makeRequest('GET', '/secret/foo').then(
+                () => { throw new Error('expected rejection'); },
+                (err) => {
+                    expect(err).to.be.instanceOf(errors.VaultHttpError);
+                    expect(err.message).to.equal('500 - ');
+                    expect(err.statusCode).to.equal(500);
+                    expect(err.error).to.equal(undefined);
+                }
             );
         });
 

--- a/test/VaultNodeConfig.test.mjs
+++ b/test/VaultNodeConfig.test.mjs
@@ -106,6 +106,56 @@ describe('VaultNodeConfig', function () {
         });
     });
 
+    describe('deepMerge()', function () {
+        const { deepMerge } = VaultNodeConfig;
+
+        it('is exported for direct use in tests', function () {
+            expect(deepMerge).to.be.a('function');
+        });
+
+        it('skips an own __proto__ key so a malicious source cannot pollute prototypes', function () {
+            // JSON.parse creates an *own* "__proto__" data property (an object literal would
+            // set the prototype instead), which is exactly how polluted input arrives.
+            const source = JSON.parse('{"__proto__": {"polluted": "yes"}, "safe": 1}');
+            const target = {};
+            deepMerge(target, source);
+
+            expect(target.safe).to.equal(1);
+            expect(Object.hasOwn(target, '__proto__')).to.equal(false);
+            expect(Object.getPrototypeOf(target)).to.equal(Object.prototype);
+            expect({}.polluted, 'Object.prototype must not be polluted').to.equal(undefined);
+        });
+
+        it('skips constructor and prototype keys', function () {
+            const source = JSON.parse('{"constructor": {"prototype": {"polluted": "yes"}}, "prototype": {"polluted": "yes"}, "safe": 1}');
+            const target = {};
+            deepMerge(target, source);
+
+            expect(target.safe).to.equal(1);
+            expect(Object.hasOwn(target, 'constructor')).to.equal(false);
+            expect(Object.hasOwn(target, 'prototype')).to.equal(false);
+            expect(target.constructor).to.equal(Object);
+            expect({}.polluted, 'Object.prototype must not be polluted').to.equal(undefined);
+        });
+
+        it('merges nested objects in place, skips undefined source values and returns the target', function () {
+            const target = { nested: { keep: 1, replace: 1 }, scalar: 'a' };
+            const result = deepMerge(target, { nested: { replace: 2, add: 3 }, scalar: undefined });
+
+            expect(result).to.equal(target);
+            expect(target).to.deep.equal({ nested: { keep: 1, replace: 2, add: 3 }, scalar: 'a' });
+        });
+
+        it('deep-clones object values assigned over non-object targets', function () {
+            const source = { obj: { a: 1 } };
+            const target = { obj: 'scalar' };
+            deepMerge(target, source);
+
+            expect(target.obj).to.deep.equal({ a: 1 });
+            expect(target.obj, 'must not share the source reference').to.not.equal(source.obj);
+        });
+    });
+
     describe('#populate()', function () {
         function instance(substitutionMap, dataByPath) {
             process.env.NODE_CONFIG_DIR = CONFIG_BASE;

--- a/test/auth.appRole.test.mjs
+++ b/test/auth.appRole.test.mjs
@@ -4,6 +4,7 @@ import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
 import VaultAppRoleAuth from '../src/auth/VaultAppRoleAuth.js';
+import errors from '../src/errors.js';
 
 use(sinonChai);
 
@@ -110,6 +111,18 @@ describe('AppRole auth backend', function () {
           { role_id: 'role123', secret_id: 'secret456' },
         ),
       ).to.be.true;
+    });
+  });
+
+  describe('config validation', function () {
+    it('throws InvalidArgumentsError when role_id is missing', () => {
+      expect(() => new VaultAppRoleAuth(getApiStub(), logger, { secret_id: 'secret456' }))
+        .to.throw(errors.InvalidArgumentsError, '"role_id" should be provided for VaultAppRoleAuth');
+    });
+
+    it('throws InvalidArgumentsError when the config is missing entirely', () => {
+      expect(() => new VaultAppRoleAuth(getApiStub(), logger, undefined))
+        .to.throw(errors.InvalidArgumentsError, '"role_id" should be provided for VaultAppRoleAuth');
     });
   });
 

--- a/test/auth.base.test.mjs
+++ b/test/auth.base.test.mjs
@@ -251,6 +251,8 @@ describe('VaultBaseAuth', function () {
             const auth = new TestAuth(api, 'mount', { authStub: sinon.stub().resolves(renewable) });
             auth._log = _.assign({}, logger, { error: errorSpy });
 
+            let renewalsAfterFirstFailure;
+
             return auth.getAuthToken()
                 .then(() => {
                     clock.tick(50000);
@@ -259,6 +261,15 @@ describe('VaultBaseAuth', function () {
                 .then(() => {
                     expect(api.makeRequest).to.have.been.calledWith('POST', '/auth/token/renew-self');
                     expect(errorSpy).to.have.been.called;
+                    // The timer must actually re-arm after the failure ...
+                    expect(auth.__refreshTimeout).to.not.equal(null);
+                    renewalsAfterFirstFailure = api.makeRequest.callCount;
+                    clock.tick(50000);
+                    return flush();
+                })
+                .then(() => {
+                    // ... so advancing the clock again triggers another renewal attempt.
+                    expect(api.makeRequest.callCount).to.be.greaterThan(renewalsAfterFirstFailure);
                 });
         });
     });

--- a/test/auth.iam.test.mjs
+++ b/test/auth.iam.test.mjs
@@ -295,6 +295,18 @@ describe('Unit AWS auth backend :: IAM', function () {
         });
     });
 
+    describe('config validation', function () {
+        it('Should throw InvalidArgumentsError if the role is missing', () => {
+            expect(() => new VaultIAMAuth(getApiStub(), logger, {}, 'aws'))
+                .to.throw(errors.InvalidArgumentsError, '"role" should be provided for VaultIAMAuth');
+        });
+
+        it('Should throw InvalidArgumentsError if the config is missing entirely', () => {
+            expect(() => new VaultIAMAuth(getApiStub(), logger, undefined, 'aws'))
+                .to.throw(errors.InvalidArgumentsError, '"role" should be provided for VaultIAMAuth');
+        });
+    });
+
     describe('base64 encoding', function () {
         it('encodes via Buffer.from (no deprecated new Buffer) and round-trips', function () {
             const auth = new VaultIAMAuth(getApiStub(), logger, { role: 'MyRole' }, 'aws');

--- a/test/auth.kubernetes.test.mjs
+++ b/test/auth.kubernetes.test.mjs
@@ -6,6 +6,7 @@ import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
 import VaultKubernetesAuth from '../src/auth/VaultKubernetesAuth.js';
 import AuthToken from '../src/auth/AuthToken.js';
+import errors from '../src/errors.js';
 
 use(sinonChai);
 
@@ -62,6 +63,24 @@ describe('VaultKubernetesAuth', function () {
             expect(auth._getTokenEntity).to.have.been.calledWith('vault-token');
             expect(token).to.equal(entity);
         });
+    });
+
+    it('throws InvalidArgumentsError when the role is missing', function () {
+        expect(() => new VaultKubernetesAuth(apiStub(), logger, {}))
+            .to.throw(errors.InvalidArgumentsError, '"role" should be provided for VaultKubernetesAuth');
+        expect(() => new VaultKubernetesAuth(apiStub(), logger, undefined))
+            .to.throw(errors.InvalidArgumentsError, '"role" should be provided for VaultKubernetesAuth');
+    });
+
+    it('propagates the fs error when the service-account token file is missing or unreadable, without hitting Vault', function () {
+        const fsError = new Error("ENOENT: no such file or directory, open '/var/run/secrets/kubernetes.io/serviceaccount/token'");
+        fsError.code = 'ENOENT';
+        readFileSync = sinon.stub(fs, 'readFileSync').throws(fsError);
+        const api = apiStub();
+        const auth = new VaultKubernetesAuth(api, logger, { role: 'r' });
+
+        expect(() => auth._authenticate()).to.throw(fsError);
+        expect(api.makeRequest).to.not.have.been.called;
     });
 
     it('never logs the JWT or the Vault client token', function () {

--- a/test/auth.token.test.mjs
+++ b/test/auth.token.test.mjs
@@ -21,6 +21,11 @@ describe('VaultTokenAuth', function () {
             .to.throw(errors.InvalidArgumentsError, 'Auth token should be provided');
     });
 
+    it('throws when the config is missing entirely', function () {
+        expect(() => new VaultTokenAuth(apiStub(), logger, undefined))
+            .to.throw(errors.InvalidArgumentsError, 'Auth token should be provided');
+    });
+
     it('defaults the mount to "token"', function () {
         const auth = new VaultTokenAuth(apiStub(), logger, { token: 't' });
         expect(auth._mount).to.equal('token');

--- a/test/errors.test.mjs
+++ b/test/errors.test.mjs
@@ -9,6 +9,7 @@ describe('errors', function () {
             'InvalidAWSCredentialsError',
             'AuthTokenExpiredError',
             'UnsupportedOperationError',
+            'VaultHttpError',
         ]);
     });
 
@@ -62,6 +63,33 @@ describe('errors', function () {
             expect(err).to.be.instanceOf(Error);
             expect(err.name).to.equal('UnsupportedOperationError');
             expect(err.message).to.equal('not supported');
+        });
+
+        it('VaultHttpError extends VaultError', function () {
+            const err = new errors.VaultHttpError(503, 'sealed');
+            expect(err).to.be.instanceOf(errors.VaultError);
+            expect(err).to.be.instanceOf(Error);
+            expect(err.name).to.equal('VaultHttpError');
+        });
+    });
+
+    describe('VaultHttpError', function () {
+        it('keeps the legacy "<status> - <text>" message shape', function () {
+            const err = new errors.VaultHttpError(403, '{"errors":["permission denied"]}');
+            expect(err.message).to.equal('403 - {"errors":["permission denied"]}');
+        });
+
+        it('exposes the status code as `statusCode` and the parsed body as `error`', function () {
+            const body = { errors: ['permission denied'] };
+            const err = new errors.VaultHttpError(403, '{"errors":["permission denied"]}', body);
+            expect(err.statusCode).to.equal(403);
+            expect(err.error).to.equal(body);
+        });
+
+        it('leaves `error` undefined when the response body is empty', function () {
+            const err = new errors.VaultHttpError(500, '');
+            expect(err.message).to.equal('500 - ');
+            expect(err.error).to.equal(undefined);
         });
     });
 });


### PR DESCRIPTION
## Summary

Implements the actionable in-repo items from the 2026-07 audit quality backlog (#111): typed HTTP errors, fail-fast auth config validation, tests for the previously untested paths, and the in-repo release-hygiene items. Items that are already covered, blocked on another in-flight PR, or maintainer-decision-shaped are listed below and left open on the issue.

Refs #111

### Issue checklist status

**Untested paths**
- [x] `VaultKubernetesAuth` `fs.readFileSync` throw path — new test asserts the fs error propagates and no login request is made
- [x] `VaultIAMAuth` default AWS credential-chain path — **already covered** by the existing "credentials from environment variables" test (constructs without explicit credentials, so `fromNodeProviderChain()` is built and resolved); no change needed
- [x] `test/auth.base.test.mjs` "reschedules when a renewal fails" — now asserts `__refreshTimeout` re-arms and that advancing the clock triggers a second renewal attempt
- [x] Prototype-pollution guard in `VaultNodeConfig.deepMerge` — `deepMerge` is now exported for direct testing; tests cover `__proto__`/`constructor`/`prototype` skipping (via `JSON.parse`-created own keys), undefined-skip, in-place nested merge, and deep-cloning
- [x] Dedicated `Lease.getMetadata()` tests (present, `fromResponse` mapping, undefined for KV v1)
- [x] `VaultApiClient` non-2xx handling — tests assert `err.error` parsed-JSON contents, the non-JSON raw-text fallback, and the empty-body (`undefined`) case

**Code quality**
- [x] Typed HTTP errors — new `VaultHttpError extends VaultError`, thrown by `VaultApiClient.makeRequest` on non-2xx. Backward compatible: message stays `"<status> - <text>"`, `statusCode`/`error` keep their shape, still `instanceof Error`
- [x] Config validation — `InvalidArgumentsError` on missing `role_id` (AppRole) / `role` (IAM, Kubernetes); Token auth now also handles a missing config object. Valid configs behave exactly as before
- [ ] **Skipped:** `VaultBaseAuth.__authToken` promise/token two-field split — a "consider" refactor of the auth state machine with no behavior change; better done as its own focused change rather than bundled into this batch

**Dependencies & release process**
- [x] `long-timeout` — documented the decision to keep it (comment at the require site in `VaultBaseAuth.js`: unmaintained but tiny, dependency-free, and it works around the 32-bit `setTimeout` limit that real token TTLs exceed)
- [x] Release-time CHANGELOG check — the publish workflow now fails if `CHANGELOG.md` has no `# <version>` release-notes heading for the version being published
- [ ] **Skipped:** structured logging / log-at-source in `VaultApiClient` — the issue says to do this after the catch/log/rethrow wrapper from #110, which is being handled in a separate in-flight PR

## Changes

- `src/errors.js` — add `VaultHttpError` (statusCode + error fields, legacy message shape)
- `src/VaultApiClient.js` — throw `VaultHttpError` instead of an ad-hoc plain `Error` on non-2xx
- `src/auth/VaultAppRoleAuth.js`, `src/auth/VaultIAMAuth.js`, `src/auth/VaultKubernetesAuth.js` — fail fast on missing required config; `src/auth/VaultTokenAuth.js` — null-safe config check
- `src/auth/VaultBaseAuth.js` — document the `long-timeout` keep decision
- `src/VaultNodeConfig.js` — export `deepMerge` so the security guard is directly testable
- `.github/workflows/publish.yml` — release-time CHANGELOG heading check before `npm publish`
- `CHANGELOG.md` — `# Unreleased` entries for the two user-facing changes
- `test/*` — 22 new/extended tests (see checklist above); the only modified existing tests are the two the issue explicitly targets (`errors` export list, renewal reschedule)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `npm run lint && npm test` passes locally (unit: 277 passing, up from 255; coverage 98.33% stmts / 96.23% branch / 100% funcs / 98.33% lines, above the 97/93/100/97 gates)
- [x] User-facing changes recorded under `# Unreleased` in `CHANGELOG.md`
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)
