### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.1.0 Release notes (2026-07-28)
 
 - Security: pin patched transitive tooling via `overrides` — `brace-expansion` to `^5.0.8`
   (clears GHSA-3jxr-9vmj-r5cp, Dependabot #60, and GHSA-mh99-v99m-4gvg) and `js-yaml` to `^4.3.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-vault-client",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.382.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"


### PR DESCRIPTION
## Summary

Release-prep for **v2.1.0**: bumps `package.json`/`package-lock.json` to `2.1.0` and converts the `# Unreleased` CHANGELOG section into a dated `# 2.1.0 Release notes (2026-07-28)` heading (required by the `publish.yml` release guard).

Minor bump per semver — the release ships backward-compatible additive API (`VaultHttpError` export, `opts.maxCacheSize`) plus perf, an internal refactor, auth fail-fast validation, and the brace-expansion/js-yaml security remediation. No breaking changes.

## Changes

- `package.json`, `package-lock.json` — version `2.0.4` → `2.1.0`.
- `CHANGELOG.md` — `# Unreleased` → `# 2.1.0 Release notes (2026-07-28)`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / tooling <!-- release prep -->

## Checklist

- [x] Tests added or updated <!-- N/A: version/changelog only -->
- [x] `npm run lint && npm test` passes locally
- [x] User-facing changes recorded under `# Unreleased` in `CHANGELOG.md` <!-- moved into the 2.1.0 dated section -->
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)

After merge, a `v2.1.0` GitHub Release will be published, triggering `publish.yml` → `npm publish --provenance`.