### PR TITLE
refactor(auth): split VaultBaseAuth.__authToken into separate promise/token fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@
     uses braces. Scoping the override per-major is not a way out: the backported `1.1.16`/`2.1.2`
     releases clear GHSA-3jxr-9vmj-r5cp but are still flagged high by GHSA-mh99-v99m-4gvg
     (unbounded-expansion OOM), which is only fixed in 5.0.8+.
+- Internal refactor: `VaultBaseAuth` no longer overloads a single `__authToken` field with two
+  types. The in-flight login now lives in `__pendingLogin` (`Promise<AuthToken>|null`) and the
+  resolved token in `__authToken` (`AuthToken|null`), so `getAuthToken()` reads the auth state
+  directly instead of discriminating with `instanceof` at each use site. No behavior change —
+  the single-flight login (concurrent callers share one login) and the renewal-timer wiring are
+  unchanged, and both are now pinned by tests. Closes #120.
 
 # 2.1.0 Release notes (2026-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Unreleased
+
+- Internal refactor: `VaultBaseAuth` no longer overloads a single `__authToken` field with two
+  types. The in-flight login now lives in `__pendingLogin` (`Promise<AuthToken>|null`) and the
+  resolved token in `__authToken` (`AuthToken|null`), so `getAuthToken()` reads the auth state
+  directly instead of discriminating with `instanceof` at each use site. No behavior change —
+  the single-flight login (concurrent callers share one login) and the renewal-timer wiring are
+  unchanged, and both are now pinned by tests. Closes #120.
+
 # 2.1.1 Release notes (2026-07-31)
 
 - Dependencies bumped, with **zero known vulnerabilities and Node 18 still working**. The selection
@@ -45,12 +54,6 @@
     uses braces. Scoping the override per-major is not a way out: the backported `1.1.16`/`2.1.2`
     releases clear GHSA-3jxr-9vmj-r5cp but are still flagged high by GHSA-mh99-v99m-4gvg
     (unbounded-expansion OOM), which is only fixed in 5.0.8+.
-- Internal refactor: `VaultBaseAuth` no longer overloads a single `__authToken` field with two
-  types. The in-flight login now lives in `__pendingLogin` (`Promise<AuthToken>|null`) and the
-  resolved token in `__authToken` (`AuthToken|null`), so `getAuthToken()` reads the auth state
-  directly instead of discriminating with `instanceof` at each use site. No behavior change —
-  the single-flight login (concurrent callers share one login) and the renewal-timer wiring are
-  unchanged, and both are now pinned by tests. Closes #120.
 
 # 2.1.0 Release notes (2026-07-28)
 

--- a/src/auth/VaultBaseAuth.js
+++ b/src/auth/VaultBaseAuth.js
@@ -38,8 +38,17 @@ class VaultBaseAuth {
         this._log = logger;
         this._mount = mount;
 
-        /** @type AuthToken */
+        /**
+         * The currently held token, or `null` when none has been obtained yet.
+         * @type {AuthToken|null}
+         */
         this.__authToken = null;
+        /**
+         * The in-flight login, or `null` when no login is running. Concurrent
+         * `getAuthToken()` callers await this same promise (single-flight).
+         * @type {Promise<AuthToken>|null}
+         */
+        this.__pendingLogin = null;
         this.__refreshTimeout = null;
     }
 
@@ -52,7 +61,12 @@ class VaultBaseAuth {
     }
 
     getAuthToken() {
-        const tokenExpired = this.__authToken instanceof AuthToken && this.__authToken.isExpired();
+        if (this.__pendingLogin !== null) {
+            this._log.debug('login already in flight');
+            return this.__pendingLogin;
+        }
+
+        const tokenExpired = this.__authToken !== null && this.__authToken.isExpired();
 
         if (tokenExpired && !this._reauthenticationAllowed()) {
             return Promise.reject(new errors.AuthTokenExpiredError(
@@ -60,32 +74,34 @@ class VaultBaseAuth {
             ));
         }
 
-        if (this.__authToken === null || tokenExpired) {
-            this._log.info('getting auth token (mount=%s)', this._mount);
-
-            const tokenPromise = this._authenticate().then(authToken => {
-                this.__authToken = authToken;
-
-                if (this.__authToken.isRenewable()) {
-                    this._log.debug(
-                        'setting refresh timer for token (accessor=%s)',
-                        authToken.getAccessor()
-                    );
-                    this.__setupTokenRefreshTimer(this.__authToken);
-                }
-
-                return this.__authToken;
-            }).catch(e => {
-                this.__authToken = null;
-                throw e;
-            });
-
-            this.__authToken = tokenPromise;
-            return tokenPromise;
+        if (this.__authToken !== null && !tokenExpired) {
+            this._log.debug('token already exist');
+            return Promise.resolve(this.__authToken);
         }
 
-        this._log.debug('token already exist');
-        return Promise.resolve(this.__authToken);
+        this._log.info('getting auth token (mount=%s)', this._mount);
+
+        const pendingLogin = this._authenticate().then(authToken => {
+            this.__pendingLogin = null;
+            this.__authToken = authToken;
+
+            if (authToken.isRenewable()) {
+                this._log.debug(
+                    'setting refresh timer for token (accessor=%s)',
+                    authToken.getAccessor()
+                );
+                this.__setupTokenRefreshTimer(authToken);
+            }
+
+            return authToken;
+        }).catch(e => {
+            this.__pendingLogin = null;
+            this.__authToken = null;
+            throw e;
+        });
+
+        this.__pendingLogin = pendingLogin;
+        return pendingLogin;
     }
 
     /**

--- a/test/auth.base.test.mjs
+++ b/test/auth.base.test.mjs
@@ -134,6 +134,48 @@ describe('VaultBaseAuth', function () {
                 });
         });
 
+        it('coalesces concurrent callers onto a single in-flight login', function () {
+            const token = nonRenewableToken();
+            let release;
+            const authStub = sinon.stub().returns(new Promise((resolve) => { release = () => resolve(token); }));
+            const auth = new TestAuth(apiStub(), 'mount', { authStub });
+
+            // Both calls happen while the login is still pending, so they must share it.
+            const first = auth.getAuthToken();
+            const second = auth.getAuthToken();
+            expect(authStub).to.have.been.calledOnce;
+
+            release();
+
+            return Promise.all([first, second]).then(([t1, t2]) => {
+                expect(t1).to.equal(token);
+                expect(t2).to.equal(token);
+                expect(authStub).to.have.been.calledOnce;
+                // Once resolved, the pending-login slot is cleared and the token is cached.
+                expect(auth.__pendingLogin).to.equal(null);
+                expect(auth.__authToken).to.equal(token);
+                return auth.getAuthToken();
+            }).then((t3) => {
+                expect(t3).to.equal(token);
+                expect(authStub).to.have.been.calledOnce;
+            });
+        });
+
+        it('clears the in-flight login when it fails, so a later call retries', function () {
+            const boom = new Error('auth failed');
+            const authStub = sinon.stub().rejects(boom);
+            const auth = new TestAuth(apiStub(), 'mount', { authStub });
+
+            return auth.getAuthToken().then(
+                () => { throw new Error('expected rejection'); },
+                (err) => {
+                    expect(err).to.equal(boom);
+                    expect(auth.__pendingLogin).to.equal(null);
+                    expect(auth.__authToken).to.equal(null);
+                }
+            );
+        });
+
         it('resets state and propagates the error when authentication fails, allowing a retry', function () {
             const boom = new Error('auth failed');
             const token = nonRenewableToken();


### PR DESCRIPTION
## Summary

Closes #120 — the one "consider"-tier item from the 2026-07 audit backlog (#111) that was intentionally left out of #119.

`VaultBaseAuth.__authToken` held **either** a `Promise` (login in flight) **or** a resolved `AuthToken`, discriminated at each use site with `instanceof`. Overloading one field with two types made the auth state machine hard to read and easy to get subtly wrong when touched.

It is now two clearly-typed fields:

| field | type | meaning |
| --- | --- | --- |
| `__pendingLogin` | `Promise<AuthToken> \| null` | a login is in flight |
| `__authToken` | `AuthToken \| null` | the resolved token |

`getAuthToken()` reads as a straight state machine: pending login → cached token → expiry/reauth → start a login. No `instanceof` discrimination anywhere.

**No behavior change** — public API and semantics are identical. Specifically preserved:

- **Single-flight login** — concurrent callers still await one in-flight login (previously implicit in `Promise.resolve(this.__authToken)` unwrapping a stored promise; now an explicit early return).
- **Renewal-timer wiring** — `__setupTokenRefreshTimer` / `__renewToken` untouched.
- **Failure reset** — a failed login clears both fields, so a later call retries.
- **Expired-token + reauth-disallowed** still rejects with `AuthTokenExpiredError`.

The only observable difference is one `debug` log line: the in-flight case now logs `login already in flight` instead of `token already exist`, which is what was actually happening.

## Changes

- `src/auth/VaultBaseAuth.js` — split the field, restructure `getAuthToken()` into explicit early returns, document both fields with JSDoc types.
- `test/auth.base.test.mjs` — two new tests pinning the invariants the refactor had to keep: concurrent callers coalesce onto a single login (and the pending slot clears on resolve), and a failed login resets both fields.
- `CHANGELOG.md` — entry under `# Unreleased`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `npm run lint && npm test` passes locally — 308 unit tests pass, lint clean, `npm run coverage` gate green (`VaultBaseAuth.js` 96.96% stmts / 97.05% branches). E2E not run (needs a live Vault).
- [x] User-facing changes recorded under `# Unreleased` in `CHANGELOG.md` — internal-refactor entry, matching the convention used for #110
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)