### PR TITLE
chore(release): 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
-# Unreleased
+# 2.1.1 Release notes (2026-07-31)
 
 - Dependencies bumped, with **zero known vulnerabilities and Node 18 still working**. The selection
   rule is deliberately "newest version that still *runs* on Node 18", not "newest version whose
   `engines` field mentions Node 18" — for most packages the `engines` bump to Node 20 is policy
   rather than a technical requirement, and capping on the declaration alone would force downgrades
-  below patched releases. `npm audit` reports 0 vulnerabilities (down from 26 — 1 critical, 7 high,
-  18 moderate — in the intermediate declaration-based approach).
+  below patched releases. `npm audit` reports 0 vulnerabilities, as it did on 2.1.0; note that
+  capping purely on `engines` declarations was tried first and produced 26 advisories (1 critical,
+  7 high, 18 moderate), because every patched release of `@aws-sdk/credential-providers`,
+  `serialize-javascript` and `brace-expansion` requires Node 20+. That approach is preserved in the
+  branch history for auditability.
   - Bumped to latest: `@aws-sdk/credential-providers` → `^3.1100.0`, `aws4` `^1.8.0` → `^1.13.2`,
     `chai` → `^6.2.2`, `globals` → `^17.8.0`, `lodash` → `^4.18.1`, `sinon` → `^22.1.0`,
     `sinon-chai` → `^4.0.1`, `eslint`/`@eslint/js` → `^9.39.5`. Security overrides stay on their

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-vault-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-vault-client",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1100.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"


### PR DESCRIPTION
## Summary

Release commit for **2.1.1** (patch). Bumps `package.json`/`package-lock.json` from 2.1.0 and moves
the `# Unreleased` notes into a dated `# 2.1.1 Release notes (2026-07-31)` section, which is what
`publish.yml` requires before it will publish.

Patch rather than minor: the only changes since 2.1.0 are dependency versions (#124). The public API
is unchanged and `engines` still reads `>=18.0.0`.

Contents of the release — all from #124:

- All dependencies bumped, selected by *"newest version that still **runs** on Node 18"* rather than
  by what each package's `engines` field declares.
- `npm audit`: **0 vulnerabilities** (2.1.0 was also clean; this holds the line while moving the
  AWS SDK forward ~130 minors to `^3.1100.0`).
- `c8` held at `^10.1.3`, `eslint` at 9.x and the `config` peer at `<4`, because those genuinely
  break on Node 18 rather than merely declaring against it. Side benefit: `npm run coverage` now
  works on Node 18, which it did not on 2.1.0.
- Two pre-existing Node 18 limitations documented in the changelog (`mocha --parallel`, brace glob
  patterns) — neither reachable from any npm script or CI job.

I reworded one clause while dating the section: it previously read "0 vulnerabilities (down from 26
…)", which could be misread as 2.1.0 having shipped 26 advisories. 2.1.0 was clean — the 26 came
from an intermediate approach on the #124 branch that capped on `engines` declarations. The
rewritten text says so explicitly.

## Changes

| File | Change |
|---|---|
| `package.json` | `2.1.0` → `2.1.1` |
| `package-lock.json` | version fields synced (`npm version --no-git-tag-version`) |
| `CHANGELOG.md` | `# Unreleased` → `# 2.1.1 Release notes (2026-07-31)`, plus the clarification above |

No source, test or CI changes.

## Verification

- `npm ci` clean on Node 18.20.8, 306 unit tests passing, `lint` clean, `npm audit --audit-level=high`
  reports 0 vulnerabilities — confirming the lockfile is still `npm ci`-consistent after the bump.
- `publish.yml`'s release guard checked locally: `grep -Eq "^# 2\.1\.1( |$)" CHANGELOG.md` passes, so
  the publish job will not fail its changelog check.
- The full matrix runs on this PR as usual.

## Post-merge steps (not done here)

Publishing is deliberately left as a separate manual action, since `npm publish` is irreversible:

1. Tag the merge commit `v2.1.1` and push the tag.
2. Create a GitHub Release for `v2.1.1`, which triggers `publish.yml` →
   `npm publish --provenance --access public`.

## Type of change

- [x] CI / tooling

## Checklist

- [x] Tests added or updated <!-- n/a: version bump + changelog only -->
- [x] `npm run lint && npm test` passes locally
- [x] User-facing changes recorded under `# Unreleased` in `CHANGELOG.md` <!-- moved into the dated 2.1.1 section, as the release process requires -->
- [x] All commits have a `Signed-off-by:` trailer (`git commit -s`)
