### PR TITLE
fix(deps): bump js-yaml to 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,9 +1612,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Fixes [Dependabot alert #61](https://github.com/namecheap/node-vault-client/security/dependabot/61): **high-severity** quadratic CPU consumption in js-yaml `!!omap` resolution ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), CVE-2026-59870).

- `js-yaml` 4.3.0 → 4.3.1 (first patched version)
- Transitive **dev** dependency (`package-lock.json` only); both requiring ranges (`^4.1.0`, `^4.3.0`) already allow 4.3.1, so this is a lockfile-only change with no manifest edits.

## Verification

- `npm ci` — clean install, lockfile integrity OK
- `npm audit` — 0 vulnerabilities
- `npm run test:unit` — 308 passing