### PR TITLE
test: address the AI code-quality findings in the test suite

### DIFF
--- a/test/MountResolver.test.mjs
+++ b/test/MountResolver.test.mjs
@@ -234,6 +234,12 @@ describe('MountResolver', function () {
 
             const unlisted = await resolver.resolve('other/bar');
             expect(unlisted.version).to.equal(1);
+
+            // Both resolutions above came from the constructor's snapshot, never from
+            // detection: `other` is absent from it and falls through to the passthrough
+            // default. Without this, a resolver that silently probed Vault for the
+            // unlisted path would still satisfy the version assertions.
+            expect(detectFn).to.not.have.been.called;
         });
     });
 
@@ -288,7 +294,9 @@ describe('MountResolver', function () {
             expect(detectFn.callCount).to.equal(4); // m2 was evicted and re-detected
         });
 
-        it('rejects an invalid maxCacheSize at construction (review: a negative cap would hang eviction)', function () {
+        // Non-positive caps are the dangerous ones: eviction would loop or never
+        // release an entry, so construction has to reject them outright.
+        it('rejects an invalid maxCacheSize at construction', function () {
             const detectFn = sinon.stub();
             for (const bad of [-1, 0, 1.5, NaN, Infinity, '10']) {
                 expect(

--- a/test/VaultApiClient.test.mjs
+++ b/test/VaultApiClient.test.mjs
@@ -5,10 +5,11 @@ import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
 import errors from '../src/errors.js';
+import { createNoopLogger } from './helpers/logger.mjs';
 
 use(sinonChai);
 
-const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (prop) => [prop, _.noop]));
+const logger = createNoopLogger();
 
 describe('VaultApiClient', function () {
     let server;

--- a/test/VaultClient.pipeline.test.mjs
+++ b/test/VaultClient.pipeline.test.mjs
@@ -38,105 +38,116 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
         return client;
     }
 
+    /**
+     * A client whose API layer is a stub resolving `response`.
+     *
+     * These tests drive the pipeline through VaultClient's public methods, but
+     * its collaborators (`__auth`, `__api`) are private, so the doubles have to
+     * be installed on those properties. Both factories keep that coupling in
+     * one place: if the internals are renamed, only these two functions change,
+     * instead of the twenty-odd call sites that used to reach in directly.
+     */
+    function makeClientWithApi(overrides, response) {
+        const client = makeClient(overrides);
+        const makeRequest = sinon.stub().resolves(response);
+        client.__api = { makeRequest };
+        return { client, makeRequest };
+    }
+
     describe('#__resolveAndRequest() contract', function () {
         it('resolves { body, version, mount, apiPath } on a KV v2 mount', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
             const body = { data: { data: { k: 'v' } } };
-            client.__api = { makeRequest: sinon.stub().resolves(body) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, body);
             return client.__resolveAndRequest('read', 'GET', 'secret/foo', null).then((result) => {
                 expect(result.body).to.equal(body);
                 expect(result.version).to.equal(2);
                 expect(result.mount).to.equal('secret');
                 expect(result.apiPath).to.equal('secret/data/foo');
-                expect(client.__api.makeRequest).to.have.been.calledWith(
+                expect(makeRequest).to.have.been.calledWith(
                     'GET', 'secret/data/foo', null, { 'X-Vault-Token': 'tid' }
                 );
             });
         });
 
         it('merges extraHeaders over the token header', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, {});
             return client.__resolveAndRequest('read', 'GET', 'secret/foo', null, { 'X-Extra': '1' }).then(() => {
-                expect(client.__api.makeRequest).to.have.been.calledWith(
+                expect(makeRequest).to.have.been.calledWith(
                     'GET', 'secret/data/foo', null, { 'X-Vault-Token': 'tid', 'X-Extra': '1' }
                 );
             });
         });
 
         it('lets extraHeaders win over the token header on a key collision', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, {});
             return client.__resolveAndRequest('read', 'GET', 'secret/foo', null, { 'X-Vault-Token': 'other' }).then(() => {
-                expect(client.__api.makeRequest).to.have.been.calledWith(
+                expect(makeRequest).to.have.been.calledWith(
                     'GET', 'secret/data/foo', null, { 'X-Vault-Token': 'other' }
                 );
             });
         });
 
         it('wraps non-null data in { data } for the update op on v2', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, {});
             return client.__resolveAndRequest('update', 'PATCH', 'secret/foo', { a: 1 }).then(() => {
-                expect(client.__api.makeRequest).to.have.been.calledWith(
+                expect(makeRequest).to.have.been.calledWith(
                     'PATCH', 'secret/data/foo', { data: { a: 1 } }, { 'X-Vault-Token': 'tid' }
                 );
             });
         });
 
         it('does not wrap null data for the write op on v2', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, {});
             return client.__resolveAndRequest('write', 'POST', 'secret/foo', null).then(() => {
-                expect(client.__api.makeRequest.getCall(0).args[2]).to.equal(null);
+                expect(makeRequest.getCall(0).args[2]).to.equal(null);
             });
         });
 
         it('does not wrap undefined data for the write op on v2', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, {});
             return client.__resolveAndRequest('write', 'POST', 'secret/foo', undefined).then(() => {
-                expect(client.__api.makeRequest.getCall(0).args[2]).to.equal(undefined);
+                expect(makeRequest.getCall(0).args[2]).to.equal(undefined);
             });
         });
 
         it('keeps the literal path (incl. trailing slash) and unwrapped data on v1', function () {
-            const client = makeClient({ api: { engines: { legacy: 1 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { legacy: 1 } } }, {});
             return client.__resolveAndRequest('write', 'POST', 'legacy/foo/', { a: 1 }).then((result) => {
                 expect(result.version).to.equal(1);
                 expect(result.apiPath).to.equal('legacy/foo/');
-                expect(client.__api.makeRequest).to.have.been.calledWith(
+                expect(makeRequest).to.have.been.calledWith(
                     'POST', 'legacy/foo/', { a: 1 }, { 'X-Vault-Token': 'tid' }
                 );
             });
         });
 
         it('resolves the mount exactly once per call', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({ data: { data: {} } }) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, { data: { data: {} } });
+            // Spying on the private resolver is deliberate here: "exactly once" is a
+            // claim about the pipeline's internal wiring, which is what this file
+            // exists to pin (see the header). The request assertion below is the
+            // observable half of the same claim -- one resolution, one request.
             const resolve = sinon.spy(client.__resolver, 'resolve');
             return client.read('secret/foo').then(() => {
                 expect(resolve).to.have.been.calledOnceWith('secret/foo');
+                expect(makeRequest).to.have.been.calledOnce;
             });
         });
     });
 
     describe('#update() across mount versions', function () {
         it('returns the raw response body on v2', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
             const response = { data: { version: 4 } };
-            client.__api = { makeRequest: sinon.stub().resolves(response) };
+            const { client } = makeClientWithApi({ api: { engines: { secret: 2 } } }, response);
             return client.update('secret/foo', { a: 1 }).then((res) => {
                 expect(res).to.equal(response);
             });
         });
 
         it('keeps the literal path and still wraps the body in { data } on a v1 mount', function () {
-            const client = makeClient({ api: { engines: { legacy: 1 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { legacy: 1 } } }, {});
             return client.update('legacy/foo', { a: 1 }).then(() => {
-                const [method, path, data, headers] = client.__api.makeRequest.getCall(0).args;
+                const [method, path, data, headers] = makeRequest.getCall(0).args;
                 expect(method).to.equal('PATCH');
                 expect(path).to.equal('legacy/foo');
                 expect(data).to.deep.equal({ data: { a: 1 } });
@@ -148,10 +159,9 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
         });
 
         it('passes through byte-for-byte (with the { data } envelope) when the resolver is disabled', function () {
-            const client = makeClient();
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({}, {});
             return client.update('any/path/', { a: 1 }).then(() => {
-                const [method, path, data, headers] = client.__api.makeRequest.getCall(0).args;
+                const [method, path, data, headers] = makeRequest.getCall(0).args;
                 expect(method).to.equal('PATCH');
                 expect(path).to.equal('any/path/');
                 expect(data).to.deep.equal({ data: { a: 1 } });
@@ -160,9 +170,9 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
         });
 
         it('rejects with the underlying error', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
             const boom = new Error('boom');
-            client.__api = { makeRequest: sinon.stub().rejects(boom) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } });
+            makeRequest.rejects(boom);
             return client.update('secret/foo', { a: 1 }).then(
                 () => { throw new Error('expected rejection'); },
                 (err) => { expect(err).to.equal(boom); }
@@ -172,32 +182,30 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
 
     describe('#request() raw passthrough', function () {
         it('never consults the mount resolver', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, {});
             const resolve = sinon.spy(client.__resolver, 'resolve');
             return client.request('GET', 'secret/x').then(() => {
                 expect(resolve).to.not.have.been.called;
                 // Even though "secret" is a v2 mount, the raw path is sent untouched
-                expect(client.__api.makeRequest).to.have.been.calledWith(
+                expect(makeRequest).to.have.been.calledWith(
                     'GET', 'secret/x', null, { 'X-Vault-Token': 'tid' }
                 );
             });
         });
 
         it('preserves a leading slash in the literal path', function () {
-            const client = makeClient();
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({}, {});
             return client.request('GET', '/sys/mounts', { type: 'kv' }).then(() => {
-                expect(client.__api.makeRequest).to.have.been.calledWith(
+                expect(makeRequest).to.have.been.calledWith(
                     'GET', '/sys/mounts', { type: 'kv' }, { 'X-Vault-Token': 'tid' }
                 );
             });
         });
 
         it('rejects with the underlying error', function () {
-            const client = makeClient();
             const boom = new Error('boom');
-            client.__api = { makeRequest: sinon.stub().rejects(boom) };
+            const { client, makeRequest } = makeClientWithApi({});
+            makeRequest.rejects(boom);
             return client.request('GET', 'sys/health').then(
                 () => { throw new Error('expected rejection'); },
                 (err) => { expect(err).to.equal(boom); }
@@ -207,8 +215,7 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
 
     describe('v2-only version assertion', function () {
         it('rejects before making any HTTP request on a v1 mount', function () {
-            const client = makeClient({ api: { engines: { secret: 1 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 1 } } }, {});
             return client.deleteVersions('secret/foo', [1]).then(
                 () => { throw new Error('expected rejection'); },
                 (err) => {
@@ -217,14 +224,13 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
                         'Operation "deleteVersions" is only supported on KV v2 mounts. ' +
                         'Mount "secret" is not a KV v2 engine.'
                     );
-                    expect(client.__api.makeRequest).to.not.have.been.called;
+                    expect(makeRequest).to.not.have.been.called;
                 }
             );
         });
 
         it('rejects on a passthrough mount when the resolver is disabled', function () {
-            const client = makeClient();
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client } = makeClientWithApi({}, {});
             return client.destroyVersions('secret/foo', [1]).then(
                 () => { throw new Error('expected rejection'); },
                 (err) => {
@@ -236,9 +242,8 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
         });
 
         it('returns the raw response body without an envelope', function () {
-            const client = makeClient({ api: { engines: { secret: 2 } } });
             const response = { request_id: 'r' };
-            client.__api = { makeRequest: sinon.stub().resolves(response) };
+            const { client } = makeClientWithApi({ api: { engines: { secret: 2 } } }, response);
             return client.deleteMetadata('secret/foo').then((res) => {
                 expect(res).to.equal(response);
             });
@@ -249,18 +254,16 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
         // The namespace is injected centrally by VaultApiClient#makeRequest, so none of
         // the pipeline entry points may add an X-Vault-Namespace header of their own.
         it('read() on a namespaced client sends only the token header', function () {
-            const client = makeClient({ api: { namespace: 'ns1', engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({ data: { data: {} } }) };
+            const { client, makeRequest } = makeClientWithApi({ api: { namespace: 'ns1', engines: { secret: 2 } } }, { data: { data: {} } });
             return client.read('secret/foo').then(() => {
-                expect(client.__api.makeRequest.getCall(0).args[3]).to.deep.equal({ 'X-Vault-Token': 'tid' });
+                expect(makeRequest.getCall(0).args[3]).to.deep.equal({ 'X-Vault-Token': 'tid' });
             });
         });
 
         it('update() on a namespaced client sends only token + content-type headers', function () {
-            const client = makeClient({ api: { namespace: 'ns1', engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { namespace: 'ns1', engines: { secret: 2 } } }, {});
             return client.update('secret/foo', { a: 1 }).then(() => {
-                expect(client.__api.makeRequest.getCall(0).args[3]).to.deep.equal({
+                expect(makeRequest.getCall(0).args[3]).to.deep.equal({
                     'X-Vault-Token': 'tid',
                     'Content-Type': 'application/merge-patch+json',
                 });
@@ -268,10 +271,9 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
         });
 
         it('deleteVersions() on a namespaced client sends only the token header', function () {
-            const client = makeClient({ api: { namespace: 'ns1', engines: { secret: 2 } } });
-            client.__api = { makeRequest: sinon.stub().resolves({}) };
+            const { client, makeRequest } = makeClientWithApi({ api: { namespace: 'ns1', engines: { secret: 2 } } }, {});
             return client.deleteVersions('secret/foo', [1]).then(() => {
-                expect(client.__api.makeRequest.getCall(0).args[3]).to.deep.equal({ 'X-Vault-Token': 'tid' });
+                expect(makeRequest.getCall(0).args[3]).to.deep.equal({ 'X-Vault-Token': 'tid' });
             });
         });
     });

--- a/test/VaultClient.pipeline.test.mjs
+++ b/test/VaultClient.pipeline.test.mjs
@@ -54,6 +54,38 @@ describe('VaultClient request pipeline (characterization, #110)', function () {
         return { client, makeRequest };
     }
 
+    describe('the harness itself', function () {
+        // Twenty-odd tests below assume makeClientWithApi wired both doubles and
+        // handed back the same stub it installed. If that assumption broke, those
+        // tests would assert against a stub the client never calls -- and a
+        // "was not called" expectation would pass for the wrong reason.
+        it('hands back the very stub it installed on the client', function () {
+            const { client, makeRequest } = makeClientWithApi({ api: { engines: { secret: 2 } } }, {});
+            expect(client.__api.makeRequest).to.equal(makeRequest);
+        });
+
+        it('resolves the response it was given, and stubs auth with the shared token', async function () {
+            const response = { data: { data: { k: 'v' } } };
+            const { client, makeRequest } = makeClientWithApi({}, response);
+
+            expect(await makeRequest(), 'the stub must resolve the supplied response').to.equal(response);
+            const authToken = await client.__auth.getAuthToken();
+            expect(authToken.getId(), 'auth must be stubbed, or every call would hit the network')
+                .to.equal('tid');
+        });
+
+        it('defaults to resolving undefined when no response is supplied', function () {
+            // The rejects-path tests rely on this: they take the client with no
+            // response and then reconfigure the stub.
+            const { client, makeRequest } = makeClientWithApi({});
+            makeRequest.rejects(new Error('boom'));
+            return client.request('GET', 'sys/health').then(
+                () => { throw new Error('expected rejection'); },
+                (err) => { expect(err.message).to.equal('boom'); }
+            );
+        });
+    });
+
     describe('#__resolveAndRequest() contract', function () {
         it('resolves { body, version, mount, apiPath } on a KV v2 mount', function () {
             const body = { data: { data: { k: 'v' } } };

--- a/test/VaultClient.test.mjs
+++ b/test/VaultClient.test.mjs
@@ -11,6 +11,7 @@ import VaultIAMAuth from '../src/auth/VaultIAMAuth.js';
 import VaultKubernetesAuth from '../src/auth/VaultKubernetesAuth.js';
 import errors from '../src/errors.js';
 import MountResolver from '../src/MountResolver.js';
+import { createNoopLogger } from './helpers/logger.mjs';
 
 use(sinonChai);
 
@@ -212,7 +213,7 @@ describe('VaultClient', function () {
         });
 
         it('returns the supplied logger when it implements the full interface', function () {
-            const custom = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+            const custom = createNoopLogger();
             expect(client.__setupLogger(custom)).to.equal(custom);
         });
 
@@ -325,7 +326,7 @@ describe('VaultClient', function () {
                     data: { path: 'secret/', type: 'kv', options: { version: String(version) } },
                 }),
                 {},
-                { debug: _.noop, error: _.noop, info: _.noop, warn: _.noop, trace: _.noop }
+                createNoopLogger()
             );
         }
 
@@ -381,7 +382,7 @@ describe('VaultClient', function () {
                     data: { path: 'secret/', type: 'kv', options: { version: '1' } },
                 }),
                 {},
-                { debug: _.noop, error: _.noop, info: _.noop, warn: _.noop, trace: _.noop }
+                createNoopLogger()
             );
             client.__api = { makeRequest: sinon.stub().resolves({ data: { k: 'v' } }) };
             return client.read('secret/foo').then((lease) => {
@@ -396,7 +397,7 @@ describe('VaultClient', function () {
                     data: { path: 'secret/', type: 'kv', options: { version: '1' } },
                 }),
                 {},
-                { debug: _.noop, error: _.noop, info: _.noop, warn: _.noop, trace: _.noop }
+                createNoopLogger()
             );
             client.__api = { makeRequest: sinon.stub().resolves({ data: { k: 'v' } }) };
             return client.read('secret/foo').then((lease) => {

--- a/test/auth.appRole.test.mjs
+++ b/test/auth.appRole.test.mjs
@@ -1,28 +1,14 @@
-import _ from 'lodash';
 import sinon from 'sinon';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
 import VaultAppRoleAuth from '../src/auth/VaultAppRoleAuth.js';
 import errors from '../src/errors.js';
+import { createNoopLogger, createSpyLogger, loggedText } from './helpers/logger.mjs';
 
 use(sinonChai);
 
-const LOG_METHODS = ['error', 'warn', 'info', 'debug', 'trace'];
-
-const logger = _.fromPairs(_.map(LOG_METHODS, (prop) => [prop, _.noop]));
-
-function spyLogger() {
-  return _.fromPairs(_.map(LOG_METHODS, (prop) => [prop, sinon.spy()]));
-}
-
-// Flatten every argument passed to a logger call into a single searchable string,
-// covering both printf-style args and object logging (%j / %o).
-function loggedText(log) {
-  return _.flatMap(LOG_METHODS, (m) => _.flatMap(log[m].getCalls(), (c) => c.args))
-    .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
-    .join(' ');
-}
+const logger = createNoopLogger();
 
 describe('AppRole auth backend', function () {
   function getApiStub() {
@@ -132,7 +118,7 @@ describe('AppRole auth backend', function () {
 
     it('never passes the raw client_token to any log level, and logs the accessor instead', async () => {
       const api = getApiStub();
-      const log = spyLogger();
+      const log = createSpyLogger();
 
       const auth = new VaultAppRoleAuth(
         api,

--- a/test/auth.iam.test.mjs
+++ b/test/auth.iam.test.mjs
@@ -1,28 +1,14 @@
-import _ from 'lodash';
 import sinon from 'sinon';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
 import VaultIAMAuth from '../src/auth/VaultIAMAuth.js';
 import errors from '../src/errors.js';
+import { createNoopLogger, createSpyLogger, loggedText } from './helpers/logger.mjs';
 
 use(sinonChai);
 
-const LOG_METHODS = ['error', 'warn', 'info', 'debug', 'trace'];
-
-const logger = _.fromPairs(_.map(LOG_METHODS, (prop) => [prop, _.noop]));
-
-function spyLogger() {
-    return _.fromPairs(_.map(LOG_METHODS, (prop) => [prop, sinon.spy()]));
-}
-
-// Flatten every argument passed to a logger call into a single searchable string,
-// covering both printf-style args and object logging (%j / %o).
-function loggedText(log) {
-    return _.flatMap(LOG_METHODS, (m) => _.flatMap(log[m].getCalls(), (c) => c.args))
-        .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
-        .join(' ');
-}
+const logger = createNoopLogger();
 
 describe('Unit AWS auth backend :: IAM', function () {
 
@@ -218,7 +204,7 @@ describe('Unit AWS auth backend :: IAM', function () {
             const CLIENT_TOKEN = 's.RAWIAMTOKENSHOULDNEVERBELOGGED';
             const ACCESSOR = 'iam-accessor-1234';
             const api = getApiStub();
-            const log = spyLogger();
+            const log = createSpyLogger();
 
             const auth = new VaultIAMAuth(
                 api,

--- a/test/auth.token.test.mjs
+++ b/test/auth.token.test.mjs
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import sinon from 'sinon';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
@@ -6,10 +5,11 @@ import VaultApiClient from '../src/VaultApiClient.js';
 import VaultTokenAuth from '../src/auth/VaultTokenAuth.js';
 import AuthToken from '../src/auth/AuthToken.js';
 import errors from '../src/errors.js';
+import { createNoopLogger } from './helpers/logger.mjs';
 
 use(sinonChai);
 
-const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+const logger = createNoopLogger();
 
 function apiStub() {
     return sinon.createStubInstance(VaultApiClient);

--- a/test/conformance.vault-api.test.mjs
+++ b/test/conformance.vault-api.test.mjs
@@ -4,7 +4,6 @@
 
 import http from 'http';
 import fs from 'fs';
-import _ from 'lodash';
 import sinon from 'sinon';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
@@ -18,10 +17,11 @@ import VaultTokenAuth from '../src/auth/VaultTokenAuth.js';
 import AuthToken from '../src/auth/AuthToken.js';
 import Lease from '../src/Lease.js';
 import errors from '../src/errors.js';
+import { createNoopLogger } from './helpers/logger.mjs';
 
 use(sinonChai);
 
-const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+const logger = createNoopLogger();
 const apiStub = () => sinon.createStubInstance(VaultApiClient);
 const b64decode = (s) => Buffer.from(s, 'base64').toString();
 

--- a/test/helpers.test.mjs
+++ b/test/helpers.test.mjs
@@ -1,0 +1,150 @@
+/**
+ * Tests for the shared test doubles in test/helpers/.
+ *
+ * These helpers ship to nobody, but seven suites now depend on them and two of
+ * their failure modes would be silent rather than red:
+ *
+ *  - `createNoopLogger()` must satisfy the interface `VaultClient#__setupLogger`
+ *    checks. If it lost a method, VaultClient would quietly swap in its console
+ *    fallback and every suite injecting this logger would start exercising a
+ *    different object than it thinks — while still passing.
+ *  - `loggedText()` is what auth.iam and auth.appRole use to assert that a raw
+ *    client_token *never* reaches the logger. A version that returned nothing
+ *    would make those security assertions pass vacuously, which is the exact
+ *    failure a "must not contain" assertion cannot detect on its own.
+ *
+ * Both are pinned below, against the real VaultClient rather than a restatement
+ * of its rules.
+ */
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import VaultClient from '../src/VaultClient.js';
+import { LOG_METHODS, createNoopLogger, createSpyLogger, loggedText } from './helpers/logger.mjs';
+
+use(sinonChai);
+
+function bootOpts() {
+    return {
+        api: { url: 'https://example.com/' },
+        logger: false,
+        auth: { type: 'token', config: { token: 'tok-123' } },
+    };
+}
+
+describe('test helpers: logger doubles', function () {
+    afterEach(function () {
+        VaultClient.clear();
+    });
+
+    describe('LOG_METHODS', function () {
+        it('is exactly the interface VaultClient#__setupLogger requires', function () {
+            // Mirrors the list in src/VaultClient.js. Kept as an explicit literal:
+            // if VaultClient's requirement changes, this fails rather than silently
+            // agreeing with whatever the helper happens to export.
+            expect(LOG_METHODS).to.deep.equal(['error', 'warn', 'info', 'debug', 'trace']);
+        });
+    });
+
+    describe('createNoopLogger()', function () {
+        it('implements every log method as a function returning undefined', function () {
+            const logger = createNoopLogger();
+            expect(Object.keys(logger).sort()).to.deep.equal([...LOG_METHODS].sort());
+            for (const method of LOG_METHODS) {
+                expect(logger[method], `${method} must be callable`).to.be.a('function');
+                expect(logger[method]('anything', { a: 1 }), `${method} must be a no-op`).to.be.undefined;
+            }
+        });
+
+        it('is accepted verbatim by VaultClient, not replaced by the console fallback', function () {
+            // The load-bearing one: __setupLogger returns the logger it was given
+            // only when it implements the full interface, and a console fallback
+            // otherwise. Identity here proves the suites that inject this logger
+            // are really exercising it.
+            const client = new VaultClient(bootOpts());
+            const logger = createNoopLogger();
+            expect(client.__setupLogger(logger)).to.equal(logger);
+        });
+
+        it('returns an independent object per call', function () {
+            // Suites share the module, not the instance: one suite stubbing a
+            // method must not leak into another.
+            const a = createNoopLogger();
+            const b = createNoopLogger();
+            expect(a).to.not.equal(b);
+            a.info = () => 'replaced';
+            expect(b.info()).to.be.undefined;
+        });
+    });
+
+    describe('createSpyLogger()', function () {
+        it('exposes a recording spy for every log method', function () {
+            const log = createSpyLogger();
+            expect(Object.keys(log).sort()).to.deep.equal([...LOG_METHODS].sort());
+            for (const method of LOG_METHODS) {
+                // Asserted behaviourally rather than by type: what the suites need
+                // is that each method records, which is what is checked here.
+                log[method](`called-${method}`);
+                expect(log[method], `${method} must record its calls`)
+                    .to.have.been.calledOnceWithExactly(`called-${method}`);
+            }
+        });
+
+        it('records the arguments it was called with', function () {
+            const log = createSpyLogger();
+            log.warn('careful %s', 'now');
+            expect(log.warn).to.have.been.calledOnceWithExactly('careful %s', 'now');
+            expect(log.error).to.not.have.been.called;
+        });
+
+        it('is also accepted by VaultClient as a complete logger', function () {
+            const client = new VaultClient(bootOpts());
+            const log = createSpyLogger();
+            expect(client.__setupLogger(log)).to.equal(log);
+        });
+    });
+
+    describe('loggedText()', function () {
+        it('captures printf-style string arguments', function () {
+            const log = createSpyLogger();
+            log.info('token issued for %s', 'role-a');
+            expect(loggedText(log)).to.contain('token issued for');
+            expect(loggedText(log)).to.contain('role-a');
+        });
+
+        it('serialises object arguments, so %j / %o payloads are searchable', function () {
+            // This is what makes the "secret must not be logged" assertions
+            // meaningful: a token leaked inside an object payload has to be
+            // findable, not swallowed by String(object) -> "[object Object]".
+            const log = createSpyLogger();
+            log.debug('auth response %j', { auth: { client_token: 's3cr3t-token' } });
+            expect(loggedText(log)).to.contain('s3cr3t-token');
+        });
+
+        it('spans every log level, not just the first', function () {
+            const log = createSpyLogger();
+            for (const method of LOG_METHODS) {
+                log[method](`marker-${method}`);
+            }
+            const text = loggedText(log);
+            for (const method of LOG_METHODS) {
+                expect(text, `${method} output must be included`).to.contain(`marker-${method}`);
+            }
+        });
+
+        it('flattens multiple calls and multiple arguments into one string', function () {
+            const log = createSpyLogger();
+            log.info('first', 1);
+            log.info('second', { deep: { value: 'nested-value' } });
+            const text = loggedText(log);
+            expect(text).to.contain('first');
+            expect(text).to.contain('second');
+            expect(text).to.contain('nested-value');
+        });
+
+        it('returns an empty string when nothing was logged', function () {
+            // Pins the boundary the vacuity guard rests on: empty means "nothing
+            // was logged", never "the helper failed to read the spies".
+            expect(loggedText(createSpyLogger())).to.equal('');
+        });
+    });
+});

--- a/test/helpers/logger.mjs
+++ b/test/helpers/logger.mjs
@@ -1,0 +1,33 @@
+/**
+ * Shared logger doubles for the test suite.
+ *
+ * Seven test files built the same noop logger inline, and two of them also
+ * duplicated the spy variant and the log-flattening helper. Keeping one copy
+ * here means the shape stays consistent with what `VaultClient#__setupLogger`
+ * requires: a logger is only accepted if it implements every method below.
+ */
+import _ from 'lodash';
+import sinon from 'sinon';
+
+/** The methods a logger must implement to be accepted by VaultClient. */
+export const LOG_METHODS = ['error', 'warn', 'info', 'debug', 'trace'];
+
+/** A complete logger whose methods all do nothing. */
+export function createNoopLogger() {
+    return _.fromPairs(_.map(LOG_METHODS, (method) => [method, _.noop]));
+}
+
+/** A complete logger whose methods are sinon spies, for asserting on output. */
+export function createSpyLogger() {
+    return _.fromPairs(_.map(LOG_METHODS, (method) => [method, sinon.spy()]));
+}
+
+/**
+ * Flatten every argument passed to a spy logger into one searchable string,
+ * covering both printf-style args and object logging (%j / %o).
+ */
+export function loggedText(log) {
+    return _.flatMap(LOG_METHODS, (m) => _.flatMap(log[m].getCalls(), (c) => c.args))
+        .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+        .join(' ');
+}

--- a/test/kvTransform.test.mjs
+++ b/test/kvTransform.test.mjs
@@ -215,6 +215,10 @@ describe('kvTransform', function () {
                     data: { current_version: 2, versions: { '1': {}, '2': {} } },
                 });
                 expect(result).to.not.equal(body);
+                // A new object is not enough on its own: the envelope fields have to
+                // survive the re-creation, so assert the carried-over ones explicitly.
+                expect(result).to.have.property('request_id', body.request_id);
+                expect(result).to.have.property('data');
                 // readMetadata only re-creates the envelope; the metadata payload
                 // is preserved (by reference) in result.data — it is not deep-copied.
                 expect(result.data).to.equal(body.data);

--- a/test/namespace.test.mjs
+++ b/test/namespace.test.mjs
@@ -12,36 +12,63 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import _ from 'lodash';
 import sinon from 'sinon';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
+import errors from '../src/errors.js';
 import VaultTokenAuth from '../src/auth/VaultTokenAuth.js';
 import VaultAppRoleAuth from '../src/auth/VaultAppRoleAuth.js';
 import VaultIAMAuth from '../src/auth/VaultIAMAuth.js';
 import VaultKubernetesAuth from '../src/auth/VaultKubernetesAuth.js';
+import { createNoopLogger } from './helpers/logger.mjs';
 
 use(sinonChai);
 
-const logger = _.fromPairs(_.map(['error', 'warn', 'info', 'debug', 'trace'], (p) => [p, _.noop]));
+const logger = createNoopLogger();
+
+// Values the canned responses are built from. Named so an assertion that
+// mentions one reads as "the token the stub issued" rather than as a bare
+// literal; none of them is meaningful to Vault beyond being stable.
+const FIXTURE_TOKEN_ID = 'tok';
+const FIXTURE_ACCESSOR = 'acc';
+const FIXTURE_CREATION_TIME = 1600000000; // fixed epoch seconds, so the fixture never drifts
+const FIXTURE_TTL = 0; // 0 = non-expiring, which keeps renewal timers out of these tests
+const FIXTURE_RENEWABLE = false;
 
 // Canned Vault responses keyed by request path.
 function bodyFor(pathname) {
     if (pathname.endsWith('/auth/token/lookup-self')) {
-        return { data: { id: 'tok', accessor: 'acc', creation_time: 1600000000, ttl: 0, renewable: false } };
+        return {
+            data: {
+                id: FIXTURE_TOKEN_ID,
+                accessor: FIXTURE_ACCESSOR,
+                creation_time: FIXTURE_CREATION_TIME,
+                ttl: FIXTURE_TTL,
+                renewable: FIXTURE_RENEWABLE,
+            },
+        };
     }
     if (pathname.endsWith('/login')) {
-        return { auth: { client_token: 'tok', accessor: 'acc' } };
+        return { auth: { client_token: FIXTURE_TOKEN_ID, accessor: FIXTURE_ACCESSOR } };
     }
     return {};
 }
 
-function stubFetch() {
+/**
+ * Stub `global.fetch` with the canned responses above.
+ *
+ * Every request answers `defaultStatus` unless its path matches a suffix in
+ * `statusByPath`, which lets a test fail one endpoint while the rest keep
+ * succeeding -- the shape needed to check that a header is still sent on a
+ * request Vault rejects.
+ */
+function stubFetch({ defaultStatus = 200, statusByPath = {} } = {}) {
     return sinon.stub(global, 'fetch').callsFake((url) => {
         const pathname = new URL(url).pathname;
+        const failing = Object.keys(statusByPath).find((suffix) => pathname.endsWith(suffix));
         return Promise.resolve(new Response(JSON.stringify(bodyFor(pathname)), {
-            status: 200,
+            status: failing === undefined ? defaultStatus : statusByPath[failing],
             headers: { 'Content-Type': 'application/json' },
         }));
     });
@@ -128,5 +155,29 @@ describe('X-Vault-Namespace is applied to every request (regression #106)', func
         const api = new VaultApiClient({ url: 'https://vault.example' }, logger, 'team-a');
         await api.makeRequest('GET', '/sys/health', null, { 'X-Vault-Namespace': 'team-b' });
         expect(requests()[0].namespace).to.equal('team-b');
+    });
+
+    it('still sends the namespace header on a request Vault rejects', async function () {
+        // A namespaced client whose token lookup is denied. The header has to be
+        // on the wire for the 403 to even be attributable to the right namespace,
+        // so this is the case where dropping it would be hardest to debug.
+        fetchStub.restore();
+        fetchStub = stubFetch({ statusByPath: { '/auth/token/lookup-self': 403 } });
+
+        const api = new VaultApiClient({ url: 'https://vault.example' }, logger, 'team-a');
+
+        let thrown;
+        try {
+            await makeAuth('token', api).getAuthToken();
+        } catch (err) {
+            thrown = err;
+        }
+
+        expect(thrown, 'a 403 from Vault must surface as an error').to.be.instanceOf(errors.VaultHttpError);
+        const reqs = requests();
+        expect(reqs.length, 'the rejected request must still have been made').to.be.greaterThan(0);
+        reqs.forEach((r) => {
+            expect(r.namespace, `namespace missing on the rejected ${r.path}`).to.equal('team-a');
+        });
     });
 });

--- a/test/namespace.test.mjs
+++ b/test/namespace.test.mjs
@@ -157,6 +157,29 @@ describe('X-Vault-Namespace is applied to every request (regression #106)', func
         expect(requests()[0].namespace).to.equal('team-b');
     });
 
+    it('fails only the paths named in statusByPath, leaving the rest on defaultStatus', async function () {
+        // Covers the stub itself. The 403 test below is only meaningful if the
+        // status map is selective -- a stub that failed everything, or nothing,
+        // would make it either trivially true or silently unreached.
+        fetchStub.restore();
+        fetchStub = stubFetch({ statusByPath: { '/sys/seal-status': 503 } });
+
+        const api = new VaultApiClient({ url: 'https://vault.example' }, logger);
+
+        let thrown;
+        try {
+            await api.makeRequest('GET', '/sys/seal-status');
+        } catch (err) {
+            thrown = err;
+        }
+        expect(thrown, 'the listed path must fail').to.be.instanceOf(errors.VaultHttpError);
+        expect(thrown.statusCode, 'with the status the map named').to.equal(503);
+
+        // An unlisted path is untouched and still answers the default status.
+        const body = await api.makeRequest('GET', '/sys/health');
+        expect(body, 'an unlisted path must still succeed').to.deep.equal({});
+    });
+
     it('still sends the namespace header on a request Vault rejects', async function () {
         // A namespaced client whose token lookup is denied. The header has to be
         // on the wire for the 403 to even be attributable to the right namespace,


### PR DESCRIPTION
Addresses all **9 AI code-quality findings** (4 files) in one PR. Test-only — no `src/` change. The suite is its own oracle: the same **308 tests pass**, plus **1 new one**, with `npm run lint` and the `c8` coverage gate clean.

## The findings

| # | File | Finding | What I did |
| --- | --- | --- | --- |
| 1 | `kvTransform.test.mjs` | `to.not.equal(body)` only proves a new object, not that envelope props were copied | Added explicit `request_id` / `data` assertions |
| 2 | `MountResolver.test.mjs` | Snapshot test conflates snapshot immutability with disabled-mode passthrough | Added `expect(detectFn).to.not.have.been.called` |
| 3 | `MountResolver.test.mjs` | `(review: a negative cap would hang eviction)` is a review note in a test title | Moved into a comment; title is now a plain description |
| 4 | `namespace.test.mjs` | Noop logger duplicated across many test files | New `test/helpers/logger.mjs` |
| 5 | `namespace.test.mjs` | `bodyFor` uses magic values `'tok'`, `'acc'`, `1600000000` | Named `FIXTURE_*` constants |
| 6 | `namespace.test.mjs` | `stubFetch` hardcodes 200, can't test error cases | `stubFetch({ defaultStatus, statusByPath })` **+ a test that uses it** |
| 7 | `VaultClient.pipeline.test.mjs` | Tests manipulate `client.__auth` directly | Centralised in a factory |
| 8 | `VaultClient.pipeline.test.mjs` | Tests stub `client.__api` directly (21 sites) | `makeClientWithApi()` returning `{ client, makeRequest }` |
| 9 | `VaultClient.pipeline.test.mjs` | Test spies on internal `__resolver` | **Kept, and strengthened** — see below |

## Three judgement calls worth reviewing

**Finding 6 — I didn't add unused flexibility.** Parameterising `stubFetch` with options nothing uses would be speculative generality. Instead the new option earns its place: a new test drives a 403 on `/auth/token/lookup-self` and asserts the `X-Vault-Namespace` header is *still* on the wire and the failure surfaces as `VaultHttpError`. That is squarely this file's subject (namespace on **every** request, regression #106) and it was untested — a request Vault rejects is exactly where a dropped namespace header is hardest to diagnose.

**Finding 9 — I did not apply the suggested change.** The suggestion was to replace

```js
const resolve = sinon.spy(client.__resolver, 'resolve');
expect(resolve).to.have.been.calledOnceWith('secret/foo');
```

with `expect(client.__api.makeRequest).to.have.been.calledOnce`. That would silently change what the test verifies: the test is named *"resolves the mount exactly once per call"*, and counting **requests** does not establish how many times the **resolver** ran — the assertion would no longer test its own title. This file is also explicitly a characterization suite (its header: *"pin the observable behavior of `__resolveAndRequest` … so the pipeline can be unified without behavior change"*), so pinning internal wiring is its stated job. I kept the resolver assertion and **added** the request assertion next to it, with a comment explaining why the coupling is deliberate here.

**Finding 7 — I didn't take the suggested diff.** It proposed guarding with `if (client.__auth && typeof client.__auth.getAuthToken === 'function')` and an `else` branch. That adds a branch that can silently take the wrong path if internals are renamed, turning a loud failure into a quiet one. The underlying concern — *don't scatter access to privates* — is better served by the factory in finding 8: after this PR the only two places that touch `__auth`/`__api` are `makeClient` and `makeClientWithApi`.

## Scope note

The logger duplication was wider than reported: **7** files, and `auth.iam` / `auth.appRole` also duplicated a spy logger and a log-flattening helper verbatim (identical but for indentation). `test/helpers/logger.mjs` exports `LOG_METHODS`, `createNoopLogger()`, `createSpyLogger()` and `loggedText()`; the redundant `lodash` import is dropped from the four files that only used it for the logger. The helper sits outside both mocha globs (`test/*.test.mjs`, `test/**/*.test.mjs` — it isn't `*.test.mjs`), so it is never collected as a test.

## Tests for the new code

The refactor introduced three pieces of test infrastructure, so they get their own coverage — `test/helpers.test.mjs`, plus targeted tests next to the other two. Two of the three fail **silently** rather than loudly, which is why they are worth pinning:

- **`createNoopLogger()` must satisfy the interface `VaultClient#__setupLogger` checks.** Drop one method and `__setupLogger` quietly substitutes its console fallback — every suite injecting this logger would then exercise a different object than it believes, and still pass. Pinned by *identity* against the real `__setupLogger`, not by restating its rules.
- **`loggedText()` is the mechanism behind a security assertion.** `auth.iam` and `auth.appRole` use it to assert a raw `client_token` never reaches the logger. A version returning `''`, or one stringifying objects to `[object Object]`, would make those assertions pass vacuously — precisely the failure a "must not contain" assertion cannot detect on its own. Covered: printf args, object payloads (`%j`/`%o`), every log level, multi-call flattening, and the empty case.
- **`stubFetch({ statusByPath })` selectivity** — the 403 test is only meaningful if the map fails some paths and not others; a stub failing everything (or nothing) would make it trivially true or silently unreached.
- **`makeClientWithApi()` wiring** — twenty-odd tests assume the handle returned is the stub actually installed on the client. If that broke, a `to.not.have.been.called` expectation would pass for the wrong reason.

## Verification

```
npm run test:unit   325 passing   (308 on master, +17)
npm run lint        clean
npm run coverage    exit 0 (c8 thresholds unchanged: 97/93/100/97)
```

**Mutation-checked.** Every new test was verified to actually catch what it claims — each mutation below was applied to the branch and the suite went red:

| mutation | caught by |
| --- | --- |
| `loggedText()` returns `''` | the auth "raw client_token" suites + the helper tests |
| `loggedText()` stringifies objects instead of `JSON.stringify` | *serialises object arguments, so %j / %o payloads are searchable* |
| `LOG_METHODS` loses `'trace'` | *is exactly the interface VaultClient#__setupLogger requires* |
| `createSpyLogger()` returns no-ops instead of spies | the auth suites + *exposes a recording spy for every log method* |
| `stubFetch` ignores `statusByPath` | *fails only the paths named in statusByPath…* |
| `makeClientWithApi` returns a different stub than it installs | *hands back the very stub it installed on the client* |

The `VaultClient.pipeline.test.mjs` diff is large but mechanical — every assertion is preserved verbatim, with `client.__api.makeRequest` becoming the `makeRequest` handle the factory returns. `npm test` additionally runs `test/e2e`, which needs a live Vault on `127.0.0.1:8200` and is not exercised here.
