### PR TITLE
docs: correct README and CONTRIBUTING where they disagree with the code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ By participating in this project you agree to abide by our [Code of Conduct](COD
 ```shell
 npm ci                 # install dependencies from the lockfile
 npm install config     # peer dependency used by the node-config integration and coverage
-docker compose up -d   # start a local dev Vault on 127.0.0.1:8200
+docker compose up -d   # start local dev Vaults: KV v1 on 127.0.0.1:8200, KV v2 on 127.0.0.1:8202
 
 npm run lint           # ESLint (must be clean)
 npm run test:unit      # fast unit tests (no Vault required)
@@ -28,7 +28,9 @@ npm run coverage       # unit tests with c8 coverage report
 ```
 
 Run `npm run lint` and the tests before pushing — the same checks run in CI
-(`.github/workflows/pipeline.yaml`: audit, lint, coverage, and a test matrix on Node 18/20/22/24).
+(`.github/workflows/pipeline.yaml`: audit, lint, coverage, a `test:unit` matrix on Node
+18/20/22/24, an `e2e` matrix on the same four versions, and a single-version `e2e-kv2` job; both
+e2e jobs run against the Vault servers started by `docker compose up -d --wait`).
 
 ## Tests
 
@@ -40,21 +42,26 @@ credentials in unit tests. The integration and `test/e2e` suites talk to the dev
 
 ## DCO sign-off
 
-This project requires a [Developer Certificate of Origin](https://developercertificate.org/)
-sign-off on every commit. Add the following trailer to each commit message (use `git commit -s`
-or add it manually):
+This project uses the [Developer Certificate of Origin](https://developercertificate.org/). Add
+the following trailer to each commit message (use `git commit -s` or add it manually):
 
 ```
 Signed-off-by: Your Name <your-email@example.com>
 ```
 
-Pull requests with commits missing the sign-off will fail the DCO check in CI.
+Sign-off is enforced by the DCO GitHub App, configured in [`.github/dco.yml`](.github/dco.yml),
+which posts its own status check on the pull request — it is not a job in
+`.github/workflows/pipeline.yaml`. That config sets `require.members: false`, which exempts
+commits authored by members of the `namecheap` organization, so in practice the check blocks
+unsigned commits from outside contributors.
 
 ## Pull requests
 
 1. Fork the repo and create a topic branch off `master`.
 2. Make your change with tests, and keep `npm run lint` and the test suite green.
-3. Record user-facing changes under the `# Unreleased` heading in [`CHANGELOG.md`](CHANGELOG.md).
+3. Record user-facing changes under the `# Unreleased` heading at the top of
+   [`CHANGELOG.md`](CHANGELOG.md); the file currently starts at the latest release, so add the
+   `# Unreleased` heading above it if it is not there yet.
 4. Sign off your commits (see above) and open the PR against `master`.
 5. A code owner (see [`.github/CODEOWNERS`](.github/CODEOWNERS)) will review your PR before merge.
 
@@ -63,12 +70,19 @@ Pull requests with commits missing the sign-off will fail the DCO check in CI.
 Publishing is automated by `.github/workflows/publish.yml`, which runs
 `npm publish --provenance --access public` whenever a GitHub Release is published:
 
+First move the `# Unreleased` notes in `CHANGELOG.md` into a heading that begins with the new
+version number — `# <version> Release notes (YYYY-MM-DD)` — and leave that edit uncommitted:
+
 ```shell
-npm version [major | minor | patch]   # bumps package.json and tags the commit
+npm version [major | minor | patch]   # bumps package.json, stages the CHANGELOG edit (the
+                                      # `version` script runs `git add -A .`) and tags the commit
 # review the version-bump commit, then:
 git push && git push --tags
 ```
 
 Then create a [GitHub Release](https://github.com/namecheap/node-vault-client/releases/new) for
-the new tag (move the `# Unreleased` notes from `CHANGELOG.md` into a dated section). Publishing
-the release triggers the workflow that pushes the package to npm.
+the new tag. Publishing the release triggers the workflow that pushes the package to npm. That
+workflow checks out the tagged commit and greps `CHANGELOG.md` for a heading matching
+`^# <version>( |$)`; if the notes were not moved before tagging, or the heading does not start
+with the bare version number, the publish fails with "No release-notes heading for version
+<version>".

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ const vaultClient = VaultClient.boot('main', {
         * [.deleteMetadata(path)](#VaultClient+deleteMetadata) ⇒ <code>Promise.&lt;Object&gt;</code>
         * [.close()](#VaultClient+close)
     * _static_
-        * [.boot(name, [options])](#VaultClient.boot) ⇒ <code>VaultClient</code>
+        * [.boot(name, options)](#VaultClient.boot) ⇒ <code>VaultClient</code>
         * [.get(name)](#VaultClient.get) ⇒ <code>VaultClient</code>
         * [.clear([name])](#VaultClient.clear)
 * [Lease](#Lease)
@@ -179,7 +179,7 @@ Client constructor function.
 | [options.auth.mount] | <code>String</code> |  | Vault auth backend mount point; default varies per method (e.g. "aws" for iam, "approle", "token", "kubernetes") |
 | options.auth.config | <code>Object</code> |  | auth configuration variables |
 | [options.auth.config.namespace] | <code>String</code> |  | Optional. Legacy location for the Vault namespace (see `api.namespace`). Sent as the `X-Vault-Namespace` header on **every** request for every auth type. |
-| [options.logger] | <code>Object</code> \| <code>false</code> |  | Logger that supports "error", "info", "warn", "trace", "debug" methods. Uses `console` by default. Pass `false` to disable logging. |
+| [options.logger] | <code>Object</code> \| <code>false</code> |  | Logger that must implement **all five** of "error", "warn", "info", "debug" and "trace" — an object missing any one of them is silently ignored and the default logger is used instead. The default logger writes to `console`, except `debug`, which is discarded so that sensitive data is never printed. Pass `false` to disable logging entirely. |
 
 ##### Custom transport (proxy / self-signed TLS)
 
@@ -219,7 +219,7 @@ MITM protection.
 #### vaultClient.fillNodeConfig() ⇒ <code>Promise</code>
 Populates Vault's values to NPM "config" module
 
-Resolves once the npm `config` module has been populated from Vault.
+Resolves once the npm `config` module has been populated from Vault. Note that setup failures are thrown **synchronously**, not returned as a rejected promise: a missing `config` peer dependency and an unreadable `<NODE_CONFIG_DIR>/custom-vault-variables.js` both throw `VaultError` before the promise is created, so use `await` or wrap the call in `try`/`catch` rather than relying on `.catch()` alone.
 
 **Kind**: instance method of [<code>VaultClient</code>](#VaultClient)  
 <a name="VaultClient+read"></a>
@@ -358,7 +358,7 @@ The destroyed version data cannot be recovered. KV v2 only — rejects with
 #### vaultClient.readMetadata(path) ⇒ <code>Promise.&lt;Object&gt;</code>
 Reads KV v2 metadata for a secret
 
-Resolves to the metadata document (`current_version`, the `versions` map, timestamps, etc.).
+Resolves to the raw parsed Vault response body; the metadata document (`current_version`, the `versions` map, timestamps, etc.) is under its `data` property, e.g. `(await client.readMetadata('secret/foo')).data.current_version`.
 KV v2 only — rejects with `UnsupportedOperationError` on non-v2 mounts.
 
 **Kind**: instance method of [<code>VaultClient</code>](#VaultClient)  
@@ -415,7 +415,7 @@ accessors to extract the secret data:
 
 <a name="VaultClient.boot"></a>
 
-#### VaultClient.boot(name, [options]) ⇒ <code>VaultClient</code>
+#### VaultClient.boot(name, options) ⇒ <code>VaultClient</code>
 Boot an instance of Vault
 
 The instance will be stored in a local hash. Calling Vault.boot multiple
@@ -427,7 +427,7 @@ times with the same name will return the same instance.
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>String</code> | Vault instance name |
-| [options] | <code>Object</code> | options for [Vault#constructor](#new_VaultClient_new). |
+| options | <code>Object</code> | options for [Vault#constructor](#new_VaultClient_new). Required on every call, including for a name that was already booted — use [VaultClient.get(name)](#VaultClient.get) to fetch an existing instance. |
 
 <a name="VaultClient.get"></a>
 
@@ -507,7 +507,7 @@ const client = VaultClient.boot('main', {
 
 ### KV v2-specific methods
 
-These methods require a KV v2 mount and throw `UnsupportedOperationError` on v1 / non-KV mounts.
+These methods require a KV v2 mount and throw `UnsupportedOperationError` on v1 / non-KV mounts. They also require the mount to be *resolved* as v2: with neither `api.kv.autoDetect: true` nor an `api.engines` entry covering the mount, every path resolves as v1 passthrough with no detection call, and these methods fail with `UnsupportedOperationError` (`Mount "secret" is not a KV v2 engine.`) even against a genuine KV v2 mount.
 
 ```javascript
 // Soft-delete specific versions
@@ -519,7 +519,8 @@ await client.undeleteVersions('secret/foo', [1]);
 // Permanently destroy versions
 await client.destroyVersions('secret/foo', [1, 2]);
 
-// Read version metadata (current_version, versions map, etc.)
+// Read version metadata. The full Vault envelope is returned, so the metadata
+// fields live under `.data` (meta.data.current_version, meta.data.versions, ...)
 const meta = await client.readMetadata('secret/foo');
 
 // Delete all metadata and version history (permanent)
@@ -591,7 +592,7 @@ await client.request('GET', 'secret/data/foo');
 
 ### Mount detection caching
 
-- Each canonical mount is detected at most once per `VaultClient` instance.
+- Each canonical mount is detected once and then cached for the life of the `VaultClient` instance. The cache is a bounded LRU with a fixed cap of 500 mounts (not configurable through client options); a long-lived client that touches more than 500 distinct mounts evicts the least-recently-used entries, and an evicted mount is detected again on its next use.
 - Concurrent first-touch requests for the same mount share a single in-flight detection promise.
 - The detection endpoint used is `GET sys/internal/ui/mounts/<path>` (readable by any authenticated token).
 - When the token lacks permission on that endpoint, set `api.engines` to skip detection.


### PR DESCRIPTION
Documentation-only. Twelve places where `README.md` / `CONTRIBUTING.md` disagree with the code, each verified against the source (and several confirmed by running the code) rather than reasoned about.

Found while writing the new [wiki](https://github.com/namecheap/node-vault-client/wiki) — two of these would have led me to publish wrong examples.

## README

| # | Claim | Reality |
| --- | --- | --- |
| 1 | `boot(name, [options])` — options optional | `boot()` throws `InvalidArgumentsError: Options should be provided` whenever `options` is `undefined`, **including for an already-booted name** (the check runs before the cache lookup). Fixed in all 3 places; `get(name)` is the lookup call. |
| 2 | `readMetadata()` resolves to the metadata document | It resolves to the **full response envelope** — the document is under `.data`. A reader writes `meta.current_version` (undefined) instead of `meta.data.current_version`. The repo's own tests assert `.data`. Two places. |
| 3 | Logger "supports … methods. Uses `console` by default" | `debug` is deliberately a **no-op** so secrets are never printed, and a logger missing **any** of the five methods is silently discarded for the default — so a partial custom logger looks ignored for no reason. |
| 4 | `fillNodeConfig() ⇒ Promise` | Its two commonest failures throw **synchronously**: missing `config` peer dep, and missing/unreadable `custom-vault-variables.js`. `fillNodeConfig().catch(h)` — the shape the signature invites — crashes instead of reaching `h`. |
| 5 | "Each canonical mount is detected at most once per instance" | The cache is a **500-entry LRU**, hard-coded and *not* settable from client options; past 500 distinct mounts, evicted entries are re-detected. |
| 6 | v2-only helpers "throw on v1 / non-KV mounts" | Omits that **resolution**, not the server, decides this: with neither `kv.autoDetect` nor an `engines` entry, every path resolves as v1, so these methods fail with `Mount "secret" is not a KV v2 engine.` **against a genuine KV v2 mount**. The message misdirects — it reads like a Vault problem. |

## CONTRIBUTING

| # | Claim | Reality |
| --- | --- | --- |
| 7 | `docker compose up -d` starts "a local dev Vault on 8200" | It starts **two**: `vault-server` (KV v1) on 8200 and `vault-server-kv2` on 8202, which `test:e2e:kv2` needs. |
| 8 | CI list: "audit, lint, coverage, test matrix" | Omits both **e2e jobs** — `e2e` on Node 18/20/22/24 and `e2e-kv2` on 20. |
| 9 | "requires DCO sign-off on every commit … will fail the DCO check in CI" | Enforced by the **DCO GitHub App** (`.github/dco.yml`), not a pipeline job, and `require.members: false` **exempts org members** — so in practice it gates outside contributors. |
| 10 | "Record changes under the `# Unreleased` heading" | No such heading exists in `CHANGELOG.md`. Now says to add it. |
| 11 | Release recipe: tag, then move the notes when creating the Release | `publish.yml` greps `CHANGELOG.md` for `^# <version>` and **fails the publish** if it is not already committed — so the changelog edit must come *before* the version bump. |
| 12 | (with 7) e2e prerequisites | Clarified that both e2e jobs run against the compose Vaults. |

## Verification

- Every replacement was checked against the cited source line; findings 1, 3 and 4 were additionally confirmed by executing the code (`boot('m')` → `InvalidArgumentsError`; `__log.debug !== console.debug`; `.catch()` never fires on the sync throw).
- I re-checked the three CONTRIBUTING infrastructure claims myself: `.github/dco.yml` really is `require: members: false`; `docker-compose.yml` really exposes 8200 and 8202; `pipeline.yaml` really has `e2e` (matrix 18/20/22/24) and `e2e-kv2` (Node 20).
- `npm run lint` clean, `npm run test:unit` 308 passing. No file outside the two docs is touched, so the published package is unchanged.

The audit also confirmed large parts are accurate and left them alone — notably the whole Install/Requirements/auth-backends section, where the example was executed verbatim and every documented config key is one the code actually reads.
