### PR TITLE
ci: run the e2e suites against Vault 1.x and 2.x

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -112,15 +112,28 @@ jobs:
   # instance started via docker-compose.
   e2e:
     runs-on: ubuntu-latest
+    name: e2e (node ${{ matrix.node-version }}, vault ${{ matrix.vault-version }})
     strategy:
       fail-fast: false
       matrix:
         node-version: [18, 20, 22, 24]
+        # Latest 1.x. Keep in step with the default in docker-compose.yml so a
+        # local `docker compose up` reproduces what CI runs.
+        vault-version: ['1.21.4']
+        include:
+          # Latest 2.x, on one Node version rather than crossed with the whole
+          # matrix: the node-version axis exercises the client's runtime and the
+          # vault-version axis the server's API, and the two have never
+          # interacted. Node 20 is the version in .nvmrc.
+          - node-version: 20
+            vault-version: '2.0.4'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Start Vault (docker compose)
+      - name: Start Vault ${{ matrix.vault-version }} (docker compose)
+        env:
+          VAULT_IMAGE: hashicorp/vault:${{ matrix.vault-version }}
         run: docker compose up -d --wait
 
       - name: Use Node.js ${{ matrix.node-version }}
@@ -142,10 +155,21 @@ jobs:
   # matrix above already covers runtime compatibility.
   e2e-kv2:
     runs-on: ubuntu-latest
+    name: e2e-kv2 (vault ${{ matrix.vault-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both supported Vault lines. The KV v2 surface — data/metadata paths,
+        # merge-patch, version and metadata operations — is where a server-side
+        # API change would show first, so this suite gets the full Vault axis
+        # even though it stays on one Node version.
+        vault-version: ['1.21.4', '2.0.4']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Start Vault (docker compose)
+      - name: Start Vault ${{ matrix.vault-version }} (docker compose)
+        env:
+          VAULT_IMAGE: hashicorp/vault:${{ matrix.vault-version }}
         run: docker compose up -d --wait
 
       - name: Use Node.js 20

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -117,16 +117,18 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18, 20, 22, 24]
-        # Latest 1.x. Keep in step with the default in docker-compose.yml so a
-        # local `docker compose up` reproduces what CI runs.
-        vault-version: ['1.21.4']
+        # Latest 1.x. Minor-line tags, not patch pins: `1.21` follows the newest
+        # 1.21.x, so patch releases are covered without touching this file. Keep
+        # in step with the default in docker-compose.yml so a local
+        # `docker compose up` reproduces what CI runs.
+        vault-version: ['1.21']
         include:
           # Latest 2.x, on one Node version rather than crossed with the whole
           # matrix: the node-version axis exercises the client's runtime and the
           # vault-version axis the server's API, and the two have never
           # interacted. Node 20 is the version in .nvmrc.
           - node-version: 20
-            vault-version: '2.0.4'
+            vault-version: '2.0'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -163,7 +165,7 @@ jobs:
         # merge-patch, version and metadata operations — is where a server-side
         # API change would show first, so this suite gets the full Vault axis
         # even though it stays on one Node version.
-        vault-version: ['1.21.4', '2.0.4']
+        vault-version: ['1.21', '2.0']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,13 @@
+# Vault version is overridable so CI can run the e2e suites against more than one
+# server line, and so you can reproduce a CI failure locally:
+#
+#   docker compose up -d --wait                                   # default, latest 1.x
+#   VAULT_IMAGE=hashicorp/vault:2.0.4 docker compose up -d --wait # latest 2.x
+#
+# Note the image moved from the deprecated Docker Hub `vault` repository (which
+# stopped receiving updates after 1.13.x) to `hashicorp/vault`. Bump the default
+# below and the matrix in .github/workflows/pipeline.yaml together.
+
 services:
   # Both services are ephemeral dev-mode servers for the e2e suites.
   #
@@ -9,23 +19,52 @@ services:
   # KV v1 server, used by test/e2e/e2e.test.mjs (npm run test:e2e).
   # Note: -dev-kv-v1 implicitly enables dev mode.
   vault-server:
-    image: vault:1.13.3
+    image: ${VAULT_IMAGE:-hashicorp/vault:1.21.4}
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: 8274d2a1-c80c-ff56-c6ed-1b99f7bcea78
+      # for the `vault status` health check below, not the server itself
+      VAULT_ADDR: http://127.0.0.1:8200
     command: [ "server", "-dev-kv-v1" ]
     cap_add:
       - IPC_LOCK
     ports:
       - 127.0.0.1:8200:8200
+    # `docker compose up -d --wait` only waits for "running" unless a health
+    # check exists, and neither this compose file nor the image defined one, so
+    # the e2e jobs raced the server's startup. It was masked in CI because
+    # `npm ci` runs afterwards and takes long enough for Vault to come up;
+    # locally, tests started immediately and failed with "SocketError: other
+    # side closed". `vault status` exits 0 only once the server answers and is
+    # unsealed, which is exactly the readiness this suite needs.
+    healthcheck:
+      test: ["CMD", "vault", "status"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 2s
 
   # KV v2 server (dev mode mounts secret/ as KV v2 by default), used by
   # test/e2e/e2e.kv2.test.mjs (npm run test:e2e:kv2).
   vault-server-kv2:
-    image: vault:1.13.3
+    image: ${VAULT_IMAGE:-hashicorp/vault:1.21.4}
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: 34c9c953-4ff5-368a-ac5c-a1e1a8e13a52
+      VAULT_ADDR: http://127.0.0.1:8200
     command: [ "server", "-dev" ]
     cap_add:
       - IPC_LOCK
     ports:
       - 127.0.0.1:8202:8200
+    # `docker compose up -d --wait` only waits for "running" unless a health
+    # check exists, and neither this compose file nor the image defined one, so
+    # the e2e jobs raced the server's startup. It was masked in CI because
+    # `npm ci` runs afterwards and takes long enough for Vault to come up;
+    # locally, tests started immediately and failed with "SocketError: other
+    # side closed". `vault status` exits 0 only once the server answers and is
+    # unsealed, which is exactly the readiness this suite needs.
+    healthcheck:
+      test: ["CMD", "vault", "status"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 2s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,18 @@
 # Vault version is overridable so CI can run the e2e suites against more than one
 # server line, and so you can reproduce a CI failure locally:
 #
-#   docker compose up -d --wait                                   # default, latest 1.x
-#   VAULT_IMAGE=hashicorp/vault:2.0.4 docker compose up -d --wait # latest 2.x
+#   docker compose up -d --wait                                 # default, latest 1.x
+#   VAULT_IMAGE=hashicorp/vault:2.0 docker compose up -d --wait  # latest 2.x
 #
-# Note the image moved from the deprecated Docker Hub `vault` repository (which
-# stopped receiving updates after 1.13.x) to `hashicorp/vault`. Bump the default
-# below and the matrix in .github/workflows/pipeline.yaml together.
+# The tag is the minor line (`1.21`), not a patch (`1.21.4`), on purpose: the
+# minor tag follows the newest patch in that line, so security and bug-fix
+# releases are picked up with no change here. That is what stops this pin
+# rotting the way the previous `vault:1.13.3` one did. Only a new *minor* line
+# (1.22, 2.1) needs a human, and it needs one in two places -- this default and
+# the matrix in .github/workflows/pipeline.yaml.
+#
+# Note the image also moved from the deprecated Docker Hub `vault` repository,
+# which stopped receiving updates after 1.13.x, to `hashicorp/vault`.
 
 services:
   # Both services are ephemeral dev-mode servers for the e2e suites.
@@ -19,7 +25,7 @@ services:
   # KV v1 server, used by test/e2e/e2e.test.mjs (npm run test:e2e).
   # Note: -dev-kv-v1 implicitly enables dev mode.
   vault-server:
-    image: ${VAULT_IMAGE:-hashicorp/vault:1.21.4}
+    image: ${VAULT_IMAGE:-hashicorp/vault:1.21}
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: 8274d2a1-c80c-ff56-c6ed-1b99f7bcea78
       # for the `vault status` health check below, not the server itself
@@ -46,7 +52,7 @@ services:
   # KV v2 server (dev mode mounts secret/ as KV v2 by default), used by
   # test/e2e/e2e.kv2.test.mjs (npm run test:e2e:kv2).
   vault-server-kv2:
-    image: ${VAULT_IMAGE:-hashicorp/vault:1.21.4}
+    image: ${VAULT_IMAGE:-hashicorp/vault:1.21}
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: 34c9c953-4ff5-368a-ac5c-a1e1a8e13a52
       VAULT_ADDR: http://127.0.0.1:8200


### PR DESCRIPTION
Adds Vault-version coverage to the e2e suites, which previously ran against exactly one server.

## The state before

`docker-compose.yml` pinned **`vault:1.13.3`** — a 2023 build from the **deprecated** Docker Hub `vault` repository, which stopped receiving updates after the 1.13.x line. So nothing in CI exercised the client against a current Vault, and nothing exercised Vault 2.x at all.

## What this does

- Moves both compose services to the maintained **`hashicorp/vault`** images.
- Makes the image an input (`VAULT_IMAGE`), defaulting to the latest 1.x, so a local `docker compose up` reproduces CI.
- Runs the suites against both supported lines, using **minor-line tags** (`1.21`, `2.0`) rather than patch pins — see [Keeping it current](#keeping-it-current).

| job | Node | Vault | jobs |
| --- | --- | --- | --- |
| `e2e` | 18, 20, 22, 24 | `1.21` | 4 |
| `e2e` (added) | 20 | **`2.0`** | 1 |
| `e2e-kv2` | 20 | `1.21` **and `2.0`** | 2 |

The KV v2 suite gets the full Vault axis because a server-side API change would surface first in the data/metadata paths, merge-patch and version operations. The KV v1 suite keeps its four-way Node matrix on 1.x plus a single 2.x job: the Node axis exercises the client's runtime, the Vault axis the server's API, and crossing them fully would double the job count for a pairing that has never differed. Net cost: **+2 jobs**.

## Also fixes a latent race

While testing the matrix I hit `TypeError: fetch failed … SocketError: other side closed` — intermittently, right after startup.

Cause: **neither this compose file nor the `hashicorp/vault` image defines a health check** (`docker inspect … .Config.Healthcheck` → `null`), so `docker compose up -d --wait` returns as soon as the containers are *running*, not when Vault is serving. Today's CI gets away with it only because `npm ci && npm install config` runs after the compose step and takes long enough for Vault to finish coming up. That is luck, not sequencing, and the new matrix runs these jobs more often.

Both services now health-check on `vault status`, which exits 0 only once the server answers **and** is unsealed, so `--wait` blocks until the suites can actually connect.

## Verification

Run locally against every image, both suites each time:

| Vault image | `test:e2e` | `test:e2e:kv2` |
| --- | --- | --- |
| `hashicorp/vault:1.21` — **the baseline** (currently 1.21.4) | 6 passing | 10 passing |
| `hashicorp/vault:2.0` (currently 2.0.4) | 6 passing | 10 passing |
| `vault:1.13.3` — the old pin, checked once so the move is known not to be a regression | 6 passing | 10 passing |

For the health-check fix specifically, the suites were started **immediately** after `docker compose up -d --wait` with no grace period — failing before the change, passing after it on both versions. `npm run lint` clean and `npm run test:unit` 308 passing throughout.

I also read Vault 2.0.0's `BREAKING CHANGES` before trusting a green run: they cover the SDK's docker helpers and packages removed from the UBI images, nothing touching the KV or auth APIs this client uses. One 2.x security change is worth knowing about even though it does not affect us — *"core: reject URL-encoded paths that do not specify a canonical path"* — since this client sends literal paths through `request()`.

## Keeping it current

The baseline is the **latest 1.x** and stays there without maintenance: the tags are the *minor line* (`1.21`, `2.0`), not patch pins, so they follow the newest patch in their line. Both resolve to the same digests as `1.21.4`/`2.0.4` today, and a future 1.21.5 is picked up with no change to this repo. That is what stops this pin rotting the way `vault:1.13.3` did. Only a new **minor** line (1.22, 2.1) needs a human, in the two places the comments name.

**Dependabot cannot do this job**, contrary to what I suggested when I opened this PR — I checked the implementation rather than the docs. Its `docker` ecosystem fetches `*.yml`/`*.yaml`, but then keeps a file only if it is a Helm chart or `likely_kubernetes_resource?`, which requires **both** `apiVersion` and `kind`:

```ruby
# docker/lib/dependabot/shared/shared_file_fetcher.rb
def likely_kubernetes_resource?(resource)
  resource.is_a?(::Hash) && resource.key?("apiVersion") && resource.key?("kind")
end
```

A `docker-compose.yml` has neither key, so it is never parsed. A `dependabot.yml` with the `docker` ecosystem would have been a silent no-op here and given false confidence — so I did not add one. If you want the *minor* bumps automated too, the workable route is a small scheduled workflow that queries the Vault release API and opens a PR; say the word and I will add it.
