### PR TITLE
feat(auth): JWT/OIDC auth backend for workload identity federation (TDD)

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -150,8 +150,7 @@ jobs:
       - name: Run e2e tests
         run: npm run test:e2e
 
-      # TDD (#130/#134): red until the JWT backend lands. Runs across the whole
-      # node x vault matrix like the rest of this job.
+      # Runs across the whole node x vault matrix like the rest of this job.
       - name: Run JWT e2e tests
         run: npm run test:e2e:jwt
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -150,6 +150,11 @@ jobs:
       - name: Run e2e tests
         run: npm run test:e2e
 
+      # TDD (#130/#134): red until the JWT backend lands. Runs across the whole
+      # node x vault matrix like the rest of this job.
+      - name: Run JWT e2e tests
+        run: npm run test:e2e:jwt
+
   # KV v2 integration suite — exercises mount auto-detection, data/metadata path
   # rewriting, merge-patch update, version ops and metadata ops against a real
   # KV v2 Vault (the vault-server-kv2 compose service). A single Node version is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
   `config.jwtPath` file source (exactly one is required); `config.role` is optional, matching
   Vault's `default_role` fallback. Models `VaultKubernetesAuth`; a `config.jwtProvider` async
   source is reserved for a follow-up. Closes #131.
+- `VaultJwtAuth` now also accepts `config.jwtProvider`, a (optionally async) function returning
+  the JWT, as its third mutually-exclusive source. It is invoked at login time, never at
+  construction and never cached, so every login — including re-logins after expiry — gets a
+  fresh token; this is what GitHub Actions' `core.getIDToken()`, cloud metadata endpoints and
+  SPIFFE workloads need. A provider resolving a non-string or empty string, or a non-function
+  `jwtProvider`, fails fast with `InvalidArgumentsError` without sending a login request. Closes
+  #132.
 
 # 2.1.2 Release notes (2026-08-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- Added a JWT auth backend (`auth.type: 'jwt'`), supporting a literal `config.jwt` or a
+  `config.jwtPath` file source (exactly one is required); `config.role` is optional, matching
+  Vault's `default_role` fallback. Models `VaultKubernetesAuth`; a `config.jwtProvider` async
+  source is reserved for a follow-up. Closes #131.
+
 # 2.1.2 Release notes (2026-08-03)
 
 - Internal refactor: `VaultBaseAuth` no longer overloads a single `__authToken` field with two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@
   endpoint. A `jwtProvider` resolving a non-string/empty string, or a non-function
   `jwtProvider`, fails fast with `InvalidArgumentsError` without sending a login request. Only
   the non-interactive `jwt` flow is implemented; the browser-redirect `oidc` flow is out of
-  scope for this service client. See the README's "JWT auth" section. Closes #130, #131 and
-  #132.
+  scope for this service client. See the README's "JWT auth" section.
 
 # 2.1.2 Release notes (2026-08-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Unreleased
 
-- Added a JWT auth backend (`auth.type: 'jwt'`), supporting a literal `config.jwt` or a
-  `config.jwtPath` file source (exactly one is required); `config.role` is optional, matching
-  Vault's `default_role` fallback. Models `VaultKubernetesAuth`; a `config.jwtProvider` async
-  source is reserved for a follow-up. Closes #131.
-- `VaultJwtAuth` now also accepts `config.jwtProvider`, a (optionally async) function returning
-  the JWT, as its third mutually-exclusive source. It is invoked at login time, never at
-  construction and never cached, so every login — including re-logins after expiry — gets a
-  fresh token; this is what GitHub Actions' `core.getIDToken()`, cloud metadata endpoints and
-  SPIFFE workloads need. A provider resolving a non-string or empty string, or a non-function
-  `jwtProvider`, fails fast with `InvalidArgumentsError` without sending a login request. Closes
+- Added a JWT auth backend (`auth.type: 'jwt'`, default mount `"jwt"`) for workload identity
+  federation — GitHub Actions, other CI systems, GCP/Azure/SPIFFE workloads — against Vault's
+  [JWT auth method](https://developer.hashicorp.com/vault/docs/auth/jwt). Models
+  `VaultKubernetesAuth`. `config.role` is optional, matching Vault's `default_role` fallback.
+  Exactly one of three mutually-exclusive sources supplies the JWT: a literal `config.jwt`
+  string (CI jobs / processes shorter-lived than the token — a re-login resends that same
+  string, so it fails once the IdP-issued token itself expires); `config.jwtPath`, a file
+  re-read on every login (rotated projected tokens); or `config.jwtProvider`, an (optionally
+  async) function invoked fresh at login time — never at construction, never cached — for
+  tokens minted per login such as GitHub Actions' `core.getIDToken()` or a cloud metadata
+  endpoint. A `jwtProvider` resolving a non-string/empty string, or a non-function
+  `jwtProvider`, fails fast with `InvalidArgumentsError` without sending a login request. Only
+  the non-interactive `jwt` flow is implemented; the browser-redirect `oidc` flow is out of
+  scope for this service client. See the README's "JWT auth" section. Closes #130, #131 and
   #132.
 
 # 2.1.2 Release notes (2026-08-03)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const VaultClient = require('node-vault-client');
 const vaultClient = VaultClient.boot('main', {
     api: { url: 'https://vault.example.com:8200/' },
     auth: { 
-        type: 'appRole', // one of: 'appRole' | 'token' | 'iam' | 'kubernetes'
+        type: 'appRole', // one of: 'appRole' | 'token' | 'iam' | 'kubernetes' | 'jwt'
         config: { role_id: '637c065f-c644-5e12-d3d1-e9fa4363af61' } 
     },
 });
@@ -42,6 +42,7 @@ vaultClient.read('secret/tst').then(lease => {
 * [AppRole](https://developer.hashicorp.com/vault/docs/auth/approle)
 * [Token](https://developer.hashicorp.com/vault/docs/auth/token)
 * [Kubernetes](https://developer.hashicorp.com/vault/docs/auth/kubernetes)
+* [JWT](https://developer.hashicorp.com/vault/docs/auth/jwt)
 
 ### AWS IAM auth
 
@@ -125,6 +126,67 @@ const vaultClient = VaultClient.boot('main', {
 });
 ```
 
+### JWT auth
+
+```javascript
+const vaultClient = VaultClient.boot('main', {
+    api: { url: 'https://vault.example.com:8200/' },
+    auth: {
+        type: 'jwt',
+        mount: 'jwt',                                  // Optional. Vault JWT auth mount point ("jwt" by default)
+        config: {
+            role: 'my-app',                             // Optional. Role configured in Vault's JWT auth backend; omitted uses the mount's `default_role`
+            jwt: process.env.CI_JOB_JWT,                // Exactly one of `jwt` / `jwtPath` / `jwtProvider` is required (see below)
+        },
+    },
+});
+```
+
+Exactly one of three mutually exclusive `config` keys supplies the JWT:
+
+* **`jwt`** — a literal token string. Use it for CI jobs and other processes that are guaranteed
+  to finish before the token expires. Caveat: the value is fixed at construction, so if the
+  client re-authenticates (its Vault-issued token TTL runs out while the process is still up) it
+  re-sends that exact same JWT — which works only until the IdP-issued token itself expires,
+  after which Vault rejects every further login attempt. Do not use `jwt` in a long-running
+  process.
+* **`jwtPath`** — path to a file containing the JWT, re-read on every login (mirrors
+  [Kubernetes auth](#kubernetes-auth)'s `tokenPath`). Use it for rotated *projected* tokens, such
+  as a Kubernetes projected service-account token the kubelet refreshes on disk, so each login
+  picks up whatever is currently on disk instead of a token captured once at startup.
+* **`jwtProvider`** — an (optionally async) function, called fresh at login time (never at
+  construction, never cached), returning `string | Promise<string>`. Use it when the JWT has to
+  be minted per login — GitHub Actions' `core.getIDToken()`, a cloud metadata endpoint, a
+  SPIFFE/SPIRE workload API.
+
+#### Authenticating from GitHub Actions
+
+```yaml
+permissions:
+  id-token: write
+```
+
+```javascript
+const core = require('@actions/core');
+const VaultClient = require('node-vault-client');
+
+const vaultClient = VaultClient.boot('ci', {
+    api: { url: process.env.VAULT_ADDR },
+    auth: {
+        type: 'jwt',
+        mount: 'gha',                                  // matches wherever the JWT method was mounted, e.g. `vault auth enable -path=gha jwt`
+        config: { role: 'ci', jwtProvider: () => core.getIDToken('vault') },
+    },
+});
+```
+
+`role` is optional here too — omit it to use the mount's `default_role`. `mount` and
+`api.namespace` behave exactly as they do for the other four backends.
+
+Vault's JWT method also offers an interactive `oidc` login (a browser redirect for a human user).
+This library implements only the non-interactive `jwt` flow: a service client doing headless
+background renewal has no browser to redirect to, so `oidc` is deliberately not supported.
+
 ## API
 
 <a name="VaultClient"></a>
@@ -175,8 +237,8 @@ Client constructor function.
 | [options.api.kv.autoDetect] | <code>boolean</code> | `false` | auto-detect the KV version of each mount on first use (see [KV v2 & generic backends](#kv-v2--generic-backends)) |
 | [options.api.engines] | <code>Object</code> | `{}` | static mount-to-version map, e.g. `{ secret: 2, legacy: 1 }` (see [KV v2 & generic backends](#kv-v2--generic-backends)) |
 | options.auth | <code>Object</code> |  |  |
-| options.auth.type | <code>String</code> |  |  |
-| [options.auth.mount] | <code>String</code> |  | Vault auth backend mount point; default varies per method (e.g. "aws" for iam, "approle", "token", "kubernetes") |
+| options.auth.type | <code>String</code> |  | one of: 'appRole' \| 'token' \| 'iam' \| 'kubernetes' \| 'jwt' |
+| [options.auth.mount] | <code>String</code> |  | Vault auth backend mount point; default varies per method (e.g. "aws" for iam, "approle", "token", "kubernetes", "jwt") |
 | options.auth.config | <code>Object</code> |  | auth configuration variables |
 | [options.auth.config.namespace] | <code>String</code> |  | Optional. Legacy location for the Vault namespace (see `api.namespace`). Sent as the `X-Vault-Namespace` header on **every** request for every auth type. |
 | [options.logger] | <code>Object</code> \| <code>false</code> |  | Logger that must implement **all five** of "error", "warn", "info", "debug" and "trace" — an object missing any one of them is silently ignored and the default logger is used instead. The default logger writes to `console`, except `debug`, which is discarded so that sensitive data is never printed. Pass `false` to disable logging entirely. |

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:unit": "mocha \"test/*.test.mjs\"",
     "test:e2e": "mocha --exit \"test/e2e/e2e.test.mjs\"",
     "test:e2e:kv2": "mocha --exit \"test/e2e/e2e.kv2.test.mjs\"",
+    "test:e2e:jwt": "mocha --exit \"test/e2e/e2e.jwt.test.mjs\"",
     "coverage": "c8 npm run test:unit",
     "lint": "eslint src/ test/",
     "version": "git add -A ."

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -8,6 +8,7 @@ const VaultTokenAuth = require('./auth/VaultTokenAuth');
 const VaultIAMAuth = require('./auth/VaultIAMAuth');
 const VaultNodeConfig = require('./VaultNodeConfig');
 const VaultKubernetesAuth = require('./auth/VaultKubernetesAuth');
+const VaultJwtAuth = require('./auth/VaultJwtAuth');
 const MountResolver = require('./MountResolver');
 const { rewritePath, normalizeResponse } = require('./kvTransform');
 
@@ -33,7 +34,7 @@ class VaultClient {
      *      every request across all auth backends. For backward compatibility `options.auth.config.namespace`
      *      is also honored when this is not set.
      * @param {Object} options.auth
-     * @param {String} options.auth.type
+     * @param {String} options.auth.type - one of: 'appRole' | 'token' | 'iam' | 'kubernetes' | 'jwt'
      * @param {Object} options.auth.config - auth configuration variables
      * @param {Object|false} options.logger - Logger that supports "error", "info", "warn", "trace", "debug" methods. Uses `console` by default. Pass `false` to disable logging.
      */
@@ -203,6 +204,13 @@ class VaultClient {
                 );
             case 'kubernetes':
                 return new VaultKubernetesAuth(
+                    api,
+                    this.__log,
+                    authConfig.config,
+                    authConfig.mount
+                );
+            case 'jwt':
+                return new VaultJwtAuth(
                     api,
                     this.__log,
                     authConfig.config,

--- a/src/auth/VaultJwtAuth.js
+++ b/src/auth/VaultJwtAuth.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const fs = require('fs');
+const VaultBaseAuth = require('./VaultBaseAuth');
+const errors = require('../errors');
+
+const JWT_SOURCE_KEYS = ['jwt', 'jwtPath', 'jwtProvider'];
+
+class VaultJwtAuth extends VaultBaseAuth {
+    /**
+     * @param {VaultApiClient} apiClient - see {@link VaultBaseAuth#constructor}
+     * @param {Object} logger
+     * @param {Object} config
+     * @param {String} [config.role] - Role configured in Vault's JWT auth backend. Optional;
+     *   when omitted, Vault falls back to the mount's configured `default_role`.
+     * @param {String} [config.jwt] - A literal JWT to present at login. Exactly one of
+     *   `jwt` / `jwtPath` / `jwtProvider` must be provided.
+     * @param {String} [config.jwtPath] - Path to a file containing the JWT. Re-read on every
+     *   login (like {@link VaultKubernetesAuth}'s `tokenPath`), so a rotated token is picked up.
+     * @param {Function} [config.jwtProvider] - (optionally async) function resolving to the JWT.
+     *   Accepted here as a mutually exclusive source (#132); not yet consumed by `_authenticate`.
+     * @param {String} [config.namespace] - Optional. Vault namespace. Applied as the X-Vault-Namespace
+     *   header to every request by {@link VaultApiClient}; see {@link VaultClient#constructor}.
+     * @param {String} mount - Vault's mount point ("jwt" by default)
+     */
+    constructor(apiClient, logger, config, mount) {
+        super(apiClient, logger, mount || 'jwt');
+
+        const providedSources = JWT_SOURCE_KEYS.filter((key) => config && config[key] !== undefined);
+        if (providedSources.length !== 1) {
+            throw new errors.InvalidArgumentsError(
+                'Exactly one of "jwt", "jwtPath" or "jwtProvider" should be provided for VaultJwtAuth'
+            );
+        }
+        if (config.jwtProvider !== undefined && typeof config.jwtProvider !== 'function') {
+            throw new errors.InvalidArgumentsError('"jwtProvider" should be a function for VaultJwtAuth');
+        }
+
+        this.__role = config.role;
+        this.__jwt = config.jwt;
+        this.__jwtPath = config.jwtPath;
+        this.__jwtProvider = config.jwtProvider;
+    }
+
+    _authenticate() {
+        let jwt;
+        let source;
+        if (this.__jwt !== undefined) {
+            jwt = this.__jwt;
+            source = 'literal';
+        } else {
+            jwt = fs.readFileSync(this.__jwtPath).toString();
+            source = 'file';
+        }
+
+        this._log.info(
+            'making authentication request: Vault role: "%s"; JWT source: %s (%d bytes)',
+            this.__role !== undefined ? this.__role : '(default_role)', source, jwt.length
+        );
+
+        const body = { jwt };
+        if (this.__role !== undefined) {
+            body.role = this.__role;
+        }
+
+        return this.__apiClient.makeRequest('POST', `/auth/${this._mount}/login`, body)
+            .then((res) => {
+                this._log.debug('received Vault client token from JWT login');
+
+                return this._getTokenEntity(res.auth.client_token);
+            });
+    }
+}
+
+module.exports = VaultJwtAuth;

--- a/src/auth/VaultJwtAuth.js
+++ b/src/auth/VaultJwtAuth.js
@@ -17,8 +17,10 @@ class VaultJwtAuth extends VaultBaseAuth {
      *   `jwt` / `jwtPath` / `jwtProvider` must be provided.
      * @param {String} [config.jwtPath] - Path to a file containing the JWT. Re-read on every
      *   login (like {@link VaultKubernetesAuth}'s `tokenPath`), so a rotated token is picked up.
-     * @param {Function} [config.jwtProvider] - (optionally async) function resolving to the JWT.
-     *   Accepted here as a mutually exclusive source (#132); not yet consumed by `_authenticate`.
+     * @param {Function} [config.jwtProvider] - (optionally async) function invoked at login time,
+     *   returning `string | Promise<string>`. Called fresh on every login (never at construction
+     *   or cached across logins) so it can mint a short-lived token -- the shape GitHub Actions'
+     *   `core.getIDToken()`, cloud metadata endpoints and SPIFFE workloads need.
      * @param {String} [config.namespace] - Optional. Vault namespace. Applied as the X-Vault-Namespace
      *   header to every request by {@link VaultApiClient}; see {@link VaultClient#constructor}.
      * @param {String} mount - Vault's mount point ("jwt" by default)
@@ -43,32 +45,50 @@ class VaultJwtAuth extends VaultBaseAuth {
     }
 
     _authenticate() {
-        let jwt;
-        let source;
-        if (this.__jwt !== undefined) {
-            jwt = this.__jwt;
-            source = 'literal';
-        } else {
-            jwt = fs.readFileSync(this.__jwtPath).toString();
-            source = 'file';
-        }
+        return Promise.resolve()
+            .then(() => this.__acquireJwt())
+            .then(({ jwt, source }) => {
+                this._log.info(
+                    'making authentication request: Vault role: "%s"; JWT source: %s (%d bytes)',
+                    this.__role !== undefined ? this.__role : '(default_role)', source, jwt.length
+                );
 
-        this._log.info(
-            'making authentication request: Vault role: "%s"; JWT source: %s (%d bytes)',
-            this.__role !== undefined ? this.__role : '(default_role)', source, jwt.length
-        );
+                const body = { jwt };
+                if (this.__role !== undefined) {
+                    body.role = this.__role;
+                }
 
-        const body = { jwt };
-        if (this.__role !== undefined) {
-            body.role = this.__role;
-        }
+                return this.__apiClient.makeRequest('POST', `/auth/${this._mount}/login`, body)
+                    .then((res) => {
+                        this._log.debug('received Vault client token from JWT login');
 
-        return this.__apiClient.makeRequest('POST', `/auth/${this._mount}/login`, body)
-            .then((res) => {
-                this._log.debug('received Vault client token from JWT login');
-
-                return this._getTokenEntity(res.auth.client_token);
+                        return this._getTokenEntity(res.auth.client_token);
+                    });
             });
+    }
+
+    /**
+     * @returns {{jwt: String, source: String}|Promise<{jwt: String, source: String}>}
+     * @private
+     */
+    __acquireJwt() {
+        if (this.__jwt !== undefined) {
+            return { jwt: this.__jwt, source: 'literal' };
+        }
+        if (this.__jwtPath !== undefined) {
+            return { jwt: fs.readFileSync(this.__jwtPath).toString(), source: 'file' };
+        }
+
+        // Wrapping in Promise.resolve().then() normalizes both a sync provider (plain return)
+        // and a synchronous throw into the same rejection path as an async one.
+        return Promise.resolve().then(() => this.__jwtProvider()).then((jwt) => {
+            if (typeof jwt !== 'string' || jwt.length === 0) {
+                throw new errors.InvalidArgumentsError(
+                    '"jwtProvider" must resolve to a non-empty JWT string'
+                );
+            }
+            return { jwt, source: 'provider' };
+        });
     }
 }
 

--- a/test/auth.jwt.test.mjs
+++ b/test/auth.jwt.test.mjs
@@ -1,0 +1,272 @@
+/**
+ * TDD specification for the JWT auth backend (#130, tasks #131 and #132).
+ *
+ * Written BEFORE the implementation: this file is the executable contract for
+ * src/auth/VaultJwtAuth.js. Until that module exists, the whole file fails
+ * with ERR_MODULE_NOT_FOUND -- that is the red phase, not a broken test.
+ * Implement per issue #131 (literal jwt + jwtPath) and #132 (jwtProvider)
+ * until every test here is green without editing this file.
+ */
+
+import { createRequire } from 'module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import sinon from 'sinon';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import VaultApiClient from '../src/VaultApiClient.js';
+import VaultClient from '../src/VaultClient.js';
+import errors from '../src/errors.js';
+import { createNoopLogger, createSpyLogger, loggedText } from './helpers/logger.mjs';
+
+use(sinonChai);
+
+const logger = createNoopLogger();
+
+// Distinctive values so the log-hygiene assertions cannot pass by accident.
+const THE_JWT = 'eyJhbGciOiJSUzI1NiJ9.TDD-SECRET-JWT-VALUE.sig';
+const THE_CLIENT_TOKEN = 'hvs.THE-VAULT-CLIENT-TOKEN-NOBODY-MAY-LOG';
+
+/**
+ * Canned Vault responses. `tokenTtl`/`tokenCreation` control whether the token
+ * the backend obtains is already expired (forcing a re-login on the next
+ * getAuthToken), mirroring the fixture style of test/namespace.test.mjs.
+ */
+function stubFetch({ tokenTtl = 0, tokenCreation = 1600000000 } = {}) {
+    return sinon.stub(global, 'fetch').callsFake((url) => {
+        const pathname = new URL(url).pathname;
+        let body = {};
+        if (pathname.endsWith('/auth/token/lookup-self')) {
+            body = { data: {
+                id: THE_CLIENT_TOKEN, accessor: 'acc',
+                creation_time: tokenCreation, ttl: tokenTtl, renewable: false,
+            } };
+        } else if (pathname.endsWith('/login')) {
+            body = { auth: { client_token: THE_CLIENT_TOKEN, accessor: 'acc' } };
+        }
+        return Promise.resolve(new Response(JSON.stringify(body), {
+            status: 200, headers: { 'Content-Type': 'application/json' },
+        }));
+    });
+}
+
+function loginCalls(fetchStub) {
+    return fetchStub.getCalls()
+        .filter((c) => new URL(c.args[0]).pathname.match(/\/auth\/.+\/login$/))
+        .map((c) => ({
+            path: new URL(c.args[0]).pathname,
+            body: JSON.parse(c.args[1].body),
+        }));
+}
+
+// TDD: loaded lazily so that, until src/auth/VaultJwtAuth.js exists, THIS
+// suite fails (every test, via the failing hook below, with a clear
+// module-not-found message) while the rest of `npm run test:unit` still runs
+// and reports. A static ESM import would abort the whole mocha run instead.
+// Once the module lands this may become a static import.
+const _require = createRequire(import.meta.url);
+let VaultJwtAuth;
+
+describe('VaultJwtAuth (TDD spec for #130)', function () {
+    let fetchStub;
+
+    before(function () {
+        VaultJwtAuth = _require('../src/auth/VaultJwtAuth.js');
+    });
+
+    beforeEach(function () {
+        fetchStub = stubFetch();
+    });
+
+    afterEach(function () {
+        fetchStub.restore();
+        VaultClient.clear();
+    });
+
+    function api() {
+        return new VaultApiClient({ url: 'https://vault.example' }, logger);
+    }
+
+    describe('constructor validation [#131/#132]', function () {
+        it('requires exactly one JWT source: none given throws', function () {
+            expect(() => new VaultJwtAuth(api(), logger, { role: 'r' }))
+                .to.throw(errors.InvalidArgumentsError);
+        });
+
+        it('requires exactly one JWT source: two given throws', function () {
+            expect(() => new VaultJwtAuth(api(), logger, { jwt: THE_JWT, jwtPath: '/tmp/x' }))
+                .to.throw(errors.InvalidArgumentsError);
+            expect(() => new VaultJwtAuth(api(), logger, { jwt: THE_JWT, jwtProvider: () => THE_JWT }))
+                .to.throw(errors.InvalidArgumentsError);
+        });
+
+        it('rejects a non-function jwtProvider', function () {
+            expect(() => new VaultJwtAuth(api(), logger, { jwtProvider: 'not-a-fn' }))
+                .to.throw(errors.InvalidArgumentsError);
+        });
+
+        it('accepts a config with no role (Vault default_role path)', function () {
+            expect(() => new VaultJwtAuth(api(), logger, { jwt: THE_JWT })).to.not.throw();
+        });
+    });
+
+    describe('literal jwt source [#131]', function () {
+        it('POSTs { role, jwt } to /auth/jwt/login and yields the client token', async function () {
+            const auth = new VaultJwtAuth(api(), logger, { role: 'my-app', jwt: THE_JWT });
+            const token = await auth.getAuthToken();
+            expect(token.getId()).to.equal(THE_CLIENT_TOKEN);
+            const logins = loginCalls(fetchStub);
+            expect(logins).to.have.length(1);
+            expect(logins[0].path).to.equal('/v1/auth/jwt/login');
+            expect(logins[0].body).to.deep.equal({ role: 'my-app', jwt: THE_JWT });
+        });
+
+        it('omits the role key entirely when role is not configured', async function () {
+            const auth = new VaultJwtAuth(api(), logger, { jwt: THE_JWT });
+            await auth.getAuthToken();
+            expect(loginCalls(fetchStub)[0].body).to.deep.equal({ jwt: THE_JWT });
+        });
+
+        it('logs in against a custom mount', async function () {
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwt: THE_JWT }, 'gha');
+            await auth.getAuthToken();
+            expect(loginCalls(fetchStub)[0].path).to.equal('/v1/auth/gha/login');
+        });
+
+        it('single-flight: concurrent getAuthToken() callers share one login', async function () {
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwt: THE_JWT });
+            const [a, b] = await Promise.all([auth.getAuthToken(), auth.getAuthToken()]);
+            expect(a).to.equal(b);
+            expect(loginCalls(fetchStub)).to.have.length(1);
+        });
+
+        it('re-authenticates when the obtained token has expired', async function () {
+            fetchStub.restore();
+            fetchStub = stubFetch({ tokenTtl: 1, tokenCreation: 1600000000 }); // expired in 2020
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwt: THE_JWT });
+            await auth.getAuthToken();
+            await auth.getAuthToken();
+            expect(loginCalls(fetchStub)).to.have.length(2);
+        });
+    });
+
+    describe('jwtPath source [#131]', function () {
+        let jwtFile;
+
+        beforeEach(function () {
+            jwtFile = path.join(os.tmpdir(), `nvc-jwt-tdd-${process.pid}.jwt`);
+            fs.writeFileSync(jwtFile, THE_JWT);
+        });
+
+        afterEach(function () {
+            try { fs.unlinkSync(jwtFile); } catch { /* ignore */ }
+        });
+
+        it('reads the JWT from the file at login time', async function () {
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwtPath: jwtFile });
+            await auth.getAuthToken();
+            expect(loginCalls(fetchStub)[0].body.jwt).to.equal(THE_JWT);
+        });
+
+        it('re-reads the file on every login, so a rotated token is picked up', async function () {
+            fetchStub.restore();
+            fetchStub = stubFetch({ tokenTtl: 1, tokenCreation: 1600000000 });
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwtPath: jwtFile });
+            await auth.getAuthToken();
+            fs.writeFileSync(jwtFile, 'eyJ.ROTATED-JWT.sig');
+            await auth.getAuthToken();
+            const logins = loginCalls(fetchStub);
+            expect(logins).to.have.length(2);
+            expect(logins[0].body.jwt).to.equal(THE_JWT);
+            expect(logins[1].body.jwt).to.equal('eyJ.ROTATED-JWT.sig');
+        });
+    });
+
+    describe('jwtProvider source [#132]', function () {
+        it('is not called at construction, once per login afterwards', async function () {
+            const provider = sinon.stub().resolves(THE_JWT);
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwtProvider: provider });
+            expect(provider).to.not.have.been.called;
+            await auth.getAuthToken();
+            expect(provider).to.have.been.calledOnce;
+            expect(loginCalls(fetchStub)[0].body.jwt).to.equal(THE_JWT);
+        });
+
+        it('is called again for a re-login, and the fresh token is sent', async function () {
+            fetchStub.restore();
+            fetchStub = stubFetch({ tokenTtl: 1, tokenCreation: 1600000000 });
+            const provider = sinon.stub();
+            provider.onFirstCall().resolves('jwt-first');
+            provider.onSecondCall().resolves('jwt-second');
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwtProvider: provider });
+            await auth.getAuthToken();
+            await auth.getAuthToken();
+            expect(provider).to.have.been.calledTwice;
+            expect(loginCalls(fetchStub).map((l) => l.body.jwt)).to.deep.equal(['jwt-first', 'jwt-second']);
+        });
+
+        it('accepts a synchronous provider', async function () {
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwtProvider: () => THE_JWT });
+            await auth.getAuthToken();
+            expect(loginCalls(fetchStub)[0].body.jwt).to.equal(THE_JWT);
+        });
+
+        it('a rejecting provider fails the login without wedging single-flight', async function () {
+            const boom = new Error('IdP unavailable');
+            const provider = sinon.stub();
+            provider.onFirstCall().rejects(boom);
+            provider.onSecondCall().resolves(THE_JWT);
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwtProvider: provider });
+            let thrown;
+            try { await auth.getAuthToken(); } catch (err) { thrown = err; }
+            expect(thrown).to.equal(boom);
+            // The failed attempt must not leave a pending login behind:
+            const token = await auth.getAuthToken();
+            expect(token.getId()).to.equal(THE_CLIENT_TOKEN);
+        });
+
+        it('rejects with InvalidArgumentsError when the provider resolves a non-string', async function () {
+            const auth = new VaultJwtAuth(api(), logger, { role: 'r', jwtProvider: () => 42 });
+            let thrown;
+            try { await auth.getAuthToken(); } catch (err) { thrown = err; }
+            expect(thrown).to.be.instanceOf(errors.InvalidArgumentsError);
+            expect(loginCalls(fetchStub)).to.have.length(0); // no garbage login sent
+        });
+    });
+
+    describe('log hygiene (#104 rule) [#131]', function () {
+        it('never passes the JWT or the client token to any log level', async function () {
+            const log = createSpyLogger();
+            const auth = new VaultJwtAuth(new VaultApiClient({ url: 'https://vault.example' }, log), log, { role: 'r', jwt: THE_JWT });
+            await auth.getAuthToken();
+            const text = loggedText(log);
+            expect(text, 'raw JWT must never reach the logger').to.not.contain(THE_JWT);
+            expect(text, 'client token must never reach the logger').to.not.contain(THE_CLIENT_TOKEN);
+        });
+    });
+
+    describe('VaultClient dispatch [#131]', function () {
+        it("boots a client with auth.type 'jwt'", async function () {
+            const client = new VaultClient({
+                api: { url: 'https://vault.example/' },
+                logger: false,
+                auth: { type: 'jwt', config: { role: 'r', jwt: THE_JWT } },
+            });
+            const lease = await client.read('secret/anything');
+            expect(lease.getData()).to.deep.equal({});
+            expect(loginCalls(fetchStub)[0].path).to.equal('/v1/auth/jwt/login');
+        });
+
+        it('honours the legacy auth.config.namespace location [#133]', async function () {
+            const client = new VaultClient({
+                api: { url: 'https://vault.example/' },
+                logger: false,
+                auth: { type: 'jwt', config: { role: 'r', jwt: THE_JWT, namespace: 'team-a' } },
+            });
+            await client.read('secret/anything');
+            const login = fetchStub.getCalls().find((c) => new URL(c.args[0]).pathname.endsWith('/login'));
+            expect(login.args[1].headers['X-Vault-Namespace']).to.equal('team-a');
+        });
+    });
+});

--- a/test/auth.jwt.test.mjs
+++ b/test/auth.jwt.test.mjs
@@ -8,7 +8,6 @@
  * until every test here is green without editing this file.
  */
 
-import { createRequire } from 'module';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -17,6 +16,7 @@ import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
 import VaultClient from '../src/VaultClient.js';
+import VaultJwtAuth from '../src/auth/VaultJwtAuth.js';
 import errors from '../src/errors.js';
 import { createNoopLogger, createSpyLogger, loggedText } from './helpers/logger.mjs';
 
@@ -60,20 +60,8 @@ function loginCalls(fetchStub) {
         }));
 }
 
-// TDD: loaded lazily so that, until src/auth/VaultJwtAuth.js exists, THIS
-// suite fails (every test, via the failing hook below, with a clear
-// module-not-found message) while the rest of `npm run test:unit` still runs
-// and reports. A static ESM import would abort the whole mocha run instead.
-// Once the module lands this may become a static import.
-const _require = createRequire(import.meta.url);
-let VaultJwtAuth;
-
 describe('VaultJwtAuth (TDD spec for #130)', function () {
     let fetchStub;
-
-    before(function () {
-        VaultJwtAuth = _require('../src/auth/VaultJwtAuth.js');
-    });
 
     beforeEach(function () {
         fetchStub = stubFetch();

--- a/test/e2e/e2e.jwt.test.mjs
+++ b/test/e2e/e2e.jwt.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * E2E for the JWT auth backend (#130/#134) against the real dev-mode Vault
+ * started by docker-compose (127.0.0.1:8200). TDD: red until #131 lands.
+ *
+ * Setup follows the AppRole precedent in e2e.test.mjs: policy -> enable the
+ * method -> configure -> role, all via the root token, and idempotent so the
+ * suite can rerun against a running stack. Teardown disables the method again
+ * so this suite leaves the shared dev server as it found it.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { expect } from 'chai';
+import VaultClient from '../../src/VaultClient.js';
+import errors from '../../src/errors.js';
+import { publicKeyPem, signJwt } from './sign-jwt.mjs';
+
+const VAULT = 'http://127.0.0.1:8200/';
+const ROOT = '8274d2a1-c80c-ff56-c6ed-1b99f7bcea78'; // see docker-compose.yml
+const AUD = 'nvc-e2e';
+
+async function rp(opts) {
+    const response = await fetch(opts.uri, {
+        method: opts.method || 'GET',
+        headers: Object.assign(
+            { Accept: 'application/json', 'X-Vault-Token': ROOT },
+            opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}
+        ),
+        body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    });
+    const text = await response.text();
+    if (!response.ok && !(opts.tolerate || []).some((t) => text.includes(t))) {
+        throw new Error(`${response.status} - ${text}`);
+    }
+    return text ? JSON.parse(text) : undefined;
+}
+
+function claims(overrides) {
+    const now = Math.floor(Date.now() / 1000);
+    return Object.assign({ aud: AUD, sub: 'e2e-user', iat: now, exp: now + 300 }, overrides);
+}
+
+describe('E2E: JWT auth backend', function () {
+    before(async function () {
+        await rp({ method: 'PUT', uri: `${VAULT}v1/sys/policy/jwt-tst`, body: {
+            rules: 'path "secret/jwt-tst" {capabilities = ["read"]}',
+        } });
+        await rp({ method: 'POST', uri: `${VAULT}v1/sys/auth/jwt`, body: { type: 'jwt' },
+            tolerate: ['path is already in use'] });
+        await rp({ method: 'POST', uri: `${VAULT}v1/auth/jwt/config`, body: {
+            jwt_validation_pubkeys: [publicKeyPem],
+        } });
+        await rp({ method: 'POST', uri: `${VAULT}v1/auth/jwt/role/tst`, body: {
+            role_type: 'jwt', bound_audiences: [AUD], user_claim: 'sub', token_policies: 'jwt-tst',
+        } });
+        await rp({ method: 'POST', uri: `${VAULT}v1/secret/jwt-tst`, body: { hello: 'from-jwt' } });
+    });
+
+    after(async function () {
+        await rp({ method: 'DELETE', uri: `${VAULT}v1/sys/auth/jwt`, tolerate: ['no matching mount'] });
+        await rp({ method: 'DELETE', uri: `${VAULT}v1/sys/policy/jwt-tst`, tolerate: ['404'] });
+    });
+
+    afterEach(function () {
+        VaultClient.clear();
+    });
+
+    function boot(config) {
+        return new VaultClient({
+            api: { url: VAULT },
+            logger: false,
+            auth: { type: 'jwt', config },
+        });
+    }
+
+    it('authenticates with a literal signed JWT and reads a secret', async function () {
+        const client = boot({ role: 'tst', jwt: signJwt(claims()) });
+        const lease = await client.read('secret/jwt-tst');
+        expect(lease.getValue('hello')).to.equal('from-jwt');
+    });
+
+    it('authenticates with a JWT read from a file (jwtPath)', async function () {
+        const jwtFile = path.join(os.tmpdir(), `nvc-e2e-${process.pid}.jwt`);
+        fs.writeFileSync(jwtFile, signJwt(claims()));
+        try {
+            const client = boot({ role: 'tst', jwtPath: jwtFile });
+            const lease = await client.read('secret/jwt-tst');
+            expect(lease.getValue('hello')).to.equal('from-jwt');
+        } finally {
+            fs.unlinkSync(jwtFile);
+        }
+    });
+
+    it('rejects a JWT with the wrong audience as VaultHttpError 400', async function () {
+        const client = boot({ role: 'tst', jwt: signJwt(claims({ aud: 'someone-else' })) });
+        let thrown;
+        try { await client.read('secret/jwt-tst'); } catch (err) { thrown = err; }
+        expect(thrown).to.be.instanceOf(errors.VaultHttpError);
+        expect(thrown.statusCode).to.equal(400);
+    });
+
+    it('rejects an expired JWT as VaultHttpError 400', async function () {
+        const now = Math.floor(Date.now() / 1000);
+        const client = boot({ role: 'tst', jwt: signJwt(claims({ iat: now - 600, exp: now - 300 })) });
+        let thrown;
+        try { await client.read('secret/jwt-tst'); } catch (err) { thrown = err; }
+        expect(thrown).to.be.instanceOf(errors.VaultHttpError);
+        expect(thrown.statusCode).to.equal(400);
+    });
+});

--- a/test/e2e/e2e.jwt.test.mjs
+++ b/test/e2e/e2e.jwt.test.mjs
@@ -1,11 +1,11 @@
 /**
- * E2E for the JWT auth backend (#130/#134) against the real dev-mode Vault
- * started by docker-compose (127.0.0.1:8200). TDD: red until #131 lands.
+ * E2E for the JWT auth backend against the real dev-mode Vault started by
+ * docker-compose (127.0.0.1:8200).
  *
- * Setup follows the AppRole precedent in e2e.test.mjs: policy -> enable the
- * method -> configure -> role, all via the root token, and idempotent so the
- * suite can rerun against a running stack. Teardown disables the method again
- * so this suite leaves the shared dev server as it found it.
+ * Setup is idempotent (tolerates "already in use") so the suite can rerun
+ * against a stack it (or a previous run) already touched. Teardown removes
+ * everything it created -- mount, policy and fixture secret -- so this suite
+ * leaves the shared dev server as it found it.
  */
 import fs from 'fs';
 import os from 'os';
@@ -58,19 +58,25 @@ describe('E2E: JWT auth backend', function () {
 
     after(async function () {
         await rp({ method: 'DELETE', uri: `${VAULT}v1/sys/auth/jwt`, tolerate: ['no matching mount'] });
-        await rp({ method: 'DELETE', uri: `${VAULT}v1/sys/policy/jwt-tst`, tolerate: ['404'] });
+        await rp({ method: 'DELETE', uri: `${VAULT}v1/sys/policy/jwt-tst` });
+        await rp({ method: 'DELETE', uri: `${VAULT}v1/secret/jwt-tst` });
     });
 
+    let client;
     afterEach(function () {
-        VaultClient.clear();
+        if (client) {
+            client.close();
+            client = undefined;
+        }
     });
 
     function boot(config) {
-        return new VaultClient({
+        client = new VaultClient({
             api: { url: VAULT },
             logger: false,
             auth: { type: 'jwt', config },
         });
+        return client;
     }
 
     it('authenticates with a literal signed JWT and reads a secret', async function () {

--- a/test/e2e/sign-jwt.mjs
+++ b/test/e2e/sign-jwt.mjs
@@ -1,0 +1,18 @@
+/**
+ * Minimal RS256 JWT signer for the e2e suite (#130/#134). node:crypto only --
+ * deliberately no jsonwebtoken dependency; the suite must stay offline.
+ */
+import crypto from 'node:crypto';
+
+export const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+
+/** The PEM the Vault jwt method is configured with (jwt_validation_pubkeys). */
+export const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' });
+
+/** Sign an RS256 JWT over the given claims with the suite's throwaway key. */
+export function signJwt(claims) {
+    const b64 = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+    const signingInput = `${b64({ alg: 'RS256', typ: 'JWT' })}.${b64(claims)}`;
+    const signature = crypto.sign('sha256', Buffer.from(signingInput), privateKey).toString('base64url');
+    return `${signingInput}.${signature}`;
+}

--- a/test/e2e/sign-jwt.mjs
+++ b/test/e2e/sign-jwt.mjs
@@ -1,6 +1,6 @@
 /**
- * Minimal RS256 JWT signer for the e2e suite (#130/#134). node:crypto only --
- * deliberately no jsonwebtoken dependency; the suite must stay offline.
+ * Minimal RS256 JWT signer for the e2e suite. node:crypto only -- deliberately
+ * no jsonwebtoken dependency; the suite must stay offline.
  */
 import crypto from 'node:crypto';
 

--- a/test/helpers.test.mjs
+++ b/test/helpers.test.mjs
@@ -1,0 +1,150 @@
+/**
+ * Tests for the shared test doubles in test/helpers/.
+ *
+ * These helpers ship to nobody, but seven suites now depend on them and two of
+ * their failure modes would be silent rather than red:
+ *
+ *  - `createNoopLogger()` must satisfy the interface `VaultClient#__setupLogger`
+ *    checks. If it lost a method, VaultClient would quietly swap in its console
+ *    fallback and every suite injecting this logger would start exercising a
+ *    different object than it thinks — while still passing.
+ *  - `loggedText()` is what auth.iam and auth.appRole use to assert that a raw
+ *    client_token *never* reaches the logger. A version that returned nothing
+ *    would make those security assertions pass vacuously, which is the exact
+ *    failure a "must not contain" assertion cannot detect on its own.
+ *
+ * Both are pinned below, against the real VaultClient rather than a restatement
+ * of its rules.
+ */
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import VaultClient from '../src/VaultClient.js';
+import { LOG_METHODS, createNoopLogger, createSpyLogger, loggedText } from './helpers/logger.mjs';
+
+use(sinonChai);
+
+function bootOpts() {
+    return {
+        api: { url: 'https://example.com/' },
+        logger: false,
+        auth: { type: 'token', config: { token: 'tok-123' } },
+    };
+}
+
+describe('test helpers: logger doubles', function () {
+    afterEach(function () {
+        VaultClient.clear();
+    });
+
+    describe('LOG_METHODS', function () {
+        it('is exactly the interface VaultClient#__setupLogger requires', function () {
+            // Mirrors the list in src/VaultClient.js. Kept as an explicit literal:
+            // if VaultClient's requirement changes, this fails rather than silently
+            // agreeing with whatever the helper happens to export.
+            expect(LOG_METHODS).to.deep.equal(['error', 'warn', 'info', 'debug', 'trace']);
+        });
+    });
+
+    describe('createNoopLogger()', function () {
+        it('implements every log method as a function returning undefined', function () {
+            const logger = createNoopLogger();
+            expect(Object.keys(logger).sort()).to.deep.equal([...LOG_METHODS].sort());
+            for (const method of LOG_METHODS) {
+                expect(logger[method], `${method} must be callable`).to.be.a('function');
+                expect(logger[method]('anything', { a: 1 }), `${method} must be a no-op`).to.be.undefined;
+            }
+        });
+
+        it('is accepted verbatim by VaultClient, not replaced by the console fallback', function () {
+            // The load-bearing one: __setupLogger returns the logger it was given
+            // only when it implements the full interface, and a console fallback
+            // otherwise. Identity here proves the suites that inject this logger
+            // are really exercising it.
+            const client = new VaultClient(bootOpts());
+            const logger = createNoopLogger();
+            expect(client.__setupLogger(logger)).to.equal(logger);
+        });
+
+        it('returns an independent object per call', function () {
+            // Suites share the module, not the instance: one suite stubbing a
+            // method must not leak into another.
+            const a = createNoopLogger();
+            const b = createNoopLogger();
+            expect(a).to.not.equal(b);
+            a.info = () => 'replaced';
+            expect(b.info()).to.be.undefined;
+        });
+    });
+
+    describe('createSpyLogger()', function () {
+        it('exposes a recording spy for every log method', function () {
+            const log = createSpyLogger();
+            expect(Object.keys(log).sort()).to.deep.equal([...LOG_METHODS].sort());
+            for (const method of LOG_METHODS) {
+                // Asserted behaviourally rather than by type: what the suites need
+                // is that each method records, which is what is checked here.
+                log[method](`called-${method}`);
+                expect(log[method], `${method} must record its calls`)
+                    .to.have.been.calledOnceWithExactly(`called-${method}`);
+            }
+        });
+
+        it('records the arguments it was called with', function () {
+            const log = createSpyLogger();
+            log.warn('careful %s', 'now');
+            expect(log.warn).to.have.been.calledOnceWithExactly('careful %s', 'now');
+            expect(log.error).to.not.have.been.called;
+        });
+
+        it('is also accepted by VaultClient as a complete logger', function () {
+            const client = new VaultClient(bootOpts());
+            const log = createSpyLogger();
+            expect(client.__setupLogger(log)).to.equal(log);
+        });
+    });
+
+    describe('loggedText()', function () {
+        it('captures printf-style string arguments', function () {
+            const log = createSpyLogger();
+            log.info('token issued for %s', 'role-a');
+            expect(loggedText(log)).to.contain('token issued for');
+            expect(loggedText(log)).to.contain('role-a');
+        });
+
+        it('serialises object arguments, so %j / %o payloads are searchable', function () {
+            // This is what makes the "secret must not be logged" assertions
+            // meaningful: a token leaked inside an object payload has to be
+            // findable, not swallowed by String(object) -> "[object Object]".
+            const log = createSpyLogger();
+            log.debug('auth response %j', { auth: { client_token: 's3cr3t-token' } });
+            expect(loggedText(log)).to.contain('s3cr3t-token');
+        });
+
+        it('spans every log level, not just the first', function () {
+            const log = createSpyLogger();
+            for (const method of LOG_METHODS) {
+                log[method](`marker-${method}`);
+            }
+            const text = loggedText(log);
+            for (const method of LOG_METHODS) {
+                expect(text, `${method} output must be included`).to.contain(`marker-${method}`);
+            }
+        });
+
+        it('flattens multiple calls and multiple arguments into one string', function () {
+            const log = createSpyLogger();
+            log.info('first', 1);
+            log.info('second', { deep: { value: 'nested-value' } });
+            const text = loggedText(log);
+            expect(text).to.contain('first');
+            expect(text).to.contain('second');
+            expect(text).to.contain('nested-value');
+        });
+
+        it('returns an empty string when nothing was logged', function () {
+            // Pins the boundary the vacuity guard rests on: empty means "nothing
+            // was logged", never "the helper failed to read the spies".
+            expect(loggedText(createSpyLogger())).to.equal('');
+        });
+    });
+});

--- a/test/helpers/logger.mjs
+++ b/test/helpers/logger.mjs
@@ -1,0 +1,33 @@
+/**
+ * Shared logger doubles for the test suite.
+ *
+ * Seven test files built the same noop logger inline, and two of them also
+ * duplicated the spy variant and the log-flattening helper. Keeping one copy
+ * here means the shape stays consistent with what `VaultClient#__setupLogger`
+ * requires: a logger is only accepted if it implements every method below.
+ */
+import _ from 'lodash';
+import sinon from 'sinon';
+
+/** The methods a logger must implement to be accepted by VaultClient. */
+export const LOG_METHODS = ['error', 'warn', 'info', 'debug', 'trace'];
+
+/** A complete logger whose methods all do nothing. */
+export function createNoopLogger() {
+    return _.fromPairs(_.map(LOG_METHODS, (method) => [method, _.noop]));
+}
+
+/** A complete logger whose methods are sinon spies, for asserting on output. */
+export function createSpyLogger() {
+    return _.fromPairs(_.map(LOG_METHODS, (method) => [method, sinon.spy()]));
+}
+
+/**
+ * Flatten every argument passed to a spy logger into one searchable string,
+ * covering both printf-style args and object logging (%j / %o).
+ */
+export function loggedText(log) {
+    return _.flatMap(LOG_METHODS, (m) => _.flatMap(log[m].getCalls(), (c) => c.args))
+        .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+        .join(' ');
+}

--- a/test/namespace.test.mjs
+++ b/test/namespace.test.mjs
@@ -9,7 +9,6 @@
  * kubernetes did on lookup-self / login) fails here.
  */
 
-import { createRequire } from 'module';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -22,6 +21,7 @@ import VaultTokenAuth from '../src/auth/VaultTokenAuth.js';
 import VaultAppRoleAuth from '../src/auth/VaultAppRoleAuth.js';
 import VaultIAMAuth from '../src/auth/VaultIAMAuth.js';
 import VaultKubernetesAuth from '../src/auth/VaultKubernetesAuth.js';
+import VaultJwtAuth from '../src/auth/VaultJwtAuth.js';
 
 use(sinonChai);
 
@@ -49,11 +49,6 @@ function stubFetch() {
 }
 
 const TYPES = ['token', 'appRole', 'iam', 'kubernetes', 'jwt'];
-
-// TDD (#130/#133): required lazily so that, until src/auth/VaultJwtAuth.js
-// exists, only the jwt rows of this suite fail -- the other backends' coverage
-// stays green. Once the module lands, this may become a static import.
-const _require = createRequire(import.meta.url);
 
 describe('X-Vault-Namespace is applied to every request (regression #106)', function () {
     let fetchStub;
@@ -89,10 +84,8 @@ describe('X-Vault-Namespace is applied to every request (regression #106)', func
                 });
             case 'kubernetes':
                 return new VaultKubernetesAuth(api, logger, { role: 'r', tokenPath: jwtPath });
-            case 'jwt': {
-                const VaultJwtAuth = _require('../src/auth/VaultJwtAuth.js');
+            case 'jwt':
                 return new VaultJwtAuth(api, logger, { role: 'r', jwt: 'header.payload.sig' });
-            }
             default:
                 throw new Error(`unknown type ${type}`);
         }

--- a/test/namespace.test.mjs
+++ b/test/namespace.test.mjs
@@ -9,6 +9,7 @@
  * kubernetes did on lookup-self / login) fails here.
  */
 
+import { createRequire } from 'module';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -47,7 +48,12 @@ function stubFetch() {
     });
 }
 
-const TYPES = ['token', 'appRole', 'iam', 'kubernetes'];
+const TYPES = ['token', 'appRole', 'iam', 'kubernetes', 'jwt'];
+
+// TDD (#130/#133): required lazily so that, until src/auth/VaultJwtAuth.js
+// exists, only the jwt rows of this suite fail -- the other backends' coverage
+// stays green. Once the module lands, this may become a static import.
+const _require = createRequire(import.meta.url);
 
 describe('X-Vault-Namespace is applied to every request (regression #106)', function () {
     let fetchStub;
@@ -83,6 +89,10 @@ describe('X-Vault-Namespace is applied to every request (regression #106)', func
                 });
             case 'kubernetes':
                 return new VaultKubernetesAuth(api, logger, { role: 'r', tokenPath: jwtPath });
+            case 'jwt': {
+                const VaultJwtAuth = _require('../src/auth/VaultJwtAuth.js');
+                return new VaultJwtAuth(api, logger, { role: 'r', jwt: 'header.payload.sig' });
+            }
             default:
                 throw new Error(`unknown type ${type}`);
         }


### PR DESCRIPTION
Implements the JWT/OIDC auth backend for workload identity federation. **TDD: the tests were committed first (red), then the implementation until green** — the spec commit is untouched by the implementation commits.

Closes #130, #131, #132, #133, #134, #135.

## Commits, one per task

| commit | task | what |
| --- | --- | --- |
| `28790ee` | — | The TDD spec: unit, namespace-conformance and e2e suites. Red by design. |
| `698a78b` | #131 | `VaultJwtAuth` with literal `jwt` and `jwtPath` sources + `VaultClient` dispatch |
| `742a823` | #132 | `jwtProvider` async source |
| `df6c707` | #133 | `'jwt'` in the #106 namespace conformance suite; lazy requires → static imports |
| `a0cd536` | #134 | e2e finalisation: fixture teardown, stale TDD comments removed |
| `b859907` | #135 | README + CHANGELOG |

## API

```javascript
auth: {
    type: 'jwt',
    mount: 'jwt',                                    // default
    config: {
        role: 'my-app',                              // optional → Vault's default_role
        jwt: process.env.CI_JOB_JWT,                 // literal, OR
        // jwtPath: '/var/run/secrets/token',        // re-read every login, OR
        // jwtProvider: () => core.getIDToken('vault'), // minted every login
    },
}
```

Exactly one source; anything else fails fast with `InvalidArgumentsError`. Single-flight login, background renewal and namespace handling are inherited from `VaultBaseAuth`/`VaultApiClient` unchanged. Only the non-interactive `jwt` flow — the browser-redirect `oidc` flow is out of scope for a headless client. No new runtime dependency.

## Verification (run by me, not reported by an agent)

| check | result |
| --- | --- |
| `npm run lint` | clean |
| `npm run test:unit` | **341 passing, 0 failing** (was 320/3 at the red commit) |
| `npm run coverage` | gate 97/93/100/97 passes |
| `npm run test:e2e:jwt` | 4/4 on Vault **1.21** and **2.0**; green twice in a row (idempotent) |
| `npm run test:e2e` / `:kv2` | 6/6 and 10/10 — unchanged |
| README snippets | both JWT examples executed against a stub; hit `/v1/auth/jwt/login` and `/v1/auth/gha/login` |
| `package.json` | only the `test:e2e:jwt` script added; **dependencies untouched** |

## One reviewer finding I investigated and rejected

The opus reviewer flagged that `jwtPath` sends file bytes verbatim, so a token file written by `echo "$TOKEN" > /run/jwt` would carry a trailing newline and be rejected by Vault's go-jose parser — a defect invisible to the tests, which write files without a newline. Plausible, well-argued, and **empirically false**: against real Vault, a JWT with a trailing `\n` (and one with a trailing space) logs in with **HTTP 200 on both 1.21 and 2.0**. No `.trim()` added — it would have been defensive code for a bug that does not exist. Evidence is in the PR thread.

The same review pass produced findings that *were* right and are applied: an unguarded `jwtProvider` fall-through in the #131 intermediate state, a self-contradicting CHANGELOG bullet, missing e2e fixture teardown, and stale "red until #131 lands" comments.
