### PR TITLE
docs(examples): runnable JWT/OIDC demo app with positive and negative scenarios

### DIFF
--- a/examples/jwt-auth/README.md
+++ b/examples/jwt-auth/README.md
@@ -1,0 +1,59 @@
+# JWT / OIDC auth demo
+
+A single-file app that exercises the `jwt` auth backend against a **real Vault**, covering the
+positive paths and the ways it is meant to fail. It doubles as a smoke test: it prints what each
+scenario did and exits non-zero if any of them behaves differently than documented.
+
+```bash
+docker compose up -d --wait            # from the repo root
+node examples/jwt-auth/vault-jwt-demo.mjs
+```
+
+Against another Vault:
+
+```bash
+VAULT_ADDR=https://vault.example.com:8200 VAULT_TOKEN=<root-or-admin-token> \
+  node examples/jwt-auth/vault-jwt-demo.mjs
+```
+
+The app configures everything it needs (two `jwt` mounts, roles, a policy, a demo secret), runs the
+scenarios, then removes all of it again. It needs a token allowed to manage `sys/auth`, `sys/policy`
+and the demo secret — a dev-mode root token is the intended use.
+
+## What it covers
+
+**Positive**
+
+| scenario | shows |
+| --- | --- |
+| literal `jwt` | the simplest wiring: a token you already have |
+| `jwtPath` | token read from a file, re-read on every login |
+| `jwtProvider` | token minted per login (the GitHub Actions / metadata-endpoint shape) |
+| `role` omitted | falls back to the mount's `default_role` |
+| custom mount | `vault auth enable -path=gha jwt` |
+| one login, many reads | the client logs in once and reuses the Vault token |
+
+**Negative**
+
+| scenario | expected |
+| --- | --- |
+| wrong audience | `VaultHttpError` 400 |
+| expired JWT | `VaultHttpError` 400 |
+| signature from an untrusted key | `VaultHttpError` 400 |
+| role that does not exist | `VaultHttpError` 400 |
+| valid login, policy denies the path | `VaultHttpError` **403** — authentication succeeded, authorization did not |
+| no JWT source / two sources / non-function `jwtProvider` | `InvalidArgumentsError` at construction |
+| `jwtProvider` resolving a non-string | `InvalidArgumentsError`, no login attempted |
+| `jwtProvider` that rejects | the provider's own error, unwrapped |
+
+The 400-vs-403 distinction is the one worth internalising: **400 means Vault rejected the JWT**
+(audience, expiry, signature, unknown role), **403 means the login worked and the resulting token
+lacks a policy for that path**. They point at completely different fixes.
+
+## Where the JWT comes from
+
+The demo signs its own RS256 tokens with a throwaway key generated at startup, so it needs no
+identity provider and no network beyond Vault itself. In production that key is your IdP: GitHub
+Actions (`core.getIDToken()`), GitLab CI, a cloud metadata endpoint, or SPIFFE/SPIRE. Vault is told
+which signatures to trust via `jwt_validation_pubkeys` (as here) or, more usually,
+`oidc_discovery_url` pointed at the provider.

--- a/examples/jwt-auth/vault-jwt-demo.mjs
+++ b/examples/jwt-auth/vault-jwt-demo.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * Runnable demo + smoke test for the JWT auth backend against a REAL Vault.
+ *
+ * It configures a throwaway `jwt` auth mount, runs positive and negative
+ * scenarios through the client, prints what each one did, cleans up, and exits
+ * non-zero if any scenario behaved differently than documented.
+ *
+ *   VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=<root> node vault-jwt-demo.mjs
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const VaultClient = require('../../src/VaultClient.js');
+const errors = require('../../src/errors.js');
+
+const ADDR = (process.env.VAULT_ADDR || 'http://127.0.0.1:8200').replace(/\/?$/, '/');
+const ROOT = process.env.VAULT_TOKEN || '8274d2a1-c80c-ff56-c6ed-1b99f7bcea78';
+const AUD = 'demo-audience';
+const SECRET_PATH = 'secret/jwt-demo';
+
+// --- a throwaway signing key: this stands in for your identity provider ------
+const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+const otherKey = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey;
+
+function signJwt(claims, key = privateKey) {
+    const b64 = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
+    const input = `${b64({ alg: 'RS256', typ: 'JWT' })}.${b64(claims)}`;
+    return `${input}.${crypto.sign('sha256', Buffer.from(input), key).toString('base64url')}`;
+}
+
+function claims(over = {}) {
+    const now = Math.floor(Date.now() / 1000);
+    return { aud: AUD, sub: 'demo-user', iat: now, exp: now + 300, ...over };
+}
+
+async function vault(method, apiPath, body) {
+    const res = await fetch(ADDR + 'v1/' + apiPath, {
+        method,
+        headers: { 'X-Vault-Token': ROOT, 'Content-Type': 'application/json' },
+        body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    return { status: res.status, body: text ? JSON.parse(text) : undefined };
+}
+
+async function setup() {
+    await vault('PUT', 'sys/policy/jwt-demo', { rules: `path "${SECRET_PATH}" {capabilities = ["read"]}` });
+    for (const mount of ['jwt', 'gha']) {
+        await vault('POST', `sys/auth/${mount}`, { type: 'jwt' });
+        await vault('POST', `auth/${mount}/config`, {
+            jwt_validation_pubkeys: [publicKey.export({ type: 'spki', format: 'pem' })],
+        });
+        await vault('POST', `auth/${mount}/role/demo`, {
+            role_type: 'jwt', bound_audiences: [AUD], user_claim: 'sub', token_policies: 'jwt-demo',
+        });
+        // A default_role lets a client omit `role` entirely.
+        await vault('POST', `auth/${mount}/config`, {
+            jwt_validation_pubkeys: [publicKey.export({ type: 'spki', format: 'pem' })],
+            default_role: 'demo',
+        });
+    }
+    // A role whose policy grants nothing, to show auth success vs authz failure.
+    await vault('POST', 'auth/jwt/role/no-access', {
+        role_type: 'jwt', bound_audiences: [AUD], user_claim: 'sub', token_policies: 'default',
+    });
+    await vault('POST', SECRET_PATH, { message: 'hello from vault' });
+}
+
+async function teardown() {
+    for (const mount of ['jwt', 'gha']) await vault('DELETE', `sys/auth/${mount}`);
+    await vault('DELETE', 'sys/policy/jwt-demo');
+    await vault('DELETE', SECRET_PATH);
+}
+
+let clients = 0;
+function boot(config, mount) {
+    const auth = { type: 'jwt', config };
+    if (mount) auth.mount = mount;
+    return VaultClient.boot(`demo-${clients++}`, { api: { url: ADDR }, logger: false, auth });
+}
+
+/** Read the demo secret; returns its value or throws. */
+const read = async (client) => (await client.read(SECRET_PATH)).getValue('message');
+
+// ---------------------------------------------------------------- scenarios
+const scenarios = [
+    // ---- positive ---------------------------------------------------------
+    {
+        kind: '+', name: 'literal JWT string',
+        expect: 'reads the secret',
+        run: async () => read(boot({ role: 'demo', jwt: signJwt(claims()) })),
+        ok: (r) => r === 'hello from vault',
+    },
+    {
+        kind: '+', name: 'JWT from a file (jwtPath)',
+        expect: 'reads the secret',
+        run: async () => {
+            const file = path.join(os.tmpdir(), `demo-${process.pid}.jwt`);
+            fs.writeFileSync(file, signJwt(claims()));
+            try { return await read(boot({ role: 'demo', jwtPath: file })); }
+            finally { fs.unlinkSync(file); }
+        },
+        ok: (r) => r === 'hello from vault',
+    },
+    {
+        kind: '+', name: 'JWT minted per login (jwtProvider)',
+        expect: 'reads the secret; provider called once',
+        run: async () => {
+            let calls = 0;
+            const client = boot({ role: 'demo', jwtProvider: async () => { calls++; return signJwt(claims()); } });
+            const value = await read(client);
+            return `${value} / provider calls: ${calls}`;
+        },
+        ok: (r) => r === 'hello from vault / provider calls: 1',
+    },
+    {
+        kind: '+', name: 'role omitted -> mount default_role',
+        expect: 'reads the secret',
+        run: async () => read(boot({ jwt: signJwt(claims()) })),
+        ok: (r) => r === 'hello from vault',
+    },
+    {
+        kind: '+', name: 'custom mount ("gha")',
+        expect: 'reads the secret',
+        run: async () => read(boot({ role: 'demo', jwt: signJwt(claims()) }, 'gha')),
+        ok: (r) => r === 'hello from vault',
+    },
+    {
+        kind: '+', name: 'one login serves many reads',
+        expect: 'provider called once for 3 reads',
+        run: async () => {
+            let calls = 0;
+            const client = boot({ role: 'demo', jwtProvider: async () => { calls++; return signJwt(claims()); } });
+            await Promise.all([read(client), read(client), read(client)]);
+            return `provider calls: ${calls}`;
+        },
+        ok: (r) => r === 'provider calls: 1',
+    },
+
+    // ---- negative ---------------------------------------------------------
+    {
+        kind: '-', name: 'wrong audience',
+        expect: 'VaultHttpError 400',
+        run: () => read(boot({ role: 'demo', jwt: signJwt(claims({ aud: 'not-the-audience' })) })),
+        ok: (r) => r instanceof errors.VaultHttpError && r.statusCode === 400,
+    },
+    {
+        kind: '-', name: 'expired JWT',
+        expect: 'VaultHttpError 400',
+        run: () => {
+            const now = Math.floor(Date.now() / 1000);
+            return read(boot({ role: 'demo', jwt: signJwt(claims({ iat: now - 600, exp: now - 300 })) }));
+        },
+        ok: (r) => r instanceof errors.VaultHttpError && r.statusCode === 400,
+    },
+    {
+        kind: '-', name: 'signature from an untrusted key',
+        expect: 'VaultHttpError 400',
+        run: () => read(boot({ role: 'demo', jwt: signJwt(claims(), otherKey) })),
+        ok: (r) => r instanceof errors.VaultHttpError && r.statusCode === 400,
+    },
+    {
+        kind: '-', name: 'role that does not exist',
+        expect: 'VaultHttpError 400',
+        run: () => read(boot({ role: 'nope', jwt: signJwt(claims()) })),
+        ok: (r) => r instanceof errors.VaultHttpError && r.statusCode === 400,
+    },
+    {
+        kind: '-', name: 'valid login, policy denies the path',
+        expect: 'VaultHttpError 403 (authn ok, authz denied)',
+        run: () => read(boot({ role: 'no-access', jwt: signJwt(claims()) })),
+        ok: (r) => r instanceof errors.VaultHttpError && r.statusCode === 403,
+    },
+    {
+        kind: '-', name: 'no JWT source configured',
+        expect: 'InvalidArgumentsError at construction',
+        run: async () => boot({ role: 'demo' }),
+        ok: (r) => r instanceof errors.InvalidArgumentsError,
+    },
+    {
+        kind: '-', name: 'two JWT sources configured',
+        expect: 'InvalidArgumentsError at construction',
+        run: async () => boot({ role: 'demo', jwt: signJwt(claims()), jwtPath: '/tmp/x' }),
+        ok: (r) => r instanceof errors.InvalidArgumentsError,
+    },
+    {
+        kind: '-', name: 'jwtProvider that is not a function',
+        expect: 'InvalidArgumentsError at construction',
+        run: async () => boot({ role: 'demo', jwtProvider: 'nope' }),
+        ok: (r) => r instanceof errors.InvalidArgumentsError,
+    },
+    {
+        kind: '-', name: 'jwtProvider resolving a non-string',
+        expect: 'InvalidArgumentsError, no login attempted',
+        run: () => read(boot({ role: 'demo', jwtProvider: async () => 42 })),
+        ok: (r) => r instanceof errors.InvalidArgumentsError,
+    },
+    {
+        kind: '-', name: 'jwtProvider that rejects',
+        expect: "the provider's own error propagates",
+        run: () => read(boot({ role: 'demo', jwtProvider: async () => { throw new Error('IdP unavailable'); } })),
+        ok: (r) => r instanceof Error && r.message === 'IdP unavailable',
+    },
+];
+
+// ---------------------------------------------------------------- runner
+const pad = (s, n) => String(s).padEnd(n);
+
+async function main() {
+    console.log(`\nVault: ${ADDR}\n`);
+    await setup();
+
+    let failures = 0;
+    for (const s of scenarios) {
+        let outcome;
+        try { outcome = await s.run(); } catch (err) { outcome = err; }
+        const passed = s.ok(outcome);
+        if (!passed) failures++;
+        const actual = outcome instanceof Error ? `${outcome.constructor.name}${outcome.statusCode ? ' ' + outcome.statusCode : ''}` : String(outcome);
+        console.log(`  ${passed ? '✓' : '✗'} ${s.kind} ${pad(s.name, 38)} expected: ${pad(s.expect, 44)} got: ${actual}`);
+    }
+
+    VaultClient.clear();
+    await teardown();
+
+    const positives = scenarios.filter((s) => s.kind === '+').length;
+    console.log(`\n${scenarios.length} scenarios (${positives} positive, ${scenarios.length - positives} negative), ${failures} unexpected\n`);
+    process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch(async (err) => {
+    console.error('demo failed to run:', err);
+    try { VaultClient.clear(); await teardown(); } catch { /* best effort */ }
+    process.exit(2);
+});


### PR DESCRIPTION
> **Stacked on #136** (base is `test/jwt-auth-tdd`) — it uses the JWT backend that PR adds. GitHub retargets this to `master` when #136 merges.
>
> ⚠️ **The full pipeline has not run on this PR, and cannot yet.** `.github/workflows/pipeline.yaml` triggers on `pull_request: branches: [master]` and `push: branches: [master]`, so a PR based on a non-master branch gets only the checks that come from apps (DCO, Snyk). The green tick here therefore means less than usual. Everything was verified locally instead — see Verification below — and the full suite will run once #136 merges and this retargets to `master` (it may need a synchronising push to kick off).

A single-file app that exercises the `jwt` auth backend against a **real Vault**, covering both what should work and how it should fail. It prints what each scenario did and **exits non-zero if any of them deviates**, so it is a demo *and* a smoke test you can point at any Vault:

```bash
docker compose up -d --wait
node examples/jwt-auth/vault-jwt-demo.mjs

# or against a real deployment
VAULT_ADDR=https://vault.example.com:8200 VAULT_TOKEN=… node examples/jwt-auth/vault-jwt-demo.mjs
```

```
  ✓ + literal JWT string                     expected: reads the secret                             got: hello from vault
  ✓ + JWT from a file (jwtPath)              expected: reads the secret                             got: hello from vault
  ✓ + JWT minted per login (jwtProvider)     expected: reads the secret; provider called once       got: hello from vault / provider calls: 1
  ✓ + role omitted -> mount default_role     expected: reads the secret                             got: hello from vault
  ✓ + custom mount ("gha")                   expected: reads the secret                             got: hello from vault
  ✓ + one login serves many reads            expected: provider called once for 3 reads             got: provider calls: 1
  ✓ - wrong audience                         expected: VaultHttpError 400                           got: VaultHttpError 400
  ✓ - expired JWT                            expected: VaultHttpError 400                           got: VaultHttpError 400
  ✓ - signature from an untrusted key        expected: VaultHttpError 400                           got: VaultHttpError 400
  ✓ - role that does not exist               expected: VaultHttpError 400                           got: VaultHttpError 400
  ✓ - valid login, policy denies the path    expected: VaultHttpError 403 (authn ok, authz denied)  got: VaultHttpError 403
  ✓ - no JWT source configured               expected: InvalidArgumentsError at construction        got: InvalidArgumentsError
  ✓ - two JWT sources configured             expected: InvalidArgumentsError at construction        got: InvalidArgumentsError
  ✓ - jwtProvider that is not a function     expected: InvalidArgumentsError at construction        got: InvalidArgumentsError
  ✓ - jwtProvider resolving a non-string     expected: InvalidArgumentsError, no login attempted    got: InvalidArgumentsError
  ✓ - jwtProvider that rejects               expected: the provider's own error propagates          got: Error

16 scenarios (6 positive, 10 negative), 0 unexpected
```

## Why the negative half is the interesting half

The five client-side validation cases fail at **construction**, before any network call — that is the cheap failure. The Vault-side ones show the distinction that actually costs people time in production:

- **400** — Vault rejected the JWT itself: wrong audience, expired, signature from a key it does not trust, unknown role.
- **403** — the login *succeeded* and the issued token simply has no policy for that path.

Same-looking failure, completely different fix. The app demonstrates both against a real server rather than asserting it in prose.

## No identity provider required

It generates a throwaway RSA key at startup, signs its own RS256 tokens, and points Vault at the public key via `jwt_validation_pubkeys` — so it runs offline against any Vault with no IdP, no `oidc_discovery_url`, and no new dependency (`node:crypto` only). In production that key is GitHub Actions / GitLab / a cloud metadata endpoint / SPIFFE, which the README explains.

Setup and teardown are self-contained (two mounts, roles, a policy, a demo secret — all removed at the end), so it is safe to rerun.

## Verification

- **16/16, exit 0, on Vault 1.21 *and* 2.0.**
- **Mutation-checked**, so it detects regressions rather than rubber-stamping: a wrong default mount fails **9** scenarios; accepting zero JWT sources fails **1**. (A third mutation — always sending `role` — correctly changed nothing, because `JSON.stringify` drops `role: undefined`.)
- `npm run lint` clean, `npm run test:unit` 341 passing, and `examples/` is **not** in the published tarball (17 files, none from `examples/`) since `package.json` ships `files: ["src"]`.
