### PR TITLE
test(e2e): make the e2e suite rerunnable against a running stack

### DIFF
--- a/test/e2e/e2e.test.mjs
+++ b/test/e2e/e2e.test.mjs
@@ -4,6 +4,7 @@ import deepFreeze from 'deep-freeze';
 import _ from 'lodash';
 import { expect } from 'chai';
 import VaultClient from '../../src/VaultClient.js';
+import errors from '../../src/errors.js';
 
 const _require = createRequire(import.meta.url);
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -60,12 +61,23 @@ describe('E2E', function () {
         expect(res.getData()).is.deep.equal(testData);
 
         const list = await vaultClient.list('secret');
-        expect(list.getData()).is.deep.equal({keys: ['tst-val']});
+        // `include`, not deep-equal: other tests in this suite write their own keys under
+        // secret/, and a rerun against a still-running compose stack sees the previous
+        // run's too (#137).
+        expect(list.getData().keys).to.include('tst-val');
     });
 
     it('Write for ssh backend should return response', async function () {
         const vaultClient = new VaultClient(this.bootOpts);
-        await vaultClient.write('/sys/mounts/ssh', {type: 'ssh'});
+        // Already mounted by a previous run against the same stack: Vault answers
+        // 400 "path is already in use", which is success for our purposes (#137).
+        try {
+            await vaultClient.write('/sys/mounts/ssh', {type: 'ssh'});
+        } catch (err) {
+            if (!(err instanceof errors.VaultHttpError) || !/already in use/.test(err.message)) {
+                throw err;
+            }
+        }
         await vaultClient.write('/ssh/roles/otp_key_role', {key_type: 'otp', default_user: 'ubuntu', cidr_list: '127.0.0.0/24'});
         const response = await vaultClient.write('/ssh/creds/otp_key_role', {ip: '127.0.0.1'});
 


### PR DESCRIPTION
Closes #137.

`npm run test:e2e` passed on a fresh stack but failed on a **second** run against the same one, because two tests assumed a pristine Vault. Locally that made iterating cost a `docker compose down -v && up` per run, and "run the suite twice" was a failing operation.

## Changes

| test | assumed | now |
| --- | --- | --- |
| `Simple read/write` | `list('secret')` deep-equals exactly `['tst-val']` | asserts `'tst-val'` **is included** — the node-config tests in the same file write `secret/a` and `secret/b`, and a rerun also sees the previous run's keys |
| `Write for ssh backend` | mounting `ssh` always succeeds | tolerates exactly `400 "path is already in use"`; **any other error still fails** |

The ssh tolerance is narrow on purpose — it matches `VaultHttpError` with that message, so a genuine mount failure is not swallowed.

Nothing about what the tests verify on a fresh stack changes, and no production code is touched.

## Verification

```
docker compose up -d --wait     # one stack, never restarted
npm run test:e2e   run 1: 6 passing
npm run test:e2e   run 2: 6 passing
npm run test:e2e   run 3: 6 passing

npm test           run 1: 361 passing     # unit + e2e + kv2 + jwt, whole glob
npm test           run 2: 361 passing
```

Both acceptance criteria in #137 are met. `npx eslint` clean.
