### PR TITLE
ci: bump upload-artifact to v7.0.1 to clear the Node 20 deprecation warning

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -81,7 +81,7 @@ jobs:
         # Upload even when the threshold gate fails, so the HTML/lcov report is available
         # to diagnose which file regressed.
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage/


### PR DESCRIPTION
Clears the warning on the `coverage` job:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/upload-artifact@ea165f8d…
```

## Cause

`actions/upload-artifact` was pinned at **v4**, whose `action.yml` declares `runs.using: node20`. It was the **last action in this repo still on a Node 20 major** — `actions/checkout` and `actions/setup-node` are already v6 and declare `node24`:

| action | pin | `runs.using` |
| --- | --- | --- |
| `actions/checkout` | v6 | `node24` ✅ |
| `actions/setup-node` | v6 | `node24` ✅ |
| `actions/upload-artifact` | **v4** | **`node20`** ⚠️ |

Because the workflow sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`, the action was *already executing* on Node 24 — the warning is that it was being **forced** rather than declaring it, which is exactly the state that breaks when the forcing flag goes away.

## Fix

Bumped to **v7.0.1** (`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`). v6 was the release that moved the default runtime to `node24`; v7.0.1 is the current major and declares it too.

Verified rather than assumed:

- The pinned SHA **is** the `v7.0.1` tag (`git/ref/tags/v7.0.1` → `043fb46d…`).
- That SHA's `action.yml` declares `using: 'node24'`.
- Our inputs still exist in v7 — we pass only `name` and `path`; v7's addition (`archive`) is **opt-in** and defaults to the previous behaviour, so the uploaded artifact is unchanged.
- Same pin already in use by the org's `go-namecheap-sdk` repo.

v7 requires an Actions runner ≥ 2.327.1; the hosted runners are on 2.336.x.

No other action in either workflow targets Node 20, so this is the whole fix — the warning should not reappear elsewhere.
