### PR TITLE
fix(client): warn when boot() is given options for an existing instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- `VaultClient.boot()` now logs a warning when it is called for a name that already exists with
+  options that differ from the ones the instance was booted with (#146). The options were, and
+  still are, ignored in that case — the memoized instance is returned unchanged — so this only
+  makes a silent mismatch visible. Silent when the options match (compared order-insensitively,
+  as a hash, so no credential is retained for the comparison) and when `logger: false`.
+
 - Added `auth.renewal: false`, which disables the background
   token-renewal timer (#17). The client then uses the token until it expires and re-authenticates
   on the next call instead of renewing it in the background. Useful for short-lived processes —

--- a/README.md
+++ b/README.md
@@ -577,6 +577,12 @@ Boot an instance of Vault
 The instance will be stored in a local hash. Calling Vault.boot multiple
 times with the same name will return the same instance.
 
+`options` are used only when the instance is first created. A later call for a name that already
+exists returns the existing instance and ignores the options passed to it; when those differ from
+the ones it was booted with, the client logs a warning rather than letting the difference pass
+silently. Use [`VaultClient.get(name)`](#VaultClient.get) to fetch an existing instance, or
+[`VaultClient.clear(name)`](#VaultClient.clear) before booting to replace one.
+
 **Kind**: static method of [<code>VaultClient</code>](#VaultClient)  
 **Returns**: <code>VaultClient</code>  
 

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Lease = require('./Lease');
+const crypto = require('crypto');
 const errors = require('./errors');
 const VaultApiClient = require('./VaultApiClient');
 const VaultAppRoleAuth = require('./auth/VaultAppRoleAuth');
@@ -14,6 +15,36 @@ const { rewritePath, normalizeResponse } = require('./kvTransform');
 
 const noop = () => {};
 const vaultInstances = {};
+
+/**
+ * Order-insensitive canonical form of the boot options, hashed so that no credential is
+ * retained just to compare two boot() calls. Functions compare by identity, which is what
+ * a caller passing `jwtProvider` expects.
+ */
+function fingerprintOptions(value, seen) {
+    if (typeof value === 'function') {
+        return 'fn';
+    }
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value) || String(value);
+    }
+    seen = seen || new Set();
+    if (seen.has(value)) {
+        return 'circular';
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+        return `[${value.map((item) => fingerprintOptions(item, seen)).join(',')}]`;
+    }
+    const body = Object.keys(value).sort()
+        .map((key) => `${JSON.stringify(key)}:${fingerprintOptions(value[key], seen)}`)
+        .join(',');
+    return `{${body}}`;
+}
+
+function optionsDigest(options) {
+    return crypto.createHash('sha256').update(fingerprintOptions(options)).digest('hex');
+}
 
 class VaultClient {
 
@@ -105,8 +136,15 @@ class VaultClient {
      * The instance will be stored in a local hash. Calling Vault.boot multiple
      * times with the same name will return the same instance.
      *
+     * `options` are used only when the instance is first created. A later call for a name
+     * that already exists returns the existing instance and ignores the options it was
+     * given; when those options differ from the ones the instance was booted with, that is
+     * logged as a warning rather than passing silently. Use {@link VaultClient.get} to
+     * fetch an existing instance, or {@link VaultClient.clear} to replace one.
+     *
      * @param {String} name - Vault instance name
-     * @param {Object} [options] - options for {@link VaultClient#constructor}.
+     * @param {Object} options - options for {@link VaultClient#constructor}. Required on
+     *      every call, including for a name that already exists.
      * @return {VaultClient}
      */
     static boot(name, options) {
@@ -117,6 +155,15 @@ class VaultClient {
         let instance = vaultInstances[name];
         if (instance === undefined) {
             vaultInstances[name] = instance = new VaultClient(options);
+            instance.__bootDigest = optionsDigest(options);
+        } else if (instance.__bootDigest !== optionsDigest(options)) {
+            instance.__log.warn(
+                'VaultClient.boot("%s") was called with different options than the existing ' +
+                'instance was booted with; the existing instance is returned and these options ' +
+                'are ignored. Use VaultClient.get("%s") to fetch it, or VaultClient.clear("%s") ' +
+                'first to replace it.',
+                name, name, name
+            );
         }
         return instance;
     }

--- a/test/VaultClient.test.mjs
+++ b/test/VaultClient.test.mjs
@@ -10,6 +10,7 @@ import VaultAppRoleAuth from '../src/auth/VaultAppRoleAuth.js';
 import VaultIAMAuth from '../src/auth/VaultIAMAuth.js';
 import VaultKubernetesAuth from '../src/auth/VaultKubernetesAuth.js';
 import errors from '../src/errors.js';
+import { createSpyLogger, loggedText } from './helpers/logger.mjs';
 import MountResolver from '../src/MountResolver.js';
 
 use(sinonChai);
@@ -196,6 +197,55 @@ describe('VaultClient', function () {
                     (err) => { expect(err).to.equal(boom); }
                 );
             });
+        });
+    });
+
+    describe('.boot() with options for an existing instance (#146)', function () {
+        const bootOpts = (overrides) => _.merge({
+            api: { url: 'https://example.com/' },
+            auth: { type: 'token', config: { token: 'tok-123' } },
+        }, overrides);
+
+        afterEach(function () {
+            VaultClient.clear();
+        });
+
+        it('returns the existing instance and warns when the options differ', function () {
+            const log = createSpyLogger();
+            const first = VaultClient.boot('dup', bootOpts({ logger: log }));
+            const second = VaultClient.boot('dup', bootOpts({ logger: log, api: { url: 'https://other.example/' } }));
+
+            expect(second, 'the memoized instance is still returned').to.equal(first);
+            expect(loggedText(log)).to.contain('different options');
+            expect(loggedText(log)).to.contain('VaultClient.get');
+        });
+
+        it('stays silent when the options are equivalent', function () {
+            const log = createSpyLogger();
+            VaultClient.boot('same', bootOpts({ logger: log }));
+            VaultClient.boot('same', bootOpts({ logger: log }));
+
+            expect(loggedText(log), 'a re-boot with the same config must not warn').to.not.contain('different options');
+        });
+
+        it('ignores key order when comparing', function () {
+            const log = createSpyLogger();
+            VaultClient.boot('order', { logger: log, api: { url: 'https://example.com/' }, auth: { type: 'token', config: { token: 't' } } });
+            VaultClient.boot('order', { auth: { config: { token: 't' }, type: 'token' }, api: { url: 'https://example.com/' }, logger: log });
+
+            expect(loggedText(log)).to.not.contain('different options');
+        });
+
+        it('does not warn for a name that was never booted', function () {
+            const log = createSpyLogger();
+            VaultClient.boot('fresh', bootOpts({ logger: log }));
+
+            expect(loggedText(log)).to.not.contain('different options');
+        });
+
+        it('still throws when options are omitted entirely', function () {
+            VaultClient.boot('needs-opts', bootOpts({ logger: false }));
+            expect(() => VaultClient.boot('needs-opts')).to.throw(errors.InvalidArgumentsError);
         });
     });
 


### PR DESCRIPTION
Closes #146.

`VaultClient.boot()` memoizes on `name` and discards the options of every later call, so a second `boot('main', …)` with different settings silently returns the first instance:

```js
let instance = vaultInstances[name];
if (instance === undefined) { vaultInstances[name] = instance = new VaultClient(options); }
return instance;   // options ignored, no warning
```

The shape that hits this: a library module boots `'main'` with defaults at import time, then a script in the same process boots `'main'` with its own config and gets the first instance back. Nothing said so — and with `auth.renewal: false` now available, quietly losing it reproduces the hang that option exists to prevent.

## Behaviour is unchanged

Deliberately, per the brief. Verified:

| | |
| --- | --- |
| second `boot()` returns the memoized instance | **unchanged** |
| the passed options are still ignored | **unchanged** |
| `get()` returns the same instance | **unchanged** |
| `boot()` without options still throws `InvalidArgumentsError` | **unchanged** |
| `clear()` then `boot()` builds a fresh instance | **unchanged** |
| `logger: false` | silent, as always |

The only new output is a `warn` when the options actually differ, naming `get()` and `clear()` as the two things the caller probably meant.

## Comparison details

Order-insensitive, so the same config written with different key order stays silent, and **hashed** — the digest is stored, never the options object, so no credential is retained on the instance just to compare later calls. Functions compare by identity, which is what a caller passing `jwtProvider` expects.

## Verification

- `npm run test:unit` **381 passing** (5 new), `npm run coverage` gate holds, `npx eslint src/ test/ examples/` clean.
- New tests: warns on differing options · silent on equivalent options · silent when only key order differs · silent on first boot · still throws without options.
- **Mutation-checked**: deleting the warning branch fails a test, so the behaviour is bound rather than described.

## Docs

README gains the memoization note under `VaultClient.boot`, the JSDoc says the same, and there is a CHANGELOG entry. No example needed — the repo's own demo already works around the cache with unique names (``boot(`demo-${n++}`)``), which is the pattern this warning points people toward.
