### PR TITLE
fix(auth): discard renewal callbacks that no longer own the token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
   makes a silent mismatch visible. Silent when the options match (compared order-insensitively,
   as a hash, so no credential is retained for the comparison) and when `logger: false`.
 
+- Fixed renewal callbacks acting on state they no longer own (#145). A renewal request still in
+  flight when its token was replaced, or when `close()` / `cancelTokenRefresh()` was called, would
+  apply its result anyway: overwriting the newer token, clearing the newer token's timer and then
+  bailing on its own expired one (leaving a live token permanently un-renewed), or re-arming a
+  timer after the client had been closed. Superseded callbacks are now discarded. Renewal that is
+  not superseded behaves exactly as before.
+
 - Added `auth.renewal: false`, which disables the background
   token-renewal timer (#17). The client then uses the token until it expires and re-authenticates
   on the next call instead of renewing it in the background. Useful for short-lived processes —

--- a/README.md
+++ b/README.md
@@ -558,6 +558,12 @@ vaultClient.close(); // process can now exit
 
 **Kind**: instance method of [<code>VaultClient</code>](#VaultClient)  
 
+
+`close()` also settles a renewal that is already in flight: a request that lands after the call is
+discarded rather than arming a fresh timer, so the client stops holding the event loop open. The
+same applies when a token is replaced by a new login — a renewal still running against the previous
+token cannot overwrite the newer one or cancel its timer.
+
 <a name="Lease"></a>
 
 ### Lease

--- a/src/auth/VaultBaseAuth.js
+++ b/src/auth/VaultBaseAuth.js
@@ -56,6 +56,7 @@ class VaultBaseAuth {
          */
         this.__pendingLogin = null;
         this.__refreshTimeout = null;
+        this.__renewalEpoch = 0;
     }
 
     /**
@@ -173,6 +174,7 @@ class VaultBaseAuth {
         const pendingLogin = this._authenticate().then(authToken => {
             this.__pendingLogin = null;
             this.__authToken = authToken;
+            this.__renewalEpoch++;
 
             if (authToken.isRenewable()) {
                 // Gate the log on the flag too: the guard lives inside
@@ -216,6 +218,7 @@ class VaultBaseAuth {
      * @returns {void}
      */
     cancelTokenRefresh() {
+        this.__renewalEpoch++;
         if (this.__refreshTimeout !== null) {
             lt.clearTimeout(this.__refreshTimeout);
             this.__refreshTimeout = null;
@@ -258,11 +261,28 @@ class VaultBaseAuth {
         const remaining = authToken.getExpiresAt() - Math.floor(Date.now() / 1000);
         const timer = Math.max(remaining * this.__renewalFraction, 1) * 1000;
 
+        // A renewal that is still in flight when the token is replaced or cancelled must not
+        // act on what it finds when it lands: it would overwrite the newer token, or clear
+        // the newer token's timer and then bail on its own expired one, leaving a live token
+        // permanently un-renewed. Anything that supersedes this timer bumps the epoch.
+        const epoch = ++this.__renewalEpoch;
+        const superseded = () => this.__renewalEpoch !== epoch;
+
         this.__refreshTimeout = lt.setTimeout(() => {
-            this.__renewToken(authToken).then(authToken => {
-                this.__authToken = authToken;
-                this.__setupTokenRefreshTimer(authToken);
+            if (superseded()) {
+                return;
+            }
+
+            this.__renewToken(authToken).then(renewedToken => {
+                if (superseded()) {
+                    return;
+                }
+                this.__authToken = renewedToken;
+                this.__setupTokenRefreshTimer(renewedToken);
             }).catch(err => {
+                if (superseded()) {
+                    return;
+                }
                 this.__setupTokenRefreshTimer(authToken);
 
                 this._log.error(`Cannot refresh auth token with "${authToken.getAccessor()}" accessor. Error: ${err.message}`);

--- a/test/auth.base.test.mjs
+++ b/test/auth.base.test.mjs
@@ -445,6 +445,118 @@ describe('VaultBaseAuth', function () {
         });
     });
 
+    describe('superseded renewal callbacks (#145)', function () {
+        let clock;
+
+        function flush(times) {
+            let p = Promise.resolve();
+            for (let i = 0; i < (times || 8); i++) {
+                p = p.then(() => undefined);
+            }
+            return p;
+        }
+
+        function deferred() {
+            let settle;
+            const promise = new Promise((resolve, reject) => { settle = { resolve, reject }; });
+            return { promise, ...settle };
+        }
+
+        /** Token A: renewable, expires at 100s, so its timer fires at 50s on a clock at 0. */
+        function tokenA() {
+            return new AuthToken('A', 'accA', 0, 100, 0, 0, true);
+        }
+
+        function tokenB() {
+            return new AuthToken('B', 'accB', 0, 1000, 0, 0, true);
+        }
+
+        /** Arms A's timer, fires it, and leaves the renew request hanging. */
+        async function renewalInFlight() {
+            const api = apiStub();
+            const renewCall = deferred();
+            api.makeRequest.returns(renewCall.promise);
+            const auth = new TestAuth(api, 'mount', { authStub: sinon.stub().resolves(tokenA()) });
+            sinon.stub(auth, '_getTokenEntity').resolves(new AuthToken('A-renewed', 'accA', 0, 200, 0, 0, true));
+
+            await auth.getAuthToken();
+            clock.tick(50000);
+            await flush();
+            expect(api.makeRequest, 'the renewal should be in flight').to.have.been.called;
+            return { auth, renewCall };
+        }
+
+        beforeEach(function () {
+            clock = sinon.useFakeTimers();
+        });
+
+        afterEach(function () {
+            clock.restore();
+            sinon.restore();
+        });
+
+        it('a stale renewal that succeeds does not overwrite the newer token', async function () {
+            const { auth, renewCall } = await renewalInFlight();
+
+            const b = tokenB();
+            auth.__authToken = b;
+            auth.__setupTokenRefreshTimer(b);
+
+            renewCall.resolve({});
+            await flush();
+
+            expect(auth.__authToken, 'the newer token must survive').to.equal(b);
+        });
+
+        it('a stale renewal that fails does not clear the newer token timer', async function () {
+            const { auth, renewCall } = await renewalInFlight();
+
+            const b = tokenB();
+            auth.__authToken = b;
+            auth.__setupTokenRefreshTimer(b);
+            const bTimer = auth.__refreshTimeout;
+
+            renewCall.reject(new Error('vault unreachable'));
+            await flush();
+
+            expect(auth.__refreshTimeout, "the newer token's timer must stay armed").to.equal(bTimer);
+            expect(auth.__refreshTimeout).to.not.equal(null);
+        });
+
+        it('a renewal in flight when cancelTokenRefresh() runs does not re-arm', async function () {
+            const { auth, renewCall } = await renewalInFlight();
+
+            auth.cancelTokenRefresh();
+            expect(auth.__refreshTimeout).to.equal(null);
+
+            renewCall.resolve({});
+            await flush();
+
+            expect(auth.__refreshTimeout, 'close() must not be undone by an in-flight renewal').to.equal(null);
+        });
+
+        it('a failing renewal in flight when cancelTokenRefresh() runs does not re-arm', async function () {
+            const { auth, renewCall } = await renewalInFlight();
+
+            auth.cancelTokenRefresh();
+            renewCall.reject(new Error('vault unreachable'));
+            await flush();
+
+            expect(auth.__refreshTimeout).to.equal(null);
+        });
+
+        it('an undisturbed renewal still applies and re-arms', async function () {
+            const { auth, renewCall } = await renewalInFlight();
+
+            renewCall.resolve({});
+            await flush();
+
+            expect(auth.__authToken.getId(), 'the renewed token should be adopted').to.equal('A-renewed');
+            expect(auth.__refreshTimeout, 'and a new timer armed').to.not.equal(null);
+            auth.cancelTokenRefresh();
+        });
+    });
+
     describe('token refresh timer', function () {
         let clock;
 


### PR DESCRIPTION
Closes #145.

A renewal request still in flight when its token was replaced — or when `close()` was called — applied its result anyway. `VaultApiClient` sets no request timeout, so a hung `renew-self` genuinely can outlive the token it was renewing.

## Three outcomes, all fixed

| scenario | before | now |
| --- | --- | --- |
| stale renewal **succeeds** after a new login | overwrote the current token with the renewed older one | discarded |
| stale renewal **fails** after a new login | re-armed against its own token — whose first act is `clearTimeout` on the **current** timer — then bailed because that token was expired, leaving a live renewable token **permanently un-renewed** | discarded; the current timer stays armed |
| either outcome after `close()` | armed a fresh timer, so the client kept holding the event loop open | discarded; `close()` stays closed |

The second is the nastiest: for `token` auth, which cannot re-authenticate, a permanently un-renewed token means a permanently dead client.

## Fix

Renewal carries an epoch. Arming a timer, completing a login and cancelling all advance it; a callback that finds the epoch moved on returns without touching anything. Guards sit at three points — when the timer fires, and when the request settles either way — because the damage happens at *settle* time, after the window has opened.

## Behaviour is unchanged

Only outcomes that are already broken change; nothing can depend on a renewal silently ceasing or `close()` not closing.

- **All 376 pre-existing tests passed untouched** the moment the guard landed, before any new test was written.
- A new test states the happy path directly: an undisturbed renewal still adopts the renewed token and re-arms.
- `git diff origin/master -- src/` → **no signature, export or public method changed**.
- e2e green against a real Vault (`test:e2e` 6/6, `test:e2e:jwt` 4/4), which exercises the live renewal path.

## Verification

- `npm run test:unit` **381 passing** (5 new), `npm run coverage` gate holds, `npx eslint src/ test/ examples/` clean.
- **Mutation-checked**, so the tests bind the fix rather than describe it:

| mutation | result |
| --- | --- |
| remove the two settle-time guards (keep the fire-time one) | **4 failing** |
| stop advancing the epoch in `cancelTokenRefresh()` | **2 failing** |

## Docs

README's `close()` section now states what stopping renewal actually guarantees — an in-flight request landing afterwards is discarded rather than re-arming — plus a CHANGELOG entry. No example change: the demo app does not exercise renewal races.
