### PR TITLE
fix(auth): reject instead of throwing when the kube token file is unreadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- Fixed the Kubernetes backend throwing a token-file read error synchronously out of `read()`
+  instead of rejecting the returned promise (#144). A `.catch()` attached to the call never ran and
+  the error could reach the process as an uncaught exception; it is now delivered as a rejection,
+  matching the JWT backend and the documented `Promise` return type. Callers using `await` inside
+  `try`/`catch` are unaffected — they caught it before and still do.
+
 - Added `auth.renewal: false`, which disables the background
   token-renewal timer (#17). The client then uses the token until it expires and re-authenticates
   on the next call instead of renewing it in the background. Useful for short-lived processes —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Unreleased
 
-- Fixed the Kubernetes backend throwing a token-file read error synchronously out of `read()`
-  instead of rejecting the returned promise (#144). A `.catch()` attached to the call never ran and
-  the error could reach the process as an uncaught exception; it is now delivered as a rejection,
-  matching the JWT backend and the documented `Promise` return type. Callers using `await` inside
-  `try`/`catch` are unaffected — they caught it before and still do.
-
 - Added `auth.renewal: false`, which disables the background
   token-renewal timer (#17). The client then uses the token until it expires and re-authenticates
   on the next call instead of renewing it in the background. Useful for short-lived processes —
@@ -42,6 +36,12 @@
   `jwtProvider`, fails fast with `InvalidArgumentsError` without sending a login request. Only
   the non-interactive `jwt` flow is implemented; the browser-redirect `oidc` flow is out of
   scope for this service client. See the README's "JWT auth" section.
+
+- Fixed the Kubernetes backend throwing a token-file read error synchronously out of `read()`
+  instead of rejecting the returned promise (#144). A `.catch()` attached to the call never ran and
+  the error could reach the process as an uncaught exception; it is now delivered as a rejection,
+  matching the JWT backend and the documented `Promise` return type. Callers using `await` inside
+  `try`/`catch` are unaffected — they caught it before and still do.
 
 # 2.1.2 Release notes (2026-08-03)
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ const vaultClient = VaultClient.boot('main', {
 });
 ```
 
+The token file is read on every login, so a projected service-account token that the kubelet
+rotates is picked up without a restart. If that read fails — the file missing mid-rotation, or
+unreadable — the error is delivered as a rejection of the call you made, so `read().catch(...)` and
+`await` inside `try`/`catch` both see it.
+
 ### JWT auth
 
 ```javascript

--- a/examples/jwt-auth/README.md
+++ b/examples/jwt-auth/README.md
@@ -46,6 +46,9 @@ and the demo secret — a dev-mode root token is the intended use.
 | `jwtProvider` resolving a non-string | `InvalidArgumentsError`, no login attempted |
 | `jwtProvider` that rejects | the provider's own error, unwrapped |
 
+Every one of these arrives as a **rejected promise**, never a synchronous throw — so a single
+`.catch()` on the call is enough, whichever way the login fails.
+
 The 400-vs-403 distinction is the one worth internalising: **400 means Vault rejected the JWT**
 (audience, expiry, signature, unknown role), **403 means the login worked and the resulting token
 lacks a policy for that path**. They point at completely different fixes.

--- a/src/auth/VaultKubernetesAuth.js
+++ b/src/auth/VaultKubernetesAuth.js
@@ -33,16 +33,19 @@ class VaultKubernetesAuth extends VaultBaseAuth {
             this.__role, this.__tokenPath
         );
 
-        const k8sJwtToken = fs.readFileSync(this.__tokenPath).toString();
-        this._log.debug(
-            'read K8s service-account JWT from "%s" (%d bytes)',
-            this.__tokenPath, k8sJwtToken.length
-        );
-
-        return this.__apiClient.makeRequest('POST', `/auth/${this._mount}/login`, {
+        // Inside the chain so a failed read rejects the returned promise instead of throwing
+        // out of getAuthToken() and past the caller's .catch(); matches VaultJwtAuth.
+        return Promise.resolve().then(() => {
+            const k8sJwtToken = fs.readFileSync(this.__tokenPath).toString();
+            this._log.debug(
+                'read K8s service-account JWT from "%s" (%d bytes)',
+                this.__tokenPath, k8sJwtToken.length
+            );
+            return k8sJwtToken;
+        }).then((k8sJwtToken) => this.__apiClient.makeRequest('POST', `/auth/${this._mount}/login`, {
             role: this.__role,
             jwt: k8sJwtToken,
-        }).then((res) => {
+        })).then((res) => {
             this._log.debug('received Vault client token from Kubernetes login');
 
             return this._getTokenEntity(res.auth.client_token);

--- a/test/auth.kubernetes.test.mjs
+++ b/test/auth.kubernetes.test.mjs
@@ -5,6 +5,7 @@ import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import VaultApiClient from '../src/VaultApiClient.js';
 import VaultKubernetesAuth from '../src/auth/VaultKubernetesAuth.js';
+import VaultClient from '../src/VaultClient.js';
 import AuthToken from '../src/auth/AuthToken.js';
 import errors from '../src/errors.js';
 
@@ -72,15 +73,45 @@ describe('VaultKubernetesAuth', function () {
             .to.throw(errors.InvalidArgumentsError, '"role" should be provided for VaultKubernetesAuth');
     });
 
-    it('propagates the fs error when the service-account token file is missing or unreadable, without hitting Vault', function () {
+    it('rejects with the fs error when the service-account token file is missing or unreadable, without hitting Vault', async function () {
         const fsError = new Error("ENOENT: no such file or directory, open '/var/run/secrets/kubernetes.io/serviceaccount/token'");
         fsError.code = 'ENOENT';
         readFileSync = sinon.stub(fs, 'readFileSync').throws(fsError);
         const api = apiStub();
         const auth = new VaultKubernetesAuth(api, logger, { role: 'r' });
 
-        expect(() => auth._authenticate()).to.throw(fsError);
+        let thrownSynchronously = false;
+        let rejection;
+        try {
+            await auth._authenticate().catch((err) => { rejection = err; });
+        } catch (err) {
+            thrownSynchronously = true;
+            rejection = err;
+        }
+
+        expect(thrownSynchronously, '_authenticate() must not throw before returning a promise').to.equal(false);
+        expect(rejection).to.equal(fsError);
         expect(api.makeRequest).to.not.have.been.called;
+    });
+
+    it('surfaces the fs error to a .catch() on client.read()', async function () {
+        const fsError = new Error('EACCES: permission denied');
+        fsError.code = 'EACCES';
+        readFileSync = sinon.stub(fs, 'readFileSync').throws(fsError);
+
+        const client = new VaultClient({
+            api: { url: 'https://vault.example/' },
+            logger: false,
+            auth: { type: 'kubernetes', config: { role: 'r' } },
+        });
+
+        let handled;
+        await new Promise((done) => {
+            client.read('secret/x').catch((err) => { handled = err; done(); });
+        });
+
+        expect(handled, 'the handler attached to read() must receive it').to.equal(fsError);
+        VaultClient.clear();
     });
 
     it('never logs the JWT or the Vault client token', function () {


### PR DESCRIPTION
Closes #144.

`VaultKubernetesAuth` read the service-account token in the body of `_authenticate()`, so a failed read threw **synchronously** out of `getAuthToken()` and out of `read()` — which is not `async` — escaping past the caller's `.catch()` and reaching the process as an uncaught exception. `VaultJwtAuth` already reads its file inside the promise chain; this makes Kubernetes match, and makes the documented `Promise` return type hold.

## Who this changes, measured

I measured all three ways callers write this, before and after the fix:

| caller shape | before | after |
| --- | --- | --- |
| `await client.read(...)` inside `try`/`catch` | caught | **caught — identical** |
| `client.read(...).catch(handler)` | **crash**, handler never ran | handler runs |
| `client.read(...)` discarded, wrapped in `try`/`catch` | caught | not caught |

Only the third changes, and it is not a supported shape — the promise is thrown away, so nothing observes success either, and any *later* failure in that same call already went unhandled.

The realistic reading: `await` users see no difference, promise-chain users stop crashing.

## Why the existing test changed

One test asserted `expect(() => auth._authenticate()).to.throw(...)` — it pinned the synchronous throw, which is the defect rather than the intent. Its name says *"propagates the fs error … without hitting Vault"*, and **both halves still hold**: it now asserts the rejection carries the same error and that `_authenticate()` returns without throwing first. A second test covers the guarantee from the caller's side, through `client.read().catch(...)`.

## Verification

- `npm run test:unit` **377 passing** (1 new, 1 rewritten), `npm run coverage` gate holds, `npx eslint src/ test/ examples/` clean.
- e2e green against real Vault: `test:e2e` 6/6, `test:e2e:jwt` 4/4.
- **Mutation-checked**: reverting to the synchronous read fails **2** tests.
- **Siblings checked** — only the JWT backend also reads a file, and it already rejects correctly (verified at runtime with a missing `jwtPath`: `.catch()` receives `ENOENT`).

## Docs

README's Kubernetes section now states that the file is read on every login (so kubelet rotation is picked up) and that a failed read arrives as a rejection. The demo's example README notes that every failure mode it exercises arrives as a rejection rather than a throw, so one `.catch()` suffices. Plus a CHANGELOG entry.
