### PR TITLE
ci: add dependabot for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    # Matches the history: runtime bumps land as `fix(deps)` because they ship to
+    # consumers, tooling as `chore(deps)`.
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      # One PR per week for the routine tooling churn, rather than one per package.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Node 18 is still in `engines` and in the CI matrix, and these majors drop
+      # it. See the 2.1.1 release notes, which record that each was tried.
+      - dependency-name: c8
+        # 11+ requires Node "20 || >=22"; 12 pulls an ESM-only yargs that dies
+        # with ERR_REQUIRE_ESM on Node 18.
+        update-types: ["version-update:semver-major"]
+      - dependency-name: eslint
+        # 10.x declares ^20.19.0 || ^22.13.0 || >=24.
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: config
+        # Peer range is deliberately <4: config 4 requires Node >=20.
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Actions are CI-only, so they must not cut a release.
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,20 @@ which posts its own status check on the pull request — it is not a job in
 commits authored by members of the `namecheap` organization, so in practice the check blocks
 unsigned commits from outside contributors.
 
+## Dependency updates
+
+Dependabot proposes updates weekly, configured in
+[`.github/dependabot.yml`](.github/dependabot.yml): runtime dependencies individually as
+`fix(deps)`, dev tooling grouped into one `chore(deps)` PR, and GitHub Actions as `ci(deps)`.
+
+Some majors are deliberately ignored there because they drop Node 18, which is still in `engines`
+and in the CI matrix — `c8` 11+, `eslint` 10.x and `config` 4. If you need one of those, it comes
+with raising the minimum Node version, not with a lockfile bump.
+
+Security advisories are separate: `npm audit --audit-level=high` runs as a blocking CI job, and the
+`overrides` block in `package.json` is how a patched transitive dependency gets pinned when the
+direct dependency has not released one yet.
+
 ## Pull requests
 
 1. Fork the repo and create a topic branch off `master`.


### PR DESCRIPTION
Closes #152. Config and docs only — no `package.json`, `src/` or test change.

The repo had **no dependency automation** — no `dependabot.yml`, no Renovate — so every bump was manual, security ones included. The history shows the cost:

```
8a556b3 fix(deps): bump js-yaml to 4.3.1 to fix GHSA-5p4m-2wfm-xmqj
a4cdaa6 fix(deps): force patched brace-expansion and js-yaml to clear high advisories
5cfa302 fix(deps): clear all vulnerabilities while keeping Node 18 working
```

With `npm audit --audit-level=high` running as a **blocking** CI job, an advisory's discovery path was a red build on an unrelated PR, and the fix was a hand-written `overrides` entry.

## The part that needed care

A naive config here would open the **same three rejected PRs every week** until someone disabled it — which is how dependency automation usually dies. Several dev dependencies are deliberately held below latest because newer majors drop **Node 18**, still in `engines` and in the CI matrix. Each is ignored at the major level with the reason inline, taken from the 2.1.1 release notes where they were tried and reverted:

| ignored major | why |
| --- | --- |
| `c8` 11+ | requires Node `20 \|\| >=22`; 12 pulls an ESM-only `yargs` that dies with `ERR_REQUIRE_ESM` on Node 18 |
| `eslint` 10.x (and `@eslint/js`) | declares `^20.19.0 \|\| ^22.13.0 \|\| >=24` |
| `config` 4 | requires Node `>=20`; the peer range is deliberately `<4` |

Minor and patch updates for those packages still flow — only the Node-18-breaking majors are held.

## Shape

- **Runtime dependencies** individually as `fix(deps)` — they ship to consumers.
- **Dev tooling** grouped into one weekly `chore(deps)` PR, so volume stays reviewable.
- **GitHub Actions** as `ci(deps)`. Included because SHA pins go stale silently — the Node 20 deprecation warning was found by reading a job log, not by a bot.

Prefixes match this repo's own history (`fix(deps)` / `chore(deps)` / `ci(deps)`), verified against `git log` rather than assumed.

## Verification

- `dependabot.yml` parses; every `dependency-name` in the ignore list matches a real entry in `package.json` (checked mechanically, not by eye).
- `CONTRIBUTING.md` gains a Dependency updates section explaining the grouping, the ignored majors and how that differs from the `npm audit` / `overrides` path for advisories.
- Checked that this **merges cleanly with #151**, which also edits `CONTRIBUTING.md` — different section, zero conflict markers.
- `npm run test:unit` 376 passing and `eslint src/ test/ examples/` clean, unchanged as expected.

One correction worth noting: my first draft justified the commit prefixes by citing a `pr-title.yml` workflow — that file exists in a sibling repo, not this one. The prefixes are now justified by this repo's actual commit history instead.
