### PR TITLE
ci: lint and run the example app so it cannot rot

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -154,6 +154,11 @@ jobs:
       - name: Run JWT e2e tests
         run: npm run test:e2e:jwt
 
+      # The example is a smoke test that exits non-zero if any scenario deviates,
+      # so running it here keeps it from rotting into stale documentation.
+      - name: Run the example app
+        run: npm run test:example
+
   # KV v2 integration suite — exercises mount auto-detection, data/metadata path
   # rewriting, merge-patch update, version ops and metadata ops against a real
   # KV v2 Vault (the vault-server-kv2 compose service). A single Node version is

--- a/examples/jwt-auth/README.md
+++ b/examples/jwt-auth/README.md
@@ -16,6 +16,10 @@ VAULT_ADDR=https://vault.example.com:8200 VAULT_TOKEN=<root-or-admin-token> \
   node examples/jwt-auth/vault-jwt-demo.mjs
 ```
 
+CI runs this on every pull request, in the `e2e` job, against both supported Vault lines — so if the
+client changes in a way that breaks any scenario below, the build fails rather than the example
+quietly going stale.
+
 The app configures everything it needs (two `jwt` mounts, roles, a policy, a demo secret), runs the
 scenarios, then removes all of it again. It needs a token allowed to manage `sys/auth`, `sys/policy`
 and the demo secret — a dev-mode root token is the intended use.

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "test:e2e": "mocha --exit \"test/e2e/e2e.test.mjs\"",
     "test:e2e:kv2": "mocha --exit \"test/e2e/e2e.kv2.test.mjs\"",
     "test:e2e:jwt": "mocha --exit \"test/e2e/e2e.jwt.test.mjs\"",
+    "test:example": "node examples/jwt-auth/vault-jwt-demo.mjs",
     "coverage": "c8 npm run test:unit",
-    "lint": "eslint src/ test/",
+    "lint": "eslint src/ test/ examples/",
     "version": "git add -A ."
   },
   "c8": {


### PR DESCRIPTION
Closes #154. CI and packaging config only — no `src/`, no test, no client behaviour.

`examples/jwt-auth/vault-jwt-demo.mjs` is written as a smoke test — 16 positive and negative scenarios against a real Vault, **non-zero exit if any deviates** — and its README presents it as something to run. But nothing ran it, and nothing linted it:

```
$ grep -rn "examples/" .github/workflows/ package.json   # no matches
$ node -p "require('./package.json').scripts.lint"       # eslint src/ test/
```

It exercises the JWT backend's entire public surface — three token sources, `default_role` fallback, custom mounts, login caching, and the 400-vs-403 distinction between a rejected JWT and a valid login without policy — so none of that was checked when the client changed. This is the same failure mode that produced #150: contributor-facing material drifting because nothing verified it. An example that silently stops working is worse than none, because it is presented as known-good.

## Changes

- `lint` becomes `eslint src/ test/ examples/`. `examples/` already passes, so this only keeps it that way.
- New `test:example` script, run in the **`e2e` job** after the JWT suite — so it executes on every PR across the Node × Vault matrix, **including the Vault 2.0 leg**.

Cost is about a second, with no new services: the job already starts the compose Vaults, and the demo configures its own mounts and removes them in teardown.

## Verification

| check | result |
| --- | --- |
| `npm run lint` (now including `examples/`) | clean |
| `npm run test:example` on Vault 1.21 | 16 scenarios, 0 unexpected, exit 0 |
| `npm run test:example` on **Vault 2.0** | 16 scenarios, 0 unexpected |
| run twice against one stack | exit 0 both times — teardown really is idempotent |
| `npm run test:unit` | 376 passing, unchanged |

**The gate has teeth**, which is the part worth checking rather than assuming: with one scenario's expectation deliberately falsified, `npm run test:example` exits **1**; restored, it exits **0**. So this fails a build rather than merely running something.

The example's README now says CI runs it, so a reader knows the scenarios are verified rather than aspirational.
