### PR TITLE
feat(types): ship first-party TypeScript declarations

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Type-check the published declarations
+        run: npm run test:types
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,28 @@
   `auth.config`, so they cannot collide with a key an existing caller already passes to a backend;
   no constructor signature changed either, so anything subclassing `VaultBaseAuth` is unaffected.
 
+- Added first-party TypeScript declarations (`index.d.ts`), referenced by the `types` field and
+  included in the published `files` (#159). The package previously shipped none, leaving
+  TypeScript consumers on the third-party `@types/node-vault-client`, which stops at the 1.x API:
+  it has no `jwt` backend, no `close()`, no `delete()`/`update()`/`request()`, none of the KV v2
+  version or metadata methods, none of the `api.namespace`/`api.kv`/`api.engines`/
+  `api.requestOptions` or renewal options, and it declares `AuthToken`, `Lease` and the other
+  sibling classes as runtime exports of the entry point even though it exports only the
+  `VaultClient` class — so `new VaultClient.Lease(...)` type-checked and then threw. `auth` is
+  typed as a discriminated union on `type`, and the three mutually-exclusive JWT sources are
+  enforced at compile time. Types that appear in signatures are exposed in type space under the
+  `VaultClient` namespace. Declarations are verified by `npm run test:types` in CI, which
+  compiles positive usage together with `@ts-expect-error` cases so a wrong signature fails the
+  build. `src/errors.d.ts` covers the error classes, which the README documents as
+  `node-vault-client/src/errors` because the entry point does not export them; that import
+  previously raised `TS7016` under `strict`, so the documented path was the one TypeScript
+  rejected. The declarations are deliberately permissive wherever the runtime tolerates more than
+  the JSDoc suggests, so that no usage which compiled against the third-party types and works at
+  runtime is newly rejected: a partial `logger` object is accepted (missing methods fall back to
+  `console`, as before), and the methods returning a Vault response body stay assignable to
+  `Promise<void>`. Runtime behaviour is unchanged; no file under `src/` was touched. If you have
+  `@types/node-vault-client` installed, uninstall it.
+
 - Added a JWT auth backend (`auth.type: 'jwt'`, default mount `"jwt"`) for workload identity
   federation — GitHub Actions, other CI systems, GCP/Azure/SPIFFE workloads — against Vault's
   [JWT auth method](https://developer.hashicorp.com/vault/docs/auth/jwt). Models

--- a/README.md
+++ b/README.md
@@ -18,6 +18,38 @@ npm install --save node-vault-client
 
 Node.js >= 18 — the client uses the native `fetch` API.
 
+### TypeScript
+
+Type declarations ship with the package, so no separate install is needed:
+
+```typescript
+import VaultClient = require('node-vault-client');
+
+const client = new VaultClient({
+    api: { url: 'http://127.0.0.1:8200' },
+    auth: { type: 'appRole', config: { role_id: 'roleId', secret_id: 'secretId' } },
+});
+
+const lease = await client.read('secret/app');
+const password = lease.getValue<string>('password');
+```
+
+`auth` is a discriminated union on `type`, so each backend only accepts its own
+configuration, and the three mutually-exclusive JWT sources (`jwt`, `jwtPath`,
+`jwtProvider`) are enforced at compile time.
+
+Types that appear in signatures are exported in type space under the `VaultClient`
+namespace — `VaultClient.Lease`, `VaultClient.VaultOptions`, `VaultClient.AuthToken`
+and the per-backend config interfaces. They are types only; the classes behind them
+are not exported at runtime.
+
+If you previously installed the third-party `@types/node-vault-client`, remove it —
+it stops at the 1.x API and its declarations take precedence in some setups:
+
+```
+npm uninstall @types/node-vault-client
+```
+
 ## Example
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,125 @@
+export = VaultClient;
+
+declare class VaultClient {
+    constructor(options: VaultClient.VaultOptions);
+
+    static boot(name: string, options: VaultClient.VaultOptions): VaultClient;
+    static get(name: string): VaultClient;
+    static clear(name?: string): void;
+
+    read(path: string): Promise<VaultClient.Lease>;
+    list(path: string): Promise<VaultClient.Lease>;
+    write(path: string, data: Record<string, any>): Promise<any>;
+    delete(path: string): Promise<any>;
+    update(path: string, data: Record<string, any>): Promise<any>;
+    request(method: string, path: string, data?: Record<string, any>): Promise<any>;
+
+    deleteVersions(path: string, versions: number[]): Promise<any>;
+    undeleteVersions(path: string, versions: number[]): Promise<any>;
+    destroyVersions(path: string, versions: number[]): Promise<any>;
+    readMetadata(path: string): Promise<any>;
+    deleteMetadata(path: string): Promise<any>;
+
+    fillNodeConfig(): Promise<any>;
+    getHeaders(token: VaultClient.AuthToken): Record<string, string>;
+    close(): void;
+}
+
+declare namespace VaultClient {
+    interface Logger {
+        error(...args: any[]): void;
+        warn(...args: any[]): void;
+        info(...args: any[]): void;
+        debug(...args: any[]): void;
+        trace(...args: any[]): void;
+    }
+
+    interface ApiConfig {
+        url: string;
+        apiVersion?: string;
+        namespace?: string;
+        requestOptions?: Record<string, any>;
+        kv?: { autoDetect?: boolean };
+        engines?: Record<string, 1 | 2>;
+    }
+
+    interface AWSCredentials {
+        accessKeyId: string;
+        secretAccessKey: string;
+        sessionToken?: string;
+    }
+
+    interface TokenAuthConfig {
+        token: string;
+        namespace?: string;
+    }
+
+    interface AppRoleAuthConfig {
+        role_id: string;
+        secret_id?: string;
+        namespace?: string;
+    }
+
+    interface IAMAuthConfig {
+        role: string;
+        credentials?: AWSCredentials;
+        iam_server_id_header_value?: string;
+        region?: string;
+        namespace?: string;
+    }
+
+    interface KubernetesAuthConfig {
+        role: string;
+        tokenPath?: string;
+        namespace?: string;
+    }
+
+    interface JwtAuthConfigCommon {
+        role?: string;
+        namespace?: string;
+    }
+
+    type JwtAuthConfig = JwtAuthConfigCommon &
+        (
+            | { jwt: string; jwtPath?: never; jwtProvider?: never }
+            | { jwtPath: string; jwt?: never; jwtProvider?: never }
+            | { jwtProvider: () => string | Promise<string>; jwt?: never; jwtPath?: never }
+        );
+
+    interface AuthOptionsCommon {
+        mount?: string;
+        renewal?: boolean;
+        renewalFraction?: number;
+        renewalIncrement?: number;
+    }
+
+    type AuthOptions = AuthOptionsCommon &
+        (
+            | { type: 'token'; config: TokenAuthConfig }
+            | { type: 'appRole'; config: AppRoleAuthConfig }
+            | { type: 'iam'; config: IAMAuthConfig }
+            | { type: 'kubernetes'; config: KubernetesAuthConfig }
+            | { type: 'jwt'; config: JwtAuthConfig }
+        );
+
+    interface VaultOptions {
+        api: ApiConfig;
+        auth: AuthOptions;
+        logger?: Partial<Logger> | false;
+    }
+
+    interface Lease {
+        getValue<T = any>(key: string): T;
+        getData<T = Record<string, any>>(): T;
+        isRenewable(): boolean;
+        getMetadata(): Record<string, any> | undefined;
+    }
+
+    interface AuthToken {
+        getId(): string;
+        getAccessor(): string;
+        isExpired(): boolean;
+        isRenewable(): boolean;
+        getExpiresAt(): number | null;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "lodash": "^4.18.1",
         "mocha": "^11.7.6",
         "sinon": "^22.1.0",
-        "sinon-chai": "^4.0.1"
+        "sinon-chai": "^4.0.1",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2237,6 +2238,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
     "node": ">=18.0.0"
   },
   "main": "src/VaultClient.js",
+  "types": "index.d.ts",
   "files": [
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "mocha --exit \"test/**/*.test.mjs\"",
     "test:unit": "mocha \"test/*.test.mjs\"",
+    "test:types": "tsc -p types/tsconfig.json",
     "test:e2e": "mocha --exit \"test/e2e/e2e.test.mjs\"",
     "test:e2e:kv2": "mocha --exit \"test/e2e/e2e.kv2.test.mjs\"",
     "test:e2e:jwt": "mocha --exit \"test/e2e/e2e.jwt.test.mjs\"",
@@ -66,6 +69,7 @@
     "lodash": "^4.18.1",
     "mocha": "^11.7.6",
     "sinon": "^22.1.0",
-    "sinon-chai": "^4.0.1"
+    "sinon-chai": "^4.0.1",
+    "typescript": "^5.9.3"
   }
 }

--- a/src/errors.d.ts
+++ b/src/errors.d.ts
@@ -1,0 +1,18 @@
+export declare class VaultError extends Error {
+    constructor(message: string, options?: { cause?: unknown });
+    name: string;
+}
+
+export declare class InvalidArgumentsError extends VaultError {}
+
+export declare class InvalidAWSCredentialsError extends InvalidArgumentsError {}
+
+export declare class AuthTokenExpiredError extends VaultError {}
+
+export declare class UnsupportedOperationError extends VaultError {}
+
+export declare class VaultHttpError extends VaultError {
+    constructor(statusCode: number, text: string, body?: unknown);
+    statusCode: number;
+    error: unknown;
+}

--- a/types/errors.test-d.ts
+++ b/types/errors.test-d.ts
@@ -1,0 +1,42 @@
+import * as errors from '../src/errors';
+
+const base: errors.VaultError = new errors.VaultError('boom');
+const chained: errors.VaultError = new errors.VaultError('boom', { cause: new Error('root') });
+const args: errors.InvalidArgumentsError = new errors.InvalidArgumentsError('bad');
+const aws: errors.InvalidAWSCredentialsError = new errors.InvalidAWSCredentialsError('bad');
+const expired: errors.AuthTokenExpiredError = new errors.AuthTokenExpiredError('gone');
+const unsupported: errors.UnsupportedOperationError = new errors.UnsupportedOperationError('v2 only');
+const http: errors.VaultHttpError = new errors.VaultHttpError(403, 'permission denied', { errors: [] });
+
+const asError: Error = base;
+const asVaultError: errors.VaultError = args;
+const asInvalidArguments: errors.InvalidArgumentsError = aws;
+
+const status: number = http.statusCode;
+const body: unknown = http.error;
+const name: string = base.name;
+const message: string = base.message;
+
+const structurallyInterchangeable: errors.InvalidArgumentsError = base;
+
+function narrows(err: unknown): number {
+    if (err instanceof errors.VaultHttpError) {
+        return err.statusCode;
+    }
+    if (err instanceof errors.UnsupportedOperationError) {
+        return 0;
+    }
+    return -1;
+}
+
+void [structurallyInterchangeable, chained, expired, unsupported, asError, asVaultError, asInvalidArguments, status, body, name, message, narrows];
+
+// @ts-expect-error statusCode is a number
+const badStatus: string = http.statusCode;
+void badStatus;
+
+// @ts-expect-error VaultHttpError requires a status code and text
+new errors.VaultHttpError();
+
+// @ts-expect-error there is no such export
+new errors.NoSuchError('x');

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,0 +1,126 @@
+import VaultClient = require('../index');
+
+const client = new VaultClient({
+    api: { url: 'http://127.0.0.1:8200' },
+    auth: { type: 'token', config: { token: 't' } },
+});
+
+new VaultClient({
+    api: {
+        url: 'http://127.0.0.1:8200',
+        apiVersion: 'v1',
+        namespace: 'team-a',
+        requestOptions: { dispatcher: {} },
+        kv: { autoDetect: true },
+        engines: { secret: 2, legacy: 1 },
+    },
+    auth: {
+        type: 'appRole',
+        mount: 'approle',
+        renewal: true,
+        renewalFraction: 0.75,
+        renewalIncrement: 3600,
+        config: { role_id: 'r', secret_id: 's' },
+    },
+    logger: false,
+});
+
+new VaultClient({
+    api: { url: 'u' },
+    auth: { type: 'iam', config: { role: 'r', region: 'eu-west-1', credentials: { accessKeyId: 'a', secretAccessKey: 'b', sessionToken: 'c' } } },
+});
+
+new VaultClient({ api: { url: 'u' }, auth: { type: 'kubernetes', config: { role: 'r', tokenPath: '/var/run/x' } } });
+new VaultClient({ api: { url: 'u' }, auth: { type: 'jwt', config: { jwt: 'e.y.z' } } });
+new VaultClient({ api: { url: 'u' }, auth: { type: 'jwt', config: { role: 'r', jwtPath: '/tmp/jwt' } } });
+new VaultClient({ api: { url: 'u' }, auth: { type: 'jwt', config: { jwtProvider: async () => 'e.y.z' } } });
+new VaultClient({ api: { url: 'u' }, auth: { type: 'jwt', config: { jwtProvider: () => 'e.y.z' } } });
+
+new VaultClient({
+    api: { url: 'u' },
+    auth: { type: 'token', config: { token: 't' } },
+    logger: { error() {}, warn() {}, info() {}, debug() {}, trace() {} },
+});
+
+const booted: VaultClient = VaultClient.boot('main', { api: { url: 'u' }, auth: { type: 'token', config: { token: 't' } } });
+const got: VaultClient = VaultClient.get('main');
+VaultClient.clear('main');
+VaultClient.clear();
+
+async function surface(): Promise<void> {
+    const lease: VaultClient.Lease = await client.read('secret/app');
+    const str: string = lease.getValue('key');
+    const num: number = lease.getValue<number>('port');
+    const data: Record<string, any> = lease.getData();
+    const renewable: boolean = lease.isRenewable();
+    const meta: Record<string, any> | undefined = lease.getMetadata();
+
+    await client.list('secret/');
+    await client.write('secret/app', { a: 1 });
+    await client.delete('secret/app');
+    await client.update('secret/app', { a: 2 });
+    await client.request('GET', 'sys/health');
+    await client.request('POST', 'sys/x', { a: 1 });
+
+    await client.deleteVersions('secret/app', [1, 2]);
+    await client.undeleteVersions('secret/app', [1]);
+    await client.destroyVersions('secret/app', [1]);
+    await client.readMetadata('secret/app');
+    await client.deleteMetadata('secret/app');
+
+    await client.fillNodeConfig();
+    client.close();
+
+    void [booted, got, str, num, data, renewable, meta];
+}
+
+void surface;
+
+async function readmeExample(): Promise<void> {
+    const c = new VaultClient({
+        api: { url: 'http://127.0.0.1:8200' },
+        auth: { type: 'appRole', config: { role_id: 'roleId', secret_id: 'secretId' } },
+    });
+
+    const lease = await c.read('secret/app');
+    const password = lease.getValue<string>('password');
+    void password;
+}
+
+void readmeExample;
+
+// @ts-expect-error the sibling classes are not exported at runtime
+new VaultClient.Lease();
+
+// @ts-expect-error AuthToken is a type, not a runtime value
+new VaultClient.AuthToken();
+
+// @ts-expect-error api.url is required
+new VaultClient({ api: {}, auth: { type: 'token', config: { token: 't' } } });
+
+// @ts-expect-error unknown auth backend
+new VaultClient({ api: { url: 'u' }, auth: { type: 'ldap', config: {} } });
+
+// @ts-expect-error token auth requires a token
+new VaultClient({ api: { url: 'u' }, auth: { type: 'token', config: {} } });
+
+// @ts-expect-error appRole requires role_id
+new VaultClient({ api: { url: 'u' }, auth: { type: 'appRole', config: { secret_id: 's' } } });
+
+// @ts-expect-error exactly one JWT source may be supplied
+new VaultClient({ api: { url: 'u' }, auth: { type: 'jwt', config: { jwt: 'a', jwtPath: '/b' } } });
+
+// @ts-expect-error a JWT source is required
+new VaultClient({ api: { url: 'u' }, auth: { type: 'jwt', config: { role: 'r' } } });
+
+// @ts-expect-error renewalFraction is a number
+new VaultClient({ api: { url: 'u' }, auth: { type: 'token', config: { token: 't' }, renewalFraction: '0.5' } });
+
+// @ts-expect-error logger accepts an object or false, not true
+new VaultClient({ api: { url: 'u' }, auth: { type: 'token', config: { token: 't' } }, logger: true });
+
+// @ts-expect-error boot requires options
+VaultClient.boot('x');
+
+// @ts-expect-error versions must be numbers
+void client.deleteVersions('secret/app', ['1']);

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "lib": ["ES2020"],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "strict": true,
+        "noEmit": true,
+        "types": [],
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": ["../index.d.ts", "../src/errors.d.ts", "index.test-d.ts", "errors.test-d.ts"]
+}


### PR DESCRIPTION
Closes #159

## Problem

The package shipped no TypeScript declarations, so TypeScript consumers fell back to `@types/node-vault-client`, published on DefinitelyTyped at **1.0.1** while this package is on **2.x**.

Those declarations describe roughly half the current API, and one part of them describes an API that does not exist:

```ts
declare namespace VaultClient {
    export { AuthToken, Lease, VaultError, VaultApiClient, /* ... */ };
}
```

The entry point is a plain class export, so this type-checks and then throws:

```
$ node -e "const V=require('node-vault-client'); console.log(typeof V, V.Lease)"
function undefined
```

Also missing there: the `jwt` backend, `close()`, `delete()`/`update()`/`request()`, every KV v2 version and metadata method, `api.namespace`/`api.kv`/`api.engines`/`api.requestOptions`, the renewal options, `UnsupportedOperationError`/`VaultHttpError`, and `logger: false`. `write()` is typed `Promise<void>` there but resolves to the parsed response body.

## Change

`index.d.ts` declaring the real surface and only the real surface, referenced by `types` and added to `files`.

- `auth` is a discriminated union on `type`, so each backend accepts only its own config.
- The three mutually-exclusive JWT sources (`jwt`, `jwtPath`, `jwtProvider`) are enforced at compile time, matching the runtime validation.
- Types appearing in signatures (`Lease`, `AuthToken`, `VaultOptions`, the per-backend configs) are exposed in **type space** under the `VaultClient` namespace — not as values, because the classes behind them are not exported at runtime.

## Typed to the runtime, not to the JSDoc

Two places where the runtime is wider than the JSDoc are typed to the runtime, so no working consumer is newly rejected:

- **`credentials.sessionToken`** is absent from the `AWSCredentials` typedef but honored — `credentials` is passed straight to `aws4.sign`, which reads `sessionToken`, and the validator only rejects arrays. Omitting it would break every STS/temporary-credential user.
- **`Lease.getValue()`** is documented `@returns {String}` but returns whatever KV stored, which for KV v2 preserves JSON types. It is generic with an `any` default (`getValue<T = any>`), so existing `const s: string = lease.getValue(k)` still compiles and `getValue<number>(k)` is available.

## Verification

`npm run test:types` compiles positive usage together with `@ts-expect-error` cases, and runs in the `lint` job. `tsc` reports an unused `@ts-expect-error` as an error, so a signature that stops rejecting bad input fails the build.

Stripping the 12 directives produces 13 errors, confirming every negative case is real rather than decorative.

End-to-end, against the packed tarball installed into a clean project:

```
npm notice 3.8kB index.d.ts          # present in the tarball
PASS — types resolved from node_modules
```

and the same installed package rejects bad usage:

```
bad.ts(2,59): error TS2322: Types of property 'jwtPath' are incompatible.
bad.ts(3,46): error TS2322: Type '"ldap"' is not assignable to type '"token" | "appRole" | "iam" | "kubernetes" | "jwt"'.
bad.ts(4,17): error TS2339: Property 'Lease' does not exist on type 'typeof VaultClient'.
```

That last one is the DefinitelyTyped defect, now caught at compile time.

## Behaviour

Unchanged. `.d.ts` files are erased at compile time and **no file under `src/` is touched** — `git diff origin/master -- src/` is empty. Unit tests still 376 passing; lint clean.

## Docs

README gains a TypeScript section under Requirements, including the note to uninstall `@types/node-vault-client`. The README's example is itself compiled as a type test so it cannot drift. CHANGELOG entry added.
---

## Backward compatibility (added after review feedback)

Shipping a `types` field makes these declarations take precedence over `@types/node-vault-client`, so a declaration stricter than the old one is a **compile break** for an existing TypeScript consumer even though nothing changes at runtime. I tested that directly rather than assuming, compiling usage that the third-party types accepted **and** that works at runtime.

Two cases were newly rejected and have been relaxed:

- **A partial `logger` object.** At runtime `__setupLogger` requires all five methods and silently falls back to `console` otherwise — so `{ error, warn, info }` works today. Typed `Partial<Logger> | false` rather than `Logger | false`.
- **Methods returning a Vault response body.** The old types declared `write()` and `fillNodeConfig()` as `Promise<void>`, so `async function f(): Promise<void> { return client.write(...) }` compiled. `Promise<Record<string, any>>` broke that; these are now `Promise<any>`, which stays assignable to `Promise<void>` while still allowing the body to be used. `getHeaders()` likewise returns `Record<string, string>` so any header key can be read, as before.

`read()`/`list()` keep the precise `Promise<Lease>` (unchanged from the old types).

What remains rejected is only usage that **cannot work at runtime**: an unknown `auth.type` (throws `Unsupported auth method`), two JWT sources at once (throws `InvalidArgumentsError`), `logger: true` (silently ignored), and `new VaultClient.Lease(...)` (`undefined` at runtime).

One judgment call left for review: `boot(name, options)` types `options` as **required**, where the old types had it optional. `boot(name)` throws `InvalidArgumentsError` at runtime, so no working code is affected — but it will fail a build that never exercised that path. Say the word and I will make it optional.

---

## Also closes #165 — declarations for the error classes

`src/errors.d.ts` was added here rather than as a separate PR, because this PR introduces the `tsconfig`, the `typescript` devDependency, the `test:types` script and the CI step that verify it. A standalone PR would either duplicate that infrastructure (a certain conflict in `package.json` and `types/`) or ship declarations nothing type-checks.

It matters more since #162: that PR documents `require('node-vault-client/src/errors')` as *the* way to reach the error classes, since the entry point exports only `VaultClient`. Under `strict`, the documented path was the one TypeScript rejected:

```
error TS7016: Could not find a declaration file for module 'node-vault-client/src/errors'.
```

Verified from a packed tarball in a clean project — `src/errors.d.ts` is published (`files` already covers `src`), the import compiles under `strict`, and `instanceof` narrowing works for each class.

One honest limitation: `InvalidArgumentsError extends VaultError {}` and friends add no members, so TypeScript treats them as **structurally interchangeable for assignment**. `instanceof` narrowing still works, which is what the catch-block idiom needs. I removed a negative test that asserted otherwise rather than adding a private brand field to fake nominal typing — a brand would declare a property the runtime does not have, and would be narrower than the classes actually are.

No existing file under `src/` is modified; the only addition there is a `.d.ts`, erased at compile time.