### PR TITLE
docs: document how to import the error classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@
   the non-interactive `jwt` flow is implemented; the browser-redirect `oidc` flow is out of
   scope for this service client. See the README's "JWT auth" section.
 
+- Documented how to import the error classes (#161). The README named
+  `UnsupportedOperationError` in eight places and `VaultError` in the error table, but nothing in
+  the repository showed a consumer how to obtain either: the only `require` of the errors module
+  was the example app's in-tree relative path. The `Error classes` section now gives the
+  `node-vault-client/src/errors` import with a worked `instanceof` example, and the table lists
+  all six exported classes with what raises each; it previously listed two. Two tests guard it:
+  one fails if `files` would stop publishing `src/errors.js`, and one fails if a class is exported
+  but missing from the README table. No runtime change, and no `exports` field was added, so every
+  existing deep import keeps working.
+
 # 2.1.2 Release notes (2026-08-03)
 
 - Internal refactor: `VaultBaseAuth` no longer overloads a single `__authToken` field with two

--- a/README.md
+++ b/README.md
@@ -755,10 +755,31 @@ await client.request('GET', 'secret/data/foo');
 
 ### Error classes
 
-| Class | When thrown |
-|---|---|
-| `UnsupportedOperationError` | A v2-only method (`deleteVersions`, `undeleteVersions`, `destroyVersions`, `readMetadata`, `deleteMetadata`) is called against a non-v2 mount. |
-| `VaultError` | Mount detection fails (e.g. permission denied) and no `api.engines` override was provided. |
+Every error the client raises extends `VaultError`. The package entry point exports the
+`VaultClient` class only, so the classes themselves are imported from `node-vault-client/src/errors`:
+
+```javascript
+const errors = require('node-vault-client/src/errors');
+
+try {
+    await client.readMetadata('secret/app');
+} catch (err) {
+    if (err instanceof errors.UnsupportedOperationError) {
+        // the mount did not resolve as KV v2 - see "Path requirements" above
+        return null;
+    }
+    throw err;
+}
+```
+
+| Class | Extends | When thrown |
+|---|---|---|
+| `VaultError` | `Error` | Base class for every error below. Raised directly when mount detection fails (e.g. permission denied) and no `api.engines` override was provided. |
+| `VaultHttpError` | `VaultError` | Vault answered with a non-2xx status. Carries the status as `statusCode` and the parsed body as `error`. |
+| `InvalidArgumentsError` | `VaultError` | Bad arguments or configuration: `boot()` called without options, an unknown instance name passed to `get()`, an unsupported `auth.type`, invalid renewal options, or an invalid node-config substitution map. |
+| `InvalidAWSCredentialsError` | `InvalidArgumentsError` | `auth.config.credentials` was supplied but is not a usable `accessKeyId` / `secretAccessKey` pair. |
+| `AuthTokenExpiredError` | `VaultError` | The Vault token expired and the backend cannot obtain a new one. `token` auth can never re-authenticate; other backends reach this only with `renewal: false` and a credential they cannot replay. |
+| `UnsupportedOperationError` | `VaultError` | A v2-only method (`deleteVersions`, `undeleteVersions`, `destroyVersions`, `readMetadata`, `deleteMetadata`) was called against a mount that did not resolve as KV v2. |
 
 ## Contributing
 

--- a/test/errors.test.mjs
+++ b/test/errors.test.mjs
@@ -1,5 +1,8 @@
+import { readFileSync } from 'node:fs';
 import { expect } from 'chai';
 import errors from '../src/errors.js';
+
+const readRepoFile = (name) => readFileSync(new URL(`../${name}`, import.meta.url), 'utf8');
 
 describe('errors', function () {
     it('exposes the expected error classes', function () {
@@ -91,5 +94,27 @@ describe('errors', function () {
             expect(err.message).to.equal('500 - ');
             expect(err.error).to.equal(undefined);
         });
+    });
+});
+
+describe('documented import path', function () {
+    it('publishes src/errors.js, which the README gives as the import path', function () {
+        const pkg = JSON.parse(readRepoFile('package.json'));
+        const published = pkg.files.some((entry) => ['src', 'src/', 'src/errors.js'].includes(entry));
+
+        expect(
+            published,
+            `package.json "files" (${pkg.files.join(', ')}) must publish src/errors.js`
+        ).to.equal(true);
+    });
+
+    it('documents every exported class in the README', function () {
+        const readme = readRepoFile('README.md');
+        const section = readme.slice(readme.indexOf('### Error classes')).split(/^## /m)[0];
+
+        expect(section).to.contain('### Error classes');
+        for (const name of Object.keys(errors)) {
+            expect(section, `${name} is exported but missing from the README table`).to.contain(name);
+        }
     });
 });


### PR DESCRIPTION
Closes #161

## Problem

The README tells you which errors the client raises but never tells you how to get hold of one. `UnsupportedOperationError` is named in eight places ("rejects with `UnsupportedOperationError` on non-v2 mounts"), and the `Error classes` table documented it and `VaultError` — yet there is no `require`/`import` line for the errors module anywhere in `README.md` or `CONTRIBUTING.md`.

The only usage in the repository is the example app's in-tree relative path:

```js
const errors = require('../../src/errors.js');   // examples/jwt-auth/vault-jwt-demo.mjs:19
```

which a consumer cannot copy. So every documented statement about catchable errors was unactionable, and a TypeScript consumer got nothing at all:

```
error TS7016: Could not find a declaration file for module 'node-vault-client/src/errors'.
```

## Change

The capability already exists — `files` includes `src`, so `node-vault-client/src/errors` resolves — which makes this purely a documentation gap.

- The `Error classes` section now gives that import with a worked `instanceof` example for the case the README already describes (a v2-only method against a v1 mount).
- The table lists **all six** exported classes with what raises each, and the class each extends. It previously listed two of six; `InvalidArgumentsError`, `InvalidAWSCredentialsError`, `AuthTokenExpiredError` and `VaultHttpError` are raised by documented paths but were absent.

## Guards

Two tests in `test/errors.test.mjs`, both confirmed to fail when falsified rather than assumed to work:

| Guard | Falsified by | Result |
|---|---|---|
| `files` still publishes `src/errors.js` | narrowing `files` to `["src/VaultClient.js"]` | `package.json "files" (src/VaultClient.js) must publish src/errors.js` |
| every exported class appears in the README table | deleting the `VaultHttpError` row | `VaultHttpError is exported but missing from the README table` |

The second guard is the one that matters: table drift is exactly what produced this gap.

## Verified end to end

The documented snippet was run **verbatim** from a packed tarball installed into a clean project, against the compose KV v1 server:

```
README snippet works verbatim -> Operation "readMetadata" is only supported on KV v2 mounts.
                                 Mount "secret" is not a KV v2 engine.
```

So the deep import resolves from `node_modules`, `instanceof` matches, and the message is the documented one.

Worth noting: `readMetadata()` authenticates *before* the KV-version check, so this needs a reachable Vault — an offline reproduction fails with `fetch failed` instead, which is why it is verified against the compose server rather than in a unit test.

## Behaviour

Unchanged. Documentation and tests only — `git diff origin/master -- src/` is empty. **No `exports` field was added**: doing so would restrict subpath imports and break existing deep importers. 378 unit tests pass; lint clean.

## Not included

TypeScript declarations for this path (`src/errors.d.ts`) would close the `TS7016` above, but the type-check infrastructure lands in #160. Better placed there than duplicated here, where a second `tsconfig` would conflict.
