### PR TITLE
docs: list Lease.getMetadata() and guard public-API doc coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,9 @@ accessors to extract the secret data:
 * `getValue(key)` ⇒ <code>String</code> — value for a single key. Throws `Requested key does not exist` when the key is absent.
 * `getData()` ⇒ <code>Object</code> — a deep-cloned copy of the whole secret data object.
 * `isRenewable()` ⇒ <code>boolean</code> — whether the underlying lease is renewable.
+* `getMetadata()` ⇒ <code>Object</code> | <code>undefined</code> — KV v2 version metadata
+  (`version`, `created_time`, `deletion_time`, `destroyed`, `custom_metadata`), or `undefined`
+  on KV v1 and non-KV mounts. See [Lease.getMetadata()](#leasegetmetadata).
 
 <a name="VaultClient.boot"></a>
 

--- a/test/docs.public-api.test.mjs
+++ b/test/docs.public-api.test.mjs
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { expect } from 'chai';
+import VaultClient from '../src/VaultClient.js';
+import Lease from '../src/Lease.js';
+
+const README = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+// getHeaders is called only from inside VaultClient and takes an AuthToken, which the
+// entry point does not export, so a consumer cannot call it.
+const NOT_PUBLIC_SURFACE = ['getHeaders'];
+
+function publicMethods(klass) {
+    return Object.getOwnPropertyNames(klass.prototype)
+        .filter((name) => name !== 'constructor' && !name.startsWith('__'));
+}
+
+function leaseSection() {
+    const heading = '### Lease';
+    const rest = README.slice(README.indexOf(heading) + heading.length);
+    const next = rest.search(/^#{1,3} /m);
+
+    return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe('public API documentation', function () {
+    it('gives every VaultClient instance method a README heading', function () {
+        for (const name of publicMethods(VaultClient)) {
+            if (NOT_PUBLIC_SURFACE.includes(name)) {
+                continue;
+            }
+
+            expect(README, `vaultClient.${name}() has no "#### vaultClient.${name}(" heading`)
+                .to.contain(`#### vaultClient.${name}(`);
+        }
+    });
+
+    it('gives every VaultClient static method a README heading', function () {
+        const statics = Object.getOwnPropertyNames(VaultClient)
+            .filter((name) => typeof VaultClient[name] === 'function');
+
+        for (const name of statics) {
+            expect(README, `VaultClient.${name}() has no "#### VaultClient.${name}(" heading`)
+                .to.contain(`#### VaultClient.${name}(`);
+        }
+    });
+
+    it('lists every Lease accessor in the Lease section', function () {
+        const section = leaseSection();
+
+        for (const name of publicMethods(Lease)) {
+            expect(section, `Lease.${name}() is missing from the "### Lease" section`)
+                .to.contain(name);
+        }
+    });
+});


### PR DESCRIPTION
Closes #163

## Problem

The README's `### Lease` section is the API reference for the object `read()` and `list()` resolve to, and it listed three of the four accessors:

```
* `getValue(key)`  ⇒ String  — value for a single key.
* `getData()`      ⇒ Object  — a deep-cloned copy of the whole secret data object.
* `isRenewable()`  ⇒ boolean — whether the underlying lease is renewable.
```

`getMetadata()` was documented, but only in a `### Lease.getMetadata()` subsection ~400 lines further down inside "KV v2 & generic backends", with no cross-reference from the API list.

## Change

`getMetadata()` added to the list, summarising the existing subsection and linking to it. The wording matches both that subsection and the source JSDoc (`@returns {Object|undefined}`, "Returns undefined for KV v1 / non-KV leases") rather than being reworded independently.

## The guard

This is the fourth documentation-drift defect filed here — #150, #154, #161, and this one. Each was a divergence between code and docs that nothing detected. The public surface is small and stable enough to assert against directly, so `test/docs.public-api.test.mjs` iterates the **actual exported methods** and requires a README heading for each.

Run against `master`, it finds exactly two things:

```
VaultClient instance methods with no '#### vaultClient.<m>(' heading : ['getHeaders']
VaultClient statics with no '#### VaultClient.<m>(' heading          : none
Lease methods missing from the '### Lease' section                   : ['getMetadata']
```

so this is a narrow fix plus a guard, not a documentation project.

`getHeaders()` is excluded by name — it is called only from inside `VaultClient` (lines 267, 304) and takes an `AuthToken`, which the entry point does not export, so a consumer cannot construct one to call it.

## Falsified in both directions

A coverage assertion that cannot fail is worse than none, so each was broken deliberately:

| Falsification | Result |
|---|---|
| rename the `#### vaultClient.close(` heading | `vaultClient.close() has no "#### vaultClient.close(" heading` |
| rename the `#### VaultClient.clear(` heading | `VaultClient.clear() has no "#### VaultClient.clear(" heading` |
| delete the `getMetadata` bullet | `Lease.getMetadata() is missing from the "### Lease" section` |
| **add an undocumented public method to `VaultClient`** | `vaultClient.purgeCache() has no "#### vaultClient.purgeCache(" heading` |

The last row is the direction the guard exists for: it reads the code side, not just the README side, so a new public method cannot ship undocumented. `src/` was restored afterwards and is untouched in this PR.

## Behaviour

Unchanged. Documentation and tests only — `git diff origin/master -- src/` is empty. 379 unit tests pass; lint clean.

## No CHANGELOG entry

Matching #151 and #155, the other documentation/CI-only changes in the queue, which carry none. It also avoids a certain conflict: all four paragraph boundaries in the `# Unreleased` section are already claimed by #147, #148, #160 and #162, so a fifth entry there could not merge cleanly with the rest.
