### PR TITLE
ci: verify the packed artifact before it can reach npm

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -189,3 +189,22 @@ jobs:
 
       - name: Run KV v2 e2e tests
         run: npm run test:e2e:kv2
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Packs the repo, installs the tarball into a throwaway project and requires it, so a
+      # `files` omission fails here instead of reaching npm.
+      - name: Verify the packed artifact
+        run: node test/verify-package.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,5 +44,14 @@ jobs:
             exit 1
           fi
 
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Verify the packed artifact
+        run: node test/verify-package.mjs
+
       - name: Publish
         run: npm publish --provenance --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,12 @@ code you change. Mock HTTP interactions with sinon — **never** use real Vault 
 credentials in unit tests. The integration and `test/e2e` suites talk to the dev Vault started by
 `docker compose up -d`.
 
+The published artifact is checked separately, because the suites run against the working tree and
+cannot see what `npm pack` includes. `node test/verify-package.mjs` packs the repository, installs
+the tarball into a throwaway project and requires it, so an artifact left out of `package.json`'s
+`files` fails there rather than reaching npm. CI runs it on every pull request, and again before
+publishing.
+
 ## DCO sign-off
 
 This project uses the [Developer Certificate of Origin](https://developercertificate.org/). Add

--- a/test/verify-package.mjs
+++ b/test/verify-package.mjs
@@ -1,0 +1,83 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, renameSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repo = dirname(dirname(fileURLToPath(import.meta.url)));
+const run = (cmd, args, cwd) => execFileSync(cmd, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+
+const checks = [
+    {
+        name: 'entry point loads and exposes the documented statics',
+        source: `
+            const VaultClient = require('node-vault-client');
+            assert.strictEqual(typeof VaultClient, 'function');
+            for (const name of ['boot', 'get', 'clear']) {
+                assert.strictEqual(typeof VaultClient[name], 'function', name + ' is missing');
+            }
+        `,
+    },
+    {
+        name: 'a client can be constructed',
+        source: `
+            const VaultClient = require('node-vault-client');
+            const client = new VaultClient({
+                api: { url: 'http://127.0.0.1:8200' },
+                auth: { type: 'token', config: { token: 't' } },
+                logger: false,
+            });
+            assert.strictEqual(typeof client.read, 'function');
+            client.close();
+        `,
+    },
+    {
+        name: 'the errors subpath resolves with every class',
+        source: `
+            const errors = require('node-vault-client/src/errors');
+            const expected = [
+                'VaultError', 'InvalidArgumentsError', 'InvalidAWSCredentialsError',
+                'AuthTokenExpiredError', 'UnsupportedOperationError', 'VaultHttpError',
+            ];
+            assert.deepStrictEqual(Object.keys(errors).sort(), expected.slice().sort());
+            assert.ok(new errors.UnsupportedOperationError('x') instanceof errors.VaultError);
+        `,
+    },
+];
+
+const workdir = mkdtempSync(join(tmpdir(), 'nvc-verify-package-'));
+
+try {
+    const tarball = run('npm', ['pack', '--silent'], repo).trim().split('\n').pop();
+    renameSync(join(repo, tarball), join(workdir, tarball));
+
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ name: 'nvc-verify-package', private: true }));
+    run('npm', ['install', '--no-audit', '--no-fund', `./${tarball}`], workdir);
+
+    let failed = 0;
+
+    for (const check of checks) {
+        const file = join(workdir, `${checks.indexOf(check)}.cjs`);
+        writeFileSync(file, `const assert = require('node:assert');\n${check.source}`);
+
+        try {
+            run('node', [file], workdir);
+            process.stdout.write(`  ok    ${check.name}\n`);
+        } catch (err) {
+            failed += 1;
+            process.stdout.write(`  FAIL  ${check.name}\n`);
+            const output = (err.stderr || err.message).trim().split('\n');
+            const cause = output.filter((line) => /Error|Cannot find module/.test(line)).slice(0, 2);
+            process.stdout.write(`${(cause.length ? cause : output.slice(0, 2)).map((l) => `        ${l.trim()}`).join('\n')}\n`);
+        }
+    }
+
+    process.stdout.write(`\n  ${checks.length - failed}/${checks.length} checks passed against the packed tarball\n`);
+
+    if (failed > 0) {
+        process.stdout.write('\n  The published package would be broken. Check the "files" list in package.json.\n');
+        process.exitCode = 1;
+    }
+} finally {
+    rmSync(workdir, { recursive: true, force: true });
+}


### PR DESCRIPTION
Closes #166

## Problem

Nothing checked what npm actually publishes. The test suites run against the working tree, so they cannot see what `npm pack` includes, and `publish.yml` ran no tests at all before `npm publish`.

Demonstrated rather than asserted — narrowing `files` to `["src/VaultClient.js"]`, the shape of mistake made by adding a top-level artifact and forgetting to list it:

```
1) does the unit suite notice?
     376 passing (133ms)

2) does the packed artifact actually work?
     Error: Cannot find module './Lease'
```

A completely broken package, and a green build.

This is live, not theoretical. `files` is `["src"]`, so anything added outside `src/` must be listed explicitly or it is silently dropped — #160 adds `index.d.ts` at the root, and that was caught by hand with `npm pack --dry-run`, not by CI. #162 added a narrow guard for one file (`src/errors.js`); this generalises it.

The failure mode is also the worst kind: with no test gate on publish, the first person to notice is a consumer whose install is broken, and a published version cannot be replaced.

## Change

`test/verify-package.mjs` packs the repository, installs the tarball into a throwaway project, and requires it:

```
  ok    entry point loads and exposes the documented statics
  ok    a client can be constructed
  ok    the errors subpath resolves with every class

  3/3 checks passed against the packed tarball
```

It runs as its own `package` job in `pipeline.yaml`, so a packaging mistake fails the PR that introduces it, and again in `publish.yml` — alongside `lint` and the unit tests — so a release cannot ship an artifact nothing verified.

## Falsified

| Falsification | Result |
|---|---|
| `files: ["src/VaultClient.js"]` | `Error: Cannot find module './Lease'`, exit 1 |
| `files: ["src", "!src/errors.js"]` | `Error: Cannot find module 'node-vault-client/src/errors'`, exit 1 |

Worth being precise about the second: excluding `errors.js` breaks **all three** checks, not just the subpath one, because `VaultClient.js` requires it. So that case does not isolate the third check — it shows the module is a hard dependency of the entry point.

I also fixed the failure output on the way: it first printed Node's loader preamble (`throw err;`) instead of the cause, which defeats the purpose of the check. It now names the missing module.

## Deliberate omissions

- **No npm script alias.** The `scripts` block is eight lines, and #155 and #160 both already insert into it; a third insertion would conflict. Invoked with `node` for now, with an alias worth adding once the queue drains.
- **No CHANGELOG entry**, matching #153 and #155, the other CI-only changes.

Both choices were checked: this branch merges cleanly with #151 (the other `CONTRIBUTING.md` change) and with the rest of the queue.

## Behaviour

Unchanged. CI, a new test helper, and one CONTRIBUTING paragraph — `git diff -- src/` is empty. 376 unit tests pass; lint clean.
