### PR TITLE
TEMP: verify the ci-ok gate fails when a job fails

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -208,3 +208,22 @@ jobs:
       # `files` omission fails here instead of reaching npm.
       - name: Verify the packed artifact
         run: node test/verify-package.mjs
+
+  # Single aggregate gate, so branch protection needs one context instead of matrix-derived
+  # names that change whenever the Node or Vault matrix changes (see issue #168).
+  ci-ok:
+    if: always()
+    needs: [audit, lint, coverage, test, e2e, e2e-kv2, package]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report job results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: printf '%s\n' "$RESULTS"
+
+      - name: Fail unless every job succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: |
+          echo "::error::one or more pipeline jobs did not succeed"
+          exit 1
+

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -23,6 +23,9 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
+      - name: DELIBERATE FAILURE to prove ci-ok can fail
+        run: exit 1
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Use Node.js 20

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -211,22 +211,3 @@ jobs:
       # `files` omission fails here instead of reaching npm.
       - name: Verify the packed artifact
         run: node test/verify-package.mjs
-
-  # Single aggregate gate, so branch protection needs one context instead of matrix-derived
-  # names that change whenever the Node or Vault matrix changes (see issue #168).
-  ci-ok:
-    if: always()
-    needs: [audit, lint, coverage, test, e2e, e2e-kv2, package]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Report job results
-        env:
-          RESULTS: ${{ toJSON(needs) }}
-        run: printf '%s\n' "$RESULTS"
-
-      - name: Fail unless every job succeeded
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
-        run: |
-          echo "::error::one or more pipeline jobs did not succeed"
-          exit 1
-

--- a/test/verify-package.mjs
+++ b/test/verify-package.mjs
@@ -81,3 +81,4 @@ try {
 } finally {
     rmSync(workdir, { recursive: true, force: true });
 }
+


### PR DESCRIPTION
Temporary draft to prove the `ci-ok` aggregate gate added in #167 actually fails when a job fails. `audit` is made to `exit 1` deliberately. Will be closed and the branch deleted once observed.