### PR TITLE
ci: add a single aggregate gate for branch protection

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -208,3 +208,22 @@ jobs:
       # `files` omission fails here instead of reaching npm.
       - name: Verify the packed artifact
         run: node test/verify-package.mjs
+
+  # Single aggregate gate, so branch protection needs one context instead of matrix-derived
+  # names that change whenever the Node or Vault matrix changes (see issue #168).
+  ci-ok:
+    if: always()
+    needs: [audit, lint, coverage, test, e2e, e2e-kv2, package]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report job results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: printf '%s\n' "$RESULTS"
+
+      - name: Fail unless every job succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: |
+          echo "::error::one or more pipeline jobs did not succeed"
+          exit 1
+


### PR DESCRIPTION
Closes #168

## Problem

Four of `master`'s required status checks can never report, so no pull request can satisfy branch protection and every merge has to bypass it:

```
required_status_checks.strict : true
required approving reviews    : 1
enforce_admins                : false

satisfied      : DCO, audit, lint, test (18), test (20), test (22), test (24)
UNSATISFIABLE  : e2e (18), e2e (20), e2e (22), e2e (24)
```

The e2e job reports as `e2e (node 18, vault 1.21)`. Commit `2b8bdd6` added the `vault-version` matrix dimension, and a matrix job's check name is derived from its matrix values, so all four contexts were renamed while protection kept naming the old ones. Nothing failed — the checks stopped being *reported* rather than reporting a failure — so the pipeline stayed green throughout and the gate quietly disarmed.

## Why re-pinning the names is the wrong fix

Replacing the four contexts with the five current ones restores the gate but leaves the same trap armed: the names embed `vault 1.21`, and `docker-compose.yml` deliberately tracks the newest patch of the minor line, so the next *minor* bump renames them again. The same applies to any Node matrix change. Coupling branch protection to matrix values is the defect.

## Change

`ci-ok` depends on every job in the pipeline and fails unless all of them succeeded. `needs` on a matrix job waits for every leg and aggregates the result, so matrix changes never touch protection again. Adding a *new* job still requires extending `needs` — a visible one-line edit in this file rather than an invisible settings change.

It also widens the gate: `coverage`, `e2e-kv2`, `package` and the real `e2e` legs currently run without being required at all.

## Sequencing

Protection can only be updated **after** this merges, once `ci-ok` exists and has reported. Suggested contexts afterwards: `ci-ok` and `DCO`.

## Verification

`ci-ok` passing on this PR shows the success path. The failure path is verified separately by temporarily breaking a job on this branch and confirming `ci-ok` goes red — see the check history on this PR. **It should not become the sole required check until that red run is visible**, since a gate that cannot fail is worse than no gate.

## Behaviour

No runtime change; CI only.