### PR TITLE
fix: restore the deliberate `config` peer-dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "config": "^3.3.12"
+        "config": ">=1 <4"
       }
     },
     "node_modules/@aws-sdk/core": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "long-timeout": "^0.1.1"
   },
   "peerDependencies": {
-    "config": "^3.3.12"
+    "config": ">=1 <4"
   },
   "overrides": {
     "serialize-javascript": "^7.0.7",


### PR DESCRIPTION
## Regression

`6b65acb` (merged via #151) narrowed the `config` peer range in `package.json` and `package-lock.json`:

```diff
-    "config": ">=1 <4"
+    "config": "^3.3.12"
```

That was **accidental and mine**. While verifying the commands #151 documents, I ran `npm install config` — which wrote the resolved version back into the manifest — and `git commit -a` swept it in with the intended `CONTRIBUTING.md` change. I caught it and force-pushed a corrected commit, but #151 had already been merged from the earlier head, so the fix never landed.

## Why it matters

The wide range is deliberate, and `CONTRIBUTING.md` records why:

- the **ceiling** is `<4` because config 4 requires Node >=20, while this package still supports Node 18 (`engines: >=18`)
- the **floor** of `>=1` is what lets consumers already on config 1.x or 2.x satisfy the peer dependency

`^3.3.12` excludes both ends. Installing a release built from current `master` alongside config 1.x or 2.x would raise a peer conflict that did not exist in 2.1.2 — a break for existing consumers, in a package where the node-config integration is a documented feature.

## Change

The two lines, nothing else. `git diff --numstat` is `+1 -1` in each file.

Verified after restoring: `npm ci` clean, lint clean, 388 unit passing, `verify-package` 3/3.

## Preventing a repeat

The trigger was `npm install <pkg>` during local verification. `npm install --no-save config` avoids it; `npm ci` alone never rewrites the manifest.