### PR TITLE
docs: document transport timeouts, redirect token forwarding, undici compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Unreleased
 
+- Documented three things about the HTTP transport that were true but unwritten, and scoped the
+  `version` npm hook. No runtime change. `api.requestOptions` now carries a note that the `undici`
+  you install has to be interface-compatible with the one Node bundles: on Node 24 a dispatcher
+  from `undici@8` is rejected by the global `fetch()` with `cause.code` of
+  `invalid onRequestStart method` before the request leaves the process, so the proxy and
+  self-signed-CA recipes need `undici@^7`. A new "Request timeouts" section records that there is
+  no default timeout — a Vault that accepts the connection and never answers leaves calls pending
+  indefinitely — and gives the dispatcher-based fix, plus why a single
+  `signal: AbortSignal.timeout(ms)` in `requestOptions` is the wrong tool: it is shared by every
+  request, so it works once and then aborts the rest. A new "Redirects and the Vault token"
+  section records that requests follow redirects (Vault HA answers standbys with a 307 to the
+  active node) and that Node's `fetch()` forwards `X-Vault-Token` across a cross-origin redirect,
+  since it strips only `Authorization`, `Cookie` and `Proxy-Authorization` — so `api.url`, its DNS
+  and any load balancer in front of it are trusted infrastructure. Finally, the `version` hook was
+  `git add -A .`, which swept any unrelated working-tree change into the release commit; it now
+  stages only `CHANGELOG.md`, `package.json` and `package-lock.json`.
+
 - `VaultClient.boot()` now logs a warning when it is called for a name that already exists with
   options that differ from the ones the instance was booted with (#146). The options were, and
   still are, ignored in that case — the memoized instance is returned unchanged — so this only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ version number — `# <version> Release notes (YYYY-MM-DD)` — and leave that e
 
 ```shell
 npm version [major | minor | patch]   # bumps package.json, stages the CHANGELOG edit (the
-                                      # `version` script runs `git add -A .`) and tags the commit
+                                      # `version` script stages it) and tags the commit
 # review the version-bump commit, then:
 git push && git push --tags
 ```

--- a/README.md
+++ b/README.md
@@ -402,6 +402,44 @@ env var with no code change. Only disable verification
 (`new Agent({ connect: { rejectUnauthorized: false } })`) in throwaway/dev setups — it removes
 MITM protection.
 
+The `undici` you install must be interface-compatible with the one Node bundles
+(`process.versions.undici`). A dispatcher from a mismatched major is rejected by the global
+`fetch()` before the request leaves the process — on Node 24, `undici@8` fails immediately with
+`TypeError: fetch failed` and `cause.code` of `invalid onRequestStart method`. Node 22 and 24
+bundle undici 7.x, so pin `undici@^7`.
+
+##### Request timeouts
+
+There is no default timeout. A Vault that accepts the connection and never answers will leave
+`read()` (and every other call) pending indefinitely. Set one through the dispatcher:
+
+```javascript
+const { Agent } = require('undici');
+
+const vaultClient = VaultClient.boot('main', {
+    api: {
+        url: 'https://vault.example.com:8200/',
+        requestOptions: { dispatcher: new Agent({ headersTimeout: 5000, bodyTimeout: 5000 }) },
+    },
+    auth: { type: 'token', config: { token: '...' } },
+});
+```
+
+A failed request rejects with `TypeError: fetch failed`, with `cause.code` set to
+`UND_ERR_HEADERS_TIMEOUT` or `UND_ERR_BODY_TIMEOUT`.
+
+Do **not** put `signal: AbortSignal.timeout(ms)` in `requestOptions`. It is created once and
+shared by every request the client makes, so it works for the first call and then aborts all
+later ones with `TimeoutError`. Pass a fresh signal per call, or use the dispatcher above.
+
+##### Redirects and the Vault token
+
+Requests follow HTTP redirects, because Vault HA clusters answer standby nodes with a 307 to the
+active node. Node's `fetch()` strips only `Authorization`, `Cookie` and `Proxy-Authorization` when
+a redirect crosses origins — `X-Vault-Token` is **not** on that list and is forwarded. A host that
+can answer for `api.url` can therefore redirect the client and receive its Vault token, so treat
+`api.url` (and the DNS and any load balancer in front of it) as trusted infrastructure.
+
 <a name="VaultClient+fillNodeConfig"></a>
 
 #### vaultClient.fillNodeConfig() ⇒ <code>Promise</code>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:example": "node examples/jwt-auth/vault-jwt-demo.mjs",
     "coverage": "c8 npm run test:unit",
     "lint": "eslint src/ test/ examples/",
-    "version": "git add -A ."
+    "version": "git add CHANGELOG.md package.json package-lock.json"
   },
   "c8": {
     "include": [


### PR DESCRIPTION
Follow-up to the review. Three transport properties that were true but unwritten, plus one live release hazard. **No runtime change** — README, CONTRIBUTING, and one npm script.

## 1. No request timeout

Measured against a server that accepts the connection and never answers:

```
no timeout configured   : STILL HANGING after 3000ms
undici headersTimeout   : UND_ERR_HEADERS_TIMEOUT (1008ms)
```

A new **Request timeouts** section records that there is no default and gives the dispatcher fix.

## 2. The `undici` major matters — and this affects the existing recipes

The proxy and self-signed-CA examples already tell you to `require('undici')` and pass a `dispatcher`. That silently breaks on a mismatched major:

| installed undici | Node 24 global `fetch()` |
|---|---|
| `8.10.1` | **rejected immediately** — `cause.code: invalid onRequestStart method` |
| `7.29.0` | works, times out at the deadline |
| `6.28.0` | works, times out at the deadline |

Node 22/24 bundle undici 7.x (`process.versions.undici` → `7.24.4` here), so the section now says to pin `undici@^7`. This was the most consequential find: it makes an already-documented feature fail with an error that points nowhere near the cause.

## 3. `AbortSignal.timeout()` in `requestOptions` is a trap

`requestOptions` is shallow-merged into every `fetch()`, so one signal object is shared by all requests:

```
req1: ok
req2: TimeoutError   <- same signal object, already fired
```

Documented as a "don't", with the dispatcher as the alternative.

## 4. Redirects forward the Vault token

`redirect: 'follow'` is deliberate — Vault HA answers standby nodes with a 307 to the active node. But Node's `fetch()` strips only `Authorization`, `Cookie` and `Proxy-Authorization` across origins. Verified against a local 307 to a second port:

```
X-Vault-Token : FORWARDED -> "REAL-SECRET-TOKEN"
Authorization : stripped (per fetch spec)
```

So a host that can answer for `api.url` can redirect the client and collect its token. The default is not changed — that would break HA — but the README now states that `api.url`, its DNS and any LB in front of it are trusted infrastructure.

## 5. The `version` hook staged everything

```diff
-    "version": "git add -A ."
+    "version": "git add CHANGELOG.md package.json package-lock.json"
```

`npm version` runs this hook with whatever happens to be dirty, so an unrelated working-tree change lands in the release commit. That is not hypothetical — it is exactly how a stray `npm install config` narrowed the `config` peer range into master earlier today (fixed in #171). CONTRIBUTING's description of the hook was updated to match rather than left quoting the old command.

## Verification

`package.json` diff is the one script line — peer range still `>=1 <4`, version untouched. lint clean, types clean, 391 unit passing, `verify-package` 3/3, and both README-drift guards still green (#162's error-table guard, #164's public-API guard) since this edits the README.