### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.2.0 Release notes (2026-09-01)
 
 - Documented three things about the HTTP transport that were true but unwritten, and scoped the
   `version` npm hook. No runtime change. `api.requestOptions` now carries a note that the `undici`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-vault-client",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-vault-client",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1100.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"


### PR DESCRIPTION
Cuts **2.2.0**. Moves the `# Unreleased` notes under a dated release heading and bumps the version in `package.json` and `package-lock.json`. Three files, four lines.

## Why minor, not major

Verified against the **published 2.1.2**, not assumed:

- **Static surface identical** — same export shape, 3 statics, 14 instance methods, every arity, 6 error classes, same hierarchy. Removed: none. Changed: none.
- **26 behavioural scenarios identical** on a live Vault, including the ones most likely to break a consumer: unknown extra keys at top level / in `auth` / in `auth.config`, the legacy `auth.config.namespace`, `logger: false` and partial loggers, `boot()` called twice with differing options, and the error classes raised on each failure path.
- `engines` (`>=18`) and the `config` peer range (`>=1 <4`) unchanged.

Everything in the release is additive.

## Contents

| | |
|---|---|
| JWT/OIDC auth backend | `auth.type: 'jwt'`, three token sources |
| Token renewal controls | `auth.renewal`, `renewalFraction`, `renewalIncrement` |
| First-party TypeScript declarations | `index.d.ts`, `src/errors.d.ts` |
| `boot()` option-mismatch warning | previously silent |
| Stale-renewal-callback fix | superseded callbacks discarded |
| Docs | error-class imports, `Lease.getMetadata()`, transport timeouts, redirect token forwarding, undici compatibility |

## Pre-release verification

```
lint clean · types clean · coverage 98.99% · verify-package 3/3 · npm audit 0 vulnerabilities
e2e + kv2 + jwt + example app green on BOTH Vault 1.21 and 2.0 · full suite 411 passing
```

Packed artifact: 19 files, 38.8 kB, `node-vault-client@2.2.0` — includes `index.d.ts` and `src/errors.d.ts`.

`publish.yml`'s guard greps `CHANGELOG.md` for `^# 2.2.0( |$)` before publishing; confirmed present on this commit.

## After merge

Tag `v2.2.0` on the merge commit and create the GitHub Release — that triggers `publish.yml`, which now runs lint, unit tests and the packed-artifact check before `npm publish --provenance`.