### PR TITLE
chore(types): drop the removed moduleResolution=node10 from the type-check config

### DIFF
--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "target": "ES2020",
         "lib": ["ES2020"],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "node18",
         "strict": true,
         "noEmit": true,
         "types": [],


### PR DESCRIPTION
## Why

Dependabot's TypeScript 5.9.3 → 7.0.2 bump (#177) fails `lint` / `ci-ok` with:

```
types/tsconfig.json(6,29): error TS5108: Option 'moduleResolution=node10' has been removed.
```

TS 7 removed `moduleResolution: "node"` (the `node10` alias). Only `types/tsconfig.json` uses it, and only `npm run test:types` runs it.

## What

Replace `module: commonjs` + `moduleResolution: node` with `module: node18`, which sets the matching resolution implicitly and checks the `import X = require()` test files the way a real CommonJS consumer resolves them.

## Compatibility

- The published `index.d.ts` (`export = VaultClient`) is untouched; consumers on any TypeScript version see identical declarations.
- TypeScript is a devDependency only.
- TS 7 native binaries run on Node ≥16.20, so the Node 18 floor and CI lane stay valid; no dependabot `ignore` entry needed.

Verified locally: `tsc -p types/tsconfig.json` passes on 5.9.3, 6.x and 7.0.2.

Landing this first lets dependabot rebase #177 onto master and go green.