### PR TITLE
ci: ignore mocha major bumps while Node 18 is supported

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,10 @@ updates:
       - dependency-name: config
         # Peer range is deliberately <4: config 4 requires Node >=20.
         update-types: ["version-update:semver-major"]
+      - dependency-name: mocha
+        # 12.x requires Node "^20.19.0 || >=22.12.0" and hard-crashes with
+        # ERR_REQUIRE_ESM under Node 18 (tried in PR #181).
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,9 @@ Dependabot proposes updates weekly, configured in
 `fix(deps)`, dev tooling grouped into one `chore(deps)` PR, and GitHub Actions as `ci(deps)`.
 
 Some majors are deliberately ignored there because they drop Node 18, which is still in `engines`
-and in the CI matrix — `c8` 11+, `eslint` 10.x and `config` 4. If you need one of those, it comes
-with raising the minimum Node version, not with a lockfile bump.
+and in the CI matrix — `c8` 11+, `eslint` 10.x, `config` 4 and `mocha` 12+ (12.x requires Node
+`^20.19.0 || >=22.12.0` and hard-crashes with `ERR_REQUIRE_ESM` under Node 18). If you need one of
+those, it comes with raising the minimum Node version, not with a lockfile bump.
 
 Security advisories are separate: `npm audit --audit-level=high` runs as a blocking CI job, and the
 `overrides` block in `package.json` is how a patched transitive dependency gets pinned when the


### PR DESCRIPTION
## Summary

PR #181 (Dependabot: bump `mocha` 11.7.6 → 12.0.0) can't be taken as-is: mocha 12.x requires Node `^20.19.0 || >=22.12.0` and hard-crashes with `ERR_REQUIRE_ESM` under Node 18, which this repo's `engines` field and CI matrix still support.

This adds `mocha` to the same semver-major `ignore` list `.github/dependabot.yml` already uses for `c8`, `eslint`, `@eslint/js` and `config` — all rejected for the identical reason (Node 18 compatibility). No functional/runtime change; `package.json`'s existing `"mocha": "^11.7.6"` already keeps installs below 12, this just stops Dependabot from re-proposing the major bump every week.

Closing #181 as a companion to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)