### PR TITLE
feat: warn once when running on Node.js 18, the last version we support it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Unreleased
 
+- **This is the last release of node-vault-client to support Node.js 18.** Node 18 reached
+  end-of-life on 2025-04-30 and no longer receives security patches from the Node.js project,
+  independent of anything pinned in this package's own dependency tree — which is itself feeling
+  the pressure: `c8`, `eslint`, `@eslint/js`, `config` and now `mocha` all have majors held back
+  in `.github/dependabot.yml` purely because they drop Node 18. Requiring the client now emits a
+  one-time `process.emitWarning` (code `NodeVaultClientNode18Deprecation`) when running under
+  Node 18, so consumers who never read a changelog still see it. The next major release raises
+  `engines.node` to `>= 20.19.0`, drops the Node 18 CI matrix legs, and clears the accumulated
+  ignore-list entries so those dependencies resume normal updates. No other behaviour changes;
+  this is purely a deprecation notice ahead of that release.
+
 - Added optional `distributedClaimAccessToken` and `distributedClaimAccessTokenProvider` keys to
   the `jwt` backend's `config` (#175), which supply Vault's optional
   `distributed_claim_access_token` login parameter. It matters only for Microsoft Entra ID (Azure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ By participating in this project you agree to abide by our [Code of Conduct](COD
 ## Prerequisites
 
 - Node.js >= 18 — the client uses the native `fetch` API. CI runs against 18, 20, 22 and 24
-  (`.nvmrc` pins 20 for local development).
+  (`.nvmrc` pins 20 for local development). This is the last release line to support Node 18 —
+  see the sunset notice in README.md and CHANGELOG.md; the next major release drops it.
 - npm (the repo ships a committed `package-lock.json`; use `npm ci`).
 - Docker — used to run a local dev Vault server for the integration and end-to-end tests
   (see `docker-compose.yml`).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ npm install --save node-vault-client
 
 Node.js >= 18 — the client uses the native `fetch` API.
 
+> **Node.js 18 sunset notice:** this is the last release of node-vault-client to support Node 18.
+> Node 18 reached end-of-life on 2025-04-30 and no longer receives security patches from the
+> Node.js project. Running this version under Node 18 emits a one-time process warning
+> (`NodeVaultClientNode18Deprecation`); the next major release raises the minimum to
+> Node.js >= 20.19.0. See [CHANGELOG.md](CHANGELOG.md) for details.
+
 ### TypeScript
 
 Type declarations ship with the package, so no separate install is needed:

--- a/src/VaultClient.js
+++ b/src/VaultClient.js
@@ -12,6 +12,9 @@ const VaultKubernetesAuth = require('./auth/VaultKubernetesAuth');
 const VaultJwtAuth = require('./auth/VaultJwtAuth');
 const MountResolver = require('./MountResolver');
 const { rewritePath, normalizeResponse } = require('./kvTransform');
+const { warnIfNode18 } = require('./checkNodeVersion');
+
+warnIfNode18();
 
 const noop = () => {};
 const vaultInstances = {};

--- a/src/checkNodeVersion.js
+++ b/src/checkNodeVersion.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const NODE_18_DEPRECATION_MESSAGE =
+    'node-vault-client: this is the last release of this package to support Node.js 18. ' +
+    'Node 18 reached end-of-life on 2025-04-30 and no longer receives security patches from ' +
+    'the Node.js project. The next major release of node-vault-client will require ' +
+    'Node.js >= 20.19.0 — see CHANGELOG.md for details.';
+const NODE_18_DEPRECATION_CODE = 'NodeVaultClientNode18Deprecation';
+
+/**
+ * Emits a one-time process warning when running on Node.js 18. Called once, at module load,
+ * from VaultClient.js — require()'s own module cache is what keeps it to once per process,
+ * not any dedup logic here.
+ *
+ * Takes a `process`-like object (defaulting to the real `process`) purely so tests can assert
+ * the behaviour on a stubbed Node version instead of on whatever Node this suite happens to run
+ * under.
+ */
+function warnIfNode18(proc) {
+    proc = proc || process;
+    const nodeVersion = proc.versions && proc.versions.node;
+    if (typeof nodeVersion === 'string' && /^18\./.test(nodeVersion)) {
+        proc.emitWarning(NODE_18_DEPRECATION_MESSAGE, { code: NODE_18_DEPRECATION_CODE });
+    }
+}
+
+module.exports = { warnIfNode18, NODE_18_DEPRECATION_MESSAGE, NODE_18_DEPRECATION_CODE };

--- a/test/checkNodeVersion.test.mjs
+++ b/test/checkNodeVersion.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for checkNodeVersion's warnIfNode18.
+ * Takes a `process`-like object so behaviour on Node 18 can be asserted without needing to
+ * actually run this suite under Node 18.
+ */
+
+import sinon from 'sinon';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import {
+    warnIfNode18,
+    NODE_18_DEPRECATION_MESSAGE,
+    NODE_18_DEPRECATION_CODE,
+} from '../src/checkNodeVersion.js';
+
+use(sinonChai);
+
+function fakeProcess(nodeVersion) {
+    return { versions: { node: nodeVersion }, emitWarning: sinon.spy() };
+}
+
+describe('checkNodeVersion', function () {
+    describe('warnIfNode18', function () {
+        it('warns once on a Node 18.x process', function () {
+            const proc = fakeProcess('18.20.8');
+            warnIfNode18(proc);
+            expect(proc.emitWarning).to.have.been.calledOnce;
+            expect(proc.emitWarning).to.have.been.calledWith(
+                NODE_18_DEPRECATION_MESSAGE,
+                { code: NODE_18_DEPRECATION_CODE },
+            );
+        });
+
+        it('does not warn on Node 20', function () {
+            const proc = fakeProcess('20.19.0');
+            warnIfNode18(proc);
+            expect(proc.emitWarning).to.not.have.been.called;
+        });
+
+        it('does not warn on Node 22 or 24', function () {
+            [fakeProcess('22.12.0'), fakeProcess('24.0.0')].forEach((proc) => {
+                warnIfNode18(proc);
+                expect(proc.emitWarning).to.not.have.been.called;
+            });
+        });
+
+        // A version like 180.0.0 must not match the "18." prefix check.
+        it('does not warn on a Node major that merely starts with 18', function () {
+            const proc = fakeProcess('180.0.0');
+            warnIfNode18(proc);
+            expect(proc.emitWarning).to.not.have.been.called;
+        });
+
+        it('defaults to the real global process when none is passed', function () {
+            const originalEmitWarning = process.emitWarning;
+            const spy = sinon.spy();
+            process.emitWarning = spy;
+            try {
+                warnIfNode18();
+            } finally {
+                process.emitWarning = originalEmitWarning;
+            }
+            // Whether it fires depends on whatever Node this suite is actually running under;
+            // this only asserts the no-arg call path reaches the real `process` without throwing.
+            expect(spy.callCount).to.be.at.least(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Node 18 reached end-of-life on 2025-04-30 and no longer receives security patches from the Node.js project — independent of anything pinned in this package's own dependency tree, which is already feeling the pressure: `c8`, `eslint`, `@eslint/js`, `config` and now `mocha` (#183) all have majors held back in `.github/dependabot.yml` purely because they drop Node 18.

This makes the coming change visible ahead of time:

- **Runtime**: a new `src/checkNodeVersion.js`, called once at module load from `VaultClient.js`, emits a one-time `process.emitWarning` (code `NodeVaultClientNode18Deprecation`) when running under Node 18 — so consumers who never read a changelog still see it. It takes a `process`-like object so the behaviour is unit-testable without needing to run this suite under Node 18 itself.
- **Docs**: README.md and CONTRIBUTING.md both get a sunset notice next to the existing `Node.js >= 18` requirement line.
- **Changelog**: records that this is the last release to support Node 18, and that the next major release raises `engines.node` to `>= 20.19.0`, drops the Node 18 CI matrix legs, and clears the accumulated dependabot ignore-list entries.

No other behaviour changes — a Node 20+ process sees nothing different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)