### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.3.0 Release notes (2026-09-11)
 
 - **This is the last release of node-vault-client to support Node.js 18.** Node 18 reached
   end-of-life on 2025-04-30 and no longer receives security patches from the Node.js project,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-vault-client",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-vault-client",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1100.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault-client",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A Vault Client implemented in pure javascript for HashiCorp Vault. It supports variety of Auth Backends and performs lease renewal for issued auth token.",
   "repository": {
     "url": "git+https://github.com/namecheap/node-vault-client.git"


### PR DESCRIPTION
## Summary

Release v2.3.0 — version bump and changelog.

Moves the `# Unreleased` notes into `# 2.3.0 Release notes (2026-09-11)` and bumps `package.json`/`package-lock.json`.

**Minor, not major**: adds `distributedClaimAccessToken`/`distributedClaimAccessTokenProvider` (#175, additive) and the Node 18 sunset warning (#184, new output only). No export, signature, or error-type changes. Lint, the 418-test unit suite, and `test/verify-package.mjs` all pass.

**This is also the last release to support Node.js 18** — see the notice in this release's CHANGELOG entry and README.md (#184). Node 18 reached end-of-life on 2025-04-30 and no longer receives upstream security patches; the next major release raises `engines.node` to `>= 20.19.0`.

After merge, tag `v2.3.0` already exists on this commit locally — pushing it and creating a GitHub Release for it triggers `publish.yml` to publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)